### PR TITLE
[workflow][fix] relocate libetcdclient.so path

### DIFF
--- a/curvefs/docker/rocky9/Dockerfile
+++ b/curvefs/docker/rocky9/Dockerfile
@@ -1,7 +1,7 @@
 FROM dingodatabase/dingofs-base:rocky9
 COPY entrypoint.sh /
 COPY curvefs /curvefs
-COPY libetcdclient.so /usr/lib/
+COPY curvefs/etcd/lib/libetcdclient.so /usr/lib/
 RUN mkdir -p /etc/curvefs /core /etc/curve && chmod a+x /entrypoint.sh \
     && cp /curvefs/tools/sbin/curvefs_tool /usr/bin \
     && cp /curvefs/tools-v2/sbin/curve /usr/bin/ 

--- a/util/image.sh
+++ b/util/image.sh
@@ -108,7 +108,7 @@ do
 done
 
 cp conf/client.conf $prefix/conf/curvebs-client.conf
-cp thirdparties/etcdclient/libetcdclient.so $docker_prefix/
+cp thirdparties/etcdclient/libetcdclient.so $prefix/etcd/lib/
 
 docker pull dingodatabase/dingofs-base:$3
 docker build --no-cache -t "$2" "$docker_prefix"

--- a/util/install_and_config.sh
+++ b/util/install_and_config.sh
@@ -102,4 +102,4 @@ do
 done
 
 cp conf/client.conf $prefix/conf/curvebs-client.conf
-cp thirdparties/etcdclient/libetcdclient.so $docker_prefix/
+cp thirdparties/etcdclient/libetcdclient.so $prefix/etcd/lib/


### PR DESCRIPTION
relocate libetcdclient.so path to `curvefs/etcd/lib/`, which will be copied to `/usr/lib` when creating the Docker image.