### PR TITLE
[workflow] transfer event info between actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,26 +5,64 @@ on:
     workflows: ["CI Build"]
     types:
       - completed
-  push:
-    tags:
-      - '*'
 
 jobs:
   docker:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'push' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Download artifact
+    - name: Download event type file
+      uses: actions/download-artifact@v4
+      with:
+        name: event
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GH_TOKEN }}
+        path: ./
+
+    - name: Download tag name file
+      if: ${{ env.EVENT == 'tag' }}
+      uses: actions/download-artifact@v4
+      with:
+        name: tag_name
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GH_TOKEN }}
+        path: ./
+
+    - name: Download dingofs artifact
       uses: actions/download-artifact@v4
       with:
         name: dingofs
         run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GH_TOKEN }}
         path: ./
+
+    - name: Config trigger event env
+      run: |
+        if [ -f event.txt ]; then
+          echo "EVENT=$(cat event.txt)" >> $GITHUB_ENV
+        fi
+
+    - name: Config push tag env
+      if: ${{ env.EVENT == 'tag' }}
+      run: |
+        if [ -f tag_name.txt ]; then
+          echo "TAG_NAME=$(cat tag_name.txt)" >> $GITHUB_ENV
+        fi
+    
+    - name: Print env info
+      run: |
+        echo "trigger event type is ${{ env.EVENT }}"
+        if [ "${{ env.EVENT }}" == "pull_request" ]; then
+          echo "pull request haven't merged, not need to publish image."
+          exit 0
+        fi
+        if [ -n "${{ env.TAG_NAME }}" ]; then
+          echo "tag name is ${{ env.TAG_NAME }}"
+        fi
 
     - name: List directory contents after download
       run: ls -la
@@ -47,7 +85,7 @@ jobs:
       with:
         images: dingodatabase/dingofs
         tags: |
-          type=ref,event=tag
+          type=raw,enable=${{ env.EVENT == 'tag' }},value=${{ env.TAG_NAME }}
           type=raw,value=latest,enable={{is_default_branch}}
           type=sha,prefix=,format=long
 

--- a/.github/workflows/v1/ci-build.yml
+++ b/.github/workflows/v1/ci-build.yml
@@ -3,8 +3,6 @@ name: CI Build
 on:
   push:
     branches: [ "master" ]
-    tags:
-      - '*'
   pull_request:
     branches: [ "master" ]
 
@@ -18,35 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Record event type
-      run: |
-        echo "hello dingofs" > event.txt
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "pull_request" > event.txt
-        elif [ "${{ github.event_name }}" == "push" ]; then
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "tag" > event.txt
-            echo "${{ github.ref }}" | sed 's/refs\/tags\///' > tag_name.txt
-          else
-            echo "push" > event.txt
-          fi
-        fi
-    
-    - name: Save event type info
-      uses: actions/upload-artifact@v4
-      with:
-        name: event
-        path: event.txt
-        compression-level: 0
-    
-    - name: Save tag name info
-      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: tag_name
-        path: tag_name.txt
-        compression-level: 0
 
     - name: Set Safe Dir
       run: git config --global --add safe.directory $PWD

--- a/.github/workflows/v1/docker-publish.yml
+++ b/.github/workflows/v1/docker-publish.yml
@@ -1,0 +1,60 @@
+name: Docker Publish
+
+on:
+  workflow_run:
+    workflows: ["CI Build"]
+    types:
+      - completed
+  push:
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'push' }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: dingofs
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GH_TOKEN }}
+        path: ./
+
+    - name: List directory contents after download
+      run: ls -la
+
+    - name: Extract artifact
+      run: tar -xzvf dingofs.tar.gz -C curvefs/docker/rocky9
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: dingodatabase/dingofs
+        tags: |
+          type=ref,event=tag
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=sha,prefix=,format=long
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: ./curvefs/docker/rocky9
+        file: ./curvefs/docker/rocky9/Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
- ci build action 记录 event 信息到 event.txt, 如果是 push tag event, 则记录 tag 信息到 tag_name.txt

- docker publish workflow 的 trigger event 只有 ci build action, 根据获取的 event info 和 tag info, 最后进行 publish image；未merged 的 pull request 不再进行镜像推送