### PR TITLE
[fix][client] Move dryrun/FakeBlockStore thread_local buffers off TLS

### DIFF
--- a/src/client/fuse/fuse_op.cc
+++ b/src/client/fuse/fuse_op.cc
@@ -587,11 +587,18 @@ void FuseOpRead(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
     // Per-worker buffer so concurrent FUSE workers don't all point their
     // replies at the same PTE page and cause get_user_pages_fast to collide
     // on a single pte_lock. Matches 3FS's per-request RDMABufPool in spirit.
-    thread_local static char kStaticMemory[kStaticMemSize] = {0};
+    // Allocated on heap (not as thread_local char[]) to keep static TLS small;
+    // a 4MB TLS array eats the pthread stack mmap and leaves worker threads
+    // with only a few KB of usable stack.
+    thread_local std::unique_ptr<char[]> kStaticMemory;
+    if (__builtin_expect(!kStaticMemory, 0)) {
+      kStaticMemory.reset(new char[kStaticMemSize]());
+    }
     CHECK_GT(kStaticMemSize, size)
         << "dryrun static memory is not enough, size: " << size;
 
-    data_buffer.RawIOBuffer()->AppendUserData(kStaticMemory, size, [](void*) {});
+    data_buffer.RawIOBuffer()->AppendUserData(kStaticMemory.get(), size,
+                                              [](void*) {});
     ReplyData(req, data_buffer);
     return;
   }

--- a/src/client/vfs/blockstore/fake_block_store.cc
+++ b/src/client/vfs/blockstore/fake_block_store.cc
@@ -18,6 +18,8 @@
 
 #include <google/protobuf/descriptor.pb.h>
 
+#include <memory>
+
 #include "cache/blockcache/block_cache.h"
 #include "client/common/const.h"
 #include "client/vfs/hub/vfs_hub.h"
@@ -31,7 +33,17 @@ static constexpr int64_t kStaticMemSize = 4 * 1024 * 1024;  // 4MB
 // BSS region (which causes kernel fuse_copy_fill -> get_user_pages_fast ->
 // follow_page_pte to serialize on a single PTE spinlock). Same fix as the
 // dryrun FuseOpRead thread_local patch (6b9136f7d).
-thread_local static char kStaticMemory[kStaticMemSize] = {0};
+// Allocated on heap (not as thread_local char[]) to keep static TLS small;
+// a 4MB TLS array eats the pthread stack mmap and leaves worker threads
+// with only a few KB of usable stack.
+thread_local static std::unique_ptr<char[]> kStaticMemory;
+
+static char* GetStaticMemory() {
+  if (__builtin_expect(!kStaticMemory, 0)) {
+    kStaticMemory.reset(new char[kStaticMemSize]());
+  }
+  return kStaticMemory.get();
+}
 
 #define METHOD_NAME() ("FakeBlockStore::" + std::string(__FUNCTION__))
 
@@ -63,7 +75,7 @@ void FakeBlockStore::DoRangeAsync(BlockKey key, uint64_t offset,
   (void)key;
   (void)offset;
   CHECK_GE(kStaticMemSize, length);
-  buffer->AppendUserData(kStaticMemory, length, NoopDeleter);
+  buffer->AppendUserData(GetStaticMemory(), length, NoopDeleter);
   callback(Status::OK());
 }
 


### PR DESCRIPTION
## Summary

The 4MB `thread_local char[]` arrays in `FuseOpRead` dryrun path and `FakeBlockStore` land in the binary's static TLS (`.tbss`). Together they blow up per-thread TLS to ~8MB. glibc sizes each pthread stack mmap as `max(stacksize, tls_static_size + page)`, so when static TLS rivals the default 8MB stack size, fuse_worker threads end up with only a few KB of usable stack and SIGSEGV on moderately deep call chains.

## Repro

Any op that does `LOG()` on the fuse_worker hot path triggers it. Concrete chain observed on a getattr:

```
FuseOpGetAttr -> VFSWrapper::GetAttr -> MDSClient::GetAttr
  -> RPC::SendRequest -> LOG(INFO) (rpc.h:355)
  -> google::LogMessage::Init -> LogMessageTime
  -> mktime -> __tz_convert -> __tzfile_compute
  -> __tzset_parse_tz -> parse_offset -> sscanf
  -> __vfscanf_internal   <-- ~28 KB scratch_buffer, guard-page fault
```

`env TZ=UTC0 dingo fs mount ...` happens to avoid the crash because the POSIX-format TZ skips `__tzfile_compute` and its sscanf tree, saving ~2-3 KB of stack — enough to stay within the tiny residual stack.

## Fix

Switch both buffers to `thread_local std::unique_ptr<char[]>` with lazy heap allocation on first use. TLS footprint collapses from ~8MB to 16 bytes (two pointers); workers regain the full 8MB stack. Buffers stay per-thread, so the original PTE-contention fix (`fuse_copy_fill -> get_user_pages_fast -> follow_page_pte` spinlock) is preserved — distinct heap pages still map to distinct PTEs.

Hot-path cost: one extra `mov %fs:<off>, %rax` + NULL check vs. direct-address TLS load. ~1 ns/op, noise compared to actual FUSE read work.

## Verification

Built in `dingodatabase/dingo-eureka:rocky9-fs` with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`:

|  | before | after |
|---|---|---|
| TLS program header size | `0x809f60` (~8.04 MB) | `0x9f80` (~40 KB) |
| fuse_worker usable stack | ~9 KB | 8 MB |
| mount + ops without `TZ=UTC0` | SIGSEGV in `__vfscanf_internal` | stable |

```
$ readelf -l bin/dingo-client | grep -A1 TLS
# before:  MemSiz 0x0000000000809f60
# after:   MemSiz 0x0000000000009f80
```

Reproduced original crash on the prior binary, then swapped in the rebuilt v2 binary against the same MDS with `TZ` unset — mount comes up, stat/ls/create/read all work, no new cores.

## Test plan

- [ ] CI passes (no new unit tests needed — existing dryrun/FakeBlockStore paths exercise the code)
- [ ] Manual: `env -u TZ dingo fs mount …` does not crash on first getattr
- [ ] `readelf -l dingo-client | grep TLS` shows TLS MemSiz < 100 KB