### PR TITLE
[fix][mds] Fix ListDentry shadow variable dropping cached-partition dentries

### DIFF
--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -2622,7 +2622,6 @@ Status FileSystem::ListDentry(Context& ctx, Ino parent, const std::string& last_
     auto partition = GetPartitionFromCache(parent);
     if (partition != nullptr) {
       trace.SetHitPartition();
-      std::vector<Dentry> dentries;
       return partition->Scan(ctx.RequestId(), last_name, limit, is_only_dir, dentries);
     }
   }


### PR DESCRIPTION
Local `std::vector<Dentry>` shadowed the out-parameter in the partition-cache branch, causing cached directory listings to return empty — breaks quota-set pre-existing usage counting.