### PR TITLE
[fix][client] Avoid use-after-free in cache CleanExpired logging.

### DIFF
--- a/src/client/vfs/metasystem/mds/chunk.cc
+++ b/src/client/vfs/metasystem/mds/chunk.cc
@@ -699,10 +699,11 @@ void ChunkCache::CleanExpired(uint64_t expire_s) {
     for (auto it = map.begin(); it != map.end();) {
       if (it->second->GetLastActiveTimeS() < expire_s) {
         auto temp = it++;
+        uint64_t ino = temp->first;
         map.erase(temp);
         clean_count_ << 1;
         LOG_DEBUG << fmt::format(
-            "[meta.chunkcache] clean expired chunkset ino({}).", temp->first);
+            "[meta.chunkcache] clean expired chunkset ino({}).", ino);
 
       } else {
         ++it;

--- a/src/client/vfs/metasystem/mds/tiny_file_data.cc
+++ b/src/client/vfs/metasystem/mds/tiny_file_data.cc
@@ -95,11 +95,11 @@ void TinyFileDataCache::CleanExpired(uint64_t expire_s) {
     for (auto it = map.begin(); it != map.end();) {
       if (it->second->LastActiveTimeS() < expire_s) {
         auto temp = it++;
+        uint64_t ino = temp->first;
         map.erase(temp);
         clean_count_ << 1;
         LOG_DEBUG << fmt::format(
-            "[meta.tinyfiledatacache.{}] clean expired tiny file data.",
-            temp->first);
+            "[meta.tinyfiledatacache.{}] clean expired tiny file data.", ino);
 
       } else {
         ++it;


### PR DESCRIPTION
<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
