### PR TITLE
[fix][test] Guard SyncPoint-driven race test with #ifndef NDEBUG

### DIFF
--- a/src/common/sync_point.h
+++ b/src/common/sync_point.h
@@ -14,11 +14,17 @@
 // Test-only synchronization points for deterministic concurrency tests.
 //
 // In production builds (NDEBUG defined), TEST_SYNC_POINT() is a no-op macro
-// with zero cost. In debug/test builds, it dispatches to a registry that
-// allows tests to inject callbacks at named program locations to interleave
-// threads, observe ordering, or simulate races deterministically.
+// with zero cost and the SyncPoint class is not declared. In debug/test
+// builds it dispatches to a registry that allows tests to inject callbacks
+// at named program locations to interleave threads, observe ordering, or
+// simulate races deterministically.
 //
-// Pattern modeled after RocksDB's util/sync_point.h.
+// Pattern modeled after RocksDB's util/sync_point.h. Tests that drive
+// SyncPoint::Get() directly (e.g. race regression tests) must therefore
+// guard their bodies with `#ifndef NDEBUG` — the test will simply not be
+// compiled into the binary in NDEBUG builds. Long-term we plan to follow
+// RocksDB's CI pattern of running unit tests in a Debug build separate from
+// the release build job, at which point the guards become redundant.
 //
 // Usage in production code:
 //   TEST_SYNC_POINT("ChunkWriter::DoFlushAsync:between_locks");

--- a/test/unit/client/vfs/data/test_chunk_writer.cc
+++ b/test/unit/client/vfs/data/test_chunk_writer.cc
@@ -515,6 +515,7 @@ TEST_F(ChunkWriterTest, FindWritable_Forward_Reuses) {
 // releases. Without the fix, T1 holds NO lock at this point, so T2 can
 // race through DoFlushAsync, push its (empty) task, and return — the
 // "T2's FlushAsync returns while T1 is in critical section" anomaly.
+#ifndef NDEBUG
 TEST_F(ChunkWriterTest, ConcurrentFlush_HoldsSliceMutexUntilQueuePush) {
   using namespace std::chrono;
 
@@ -600,6 +601,7 @@ TEST_F(ChunkWriterTest, ConcurrentFlush_HoldsSliceMutexUntilQueuePush) {
          "caller can race in with empty to_commit and push an empty "
          "FlushTask ahead.";
 }
+#endif  // NDEBUG
 
 }  // namespace vfs
 }  // namespace client


### PR DESCRIPTION
## Summary

Fixes the upstream CI compile failure introduced by `fcdd6b25d` (`[test][client] Add ChunkWriter DoFlushAsync flush race regression test`):

```
test/unit/client/vfs/data/test_chunk_writer.cc:542:3:
  error: 'SyncPoint' has not been declared
```

CI run: https://github.com/dingodb/dingofs/actions/runs/25157973328/job/73744636256

## Root cause

`src/common/sync_point.h` follows RocksDB's `util/sync_point.h` pattern: under `NDEBUG` the `SyncPoint` class is not declared and `TEST_SYNC_POINT(...)` expands to a no-op. The new race regression test calls `SyncPoint::Get()->...` directly to coordinate two threads inside `ChunkWriter::DoFlushAsync`, so it fails to compile under `NDEBUG`.

Upstream CI runs `make file_build only=//src/* release=1 unit_tests=ON` — `RelWithDebInfo` (defines `NDEBUG`) **and** `BUILD_UNIT_TESTS=ON` together. CI compiles the test source but never runs the binary, so the only thing that needs to hold is **compilation** in NDEBUG mode.

## Fix

Wrap the `TEST_F(ChunkWriterTest, ConcurrentFlush_HoldsSliceMutexUntilQueuePush)` body with `#ifndef NDEBUG ... #endif` so the test is excluded from translation units compiled with `NDEBUG`. Update `src/common/sync_point.h`'s header comment to make this contract explicit for future tests.

The test stays fully active in Debug builds, where the sync points are armed and the race assertion is meaningful.

## Follow-up (separate PR)

Long-term we should match RocksDB's CI structure: split `ci-build.yml` into a `build-release` job (NDEBUG, no tests, produces release artifacts) and a `unit-test` job (Debug, builds + runs `test_client`). Once that lands, the `#ifndef NDEBUG` guards become redundant. Tracked separately.

## Test plan

- [x] `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_UNIT_TESTS=ON` followed by `make test_client_vfs_data` — reproduces upstream's compile config and now passes
- [x] `cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_UNIT_TESTS=ON` — test stays compiled and runnable
- [ ] Upstream CI reruns green