### PR TITLE
[refactor][blockaccess] Replace InitBlockAccessOption with FillXxxFromGFlags helpers; fix AWS SDK log_prefix dropped to cwd

### DIFF
--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -176,8 +176,9 @@ Status VFSHubImpl::Start(bool skip_mount) {
 
   // block accesser
   {
-    // set s3/rados config info
-    blockaccess::InitBlockAccessOption(&blockaccess_options_);
+    // 1) decide backend type from fs_info and set per-backend connection
+    //    info FIRST. The backend-specific gflag-fill below depends on
+    //    `type` being correct.
     if (fs_info_.storage_info.store_type == StoreType::kS3) {
       auto s3_info = fs_info_.storage_info.s3_info;
       blockaccess_options_.type = blockaccess::AccesserType::kS3;
@@ -186,7 +187,8 @@ Status VFSHubImpl::Start(bool skip_mount) {
                               .sk = s3_info.sk,
                               .endpoint = s3_info.endpoint,
                               .bucket_name = s3_info.bucket_name};
-
+      blockaccess::FillAwsSdkConfigFromGFlags(
+          &blockaccess_options_.s3_options.aws_sdk_config);
     } else if (fs_info_.storage_info.store_type == StoreType::kRados) {
       auto rados_info = fs_info_.storage_info.rados_info;
       blockaccess_options_.type = blockaccess::AccesserType::kRados;
@@ -203,6 +205,10 @@ Status VFSHubImpl::Start(bool skip_mount) {
     } else {
       return Status::InvalidParam("unsupported store type");
     }
+
+    // 2) Throttle options are backend-agnostic.
+    blockaccess::FillThrottleOptionsFromGFlags(
+        &blockaccess_options_.throttle_options);
 
     block_accesser_ = blockaccess::NewPrefixBlockAccesser(
         fs_info_.name, blockaccess_options_);

--- a/src/common/blockaccess/accesser_common.h
+++ b/src/common/blockaccess/accesser_common.h
@@ -41,7 +41,9 @@ struct BlockAccesserThrottleOptions {
   uint64_t bpsWriteMB{0};
 };
 
-inline void InitBlockAccesserThrottleOptions(
+// Fill throttle options from global gflags. Backend-agnostic — same gflags
+// apply to S3 / Rados / LocalFile.
+inline void FillThrottleOptionsFromGFlags(
     BlockAccesserThrottleOptions* options) {
   options->iopsTotalLimit = FLAGS_iops_total_limit;
   options->iopsReadLimit = FLAGS_iops_read_limit;
@@ -78,13 +80,6 @@ struct BlockAccessOptions {
   LocalFileOptions file_options;
   BlockAccesserThrottleOptions throttle_options;
 };
-
-inline void InitBlockAccessOption(blockaccess::BlockAccessOptions* option) {
-  if (option->type == blockaccess::kS3) {
-    blockaccess::InitAwsSdkConfig(&option->s3_options.aws_sdk_config);
-  }
-  blockaccess::InitBlockAccesserThrottleOptions(&option->throttle_options);
-}
 
 // TODO: refact this use one struct
 struct GetObjectAsyncContext;

--- a/src/common/blockaccess/bench/block_access_bench.cc
+++ b/src/common/blockaccess/bench/block_access_bench.cc
@@ -217,7 +217,7 @@ Status BlockAccessBench::Init() {
       access_options.s3_options.s3_info.endpoint = options_.s3_endpoint;
       access_options.s3_options.s3_info.ak = options_.s3_ak;
       access_options.s3_options.s3_info.sk = options_.s3_sk;
-      InitBlockAccessOption(&access_options);
+      FillAwsSdkConfigFromGFlags(&access_options.s3_options.aws_sdk_config);
       access_options.s3_options.aws_sdk_config.use_crt_client =
           options_.s3_use_crt_client;
       access_options.s3_options.aws_sdk_config.use_thread_pool =
@@ -231,16 +231,14 @@ Status BlockAccessBench::Init() {
       access_options.rados_options.cluster_name = options_.rados_cluster_name;
       access_options.rados_options.user_name = options_.rados_user_name;
       access_options.rados_options.key = options_.rados_key;
-      InitBlockAccessOption(&access_options);
       break;
     case AccesserType::kLocalFile:
       access_options.file_options.path = options_.data_path;
-      InitBlockAccessOption(&access_options);
       break;
     default:
-      InitBlockAccessOption(&access_options);
       break;
   }
+  FillThrottleOptionsFromGFlags(&access_options.throttle_options);
 
   accesser_ = NewShareBlockAccesser(access_options);
   if (accesser_ == nullptr) {

--- a/src/common/blockaccess/s3/s3_common.h
+++ b/src/common/blockaccess/s3/s3_common.h
@@ -63,7 +63,11 @@ struct S3Options {
   AwsSdkConfig aws_sdk_config;
 };
 
-inline void InitAwsSdkConfig(AwsSdkConfig* aws_sdk_config) {
+// Fill AwsSdkConfig fields from global gflags (FLAGS_s3_*, FLAGS_log_dir).
+// Pure side-effect-on-arg function — does NOT construct anything, just
+// syncs the global flag state into the caller-owned struct. Caller MUST
+// invoke this only when it actually wants an S3 backend.
+inline void FillAwsSdkConfigFromGFlags(AwsSdkConfig* aws_sdk_config) {
   aws_sdk_config->region = FLAGS_s3_region;
   aws_sdk_config->loglevel = FLAGS_s3_loglevel;
 


### PR DESCRIPTION
## Problem

dingo-client's AWS SDK logs were silently written to the **current working directory** (e.g. `<cwd>/2026-05-11-05.log`) instead of the configured `<FLAGS_log_dir>/aws_sdk_<pid>_*.log`. The miswritten log files looked like dingofs application logs at first glance but actually contained AWS SDK internal events (S3Client / AuthSigning / connection-manager), making troubleshooting harder — grepping the real glog directory for client errors returned 0 hits while the smoking gun was sitting next to the deploy wrapper.

## Root cause

`InitBlockAccessOption()` (accesser_common.h) had a hidden ordering trap: it inspected `option->type` to decide whether to call `InitAwsSdkConfig` (which sets the AWS log_prefix), but `BlockAccessOptions::type` had **no default initializer**. The if-branch happened to work most of the time because `AccesserType` is defined with `kS3 = 0` and the surrounding allocation was usually zero-initialized, so the uninitialized `type` field coincidentally matched `kS3`.

But `vfs_hub.cc:180` called `InitBlockAccessOption` **before** assigning `type` from `fs_info.storage_info.store_type` (vfs_hub.cc:181-205). On startup paths where the field was not zero-initialized at that exact moment, the AWS SDK branch was skipped silently. With `InitAwsSdkConfig` skipped, `AwsSdkConfig::log_prefix` kept its empty default and AWS SDK `DefaultLogSystem` fell back to writing hourly logs in the process cwd.

## Fix — refactor

Remove the implicit "set type before calling" trap by replacing the wrapper with explicit per-backend fill helpers:

- Rename `InitAwsSdkConfig` → **`FillAwsSdkConfigFromGFlags`**. It copies gflag state into a caller-owned struct; it does not construct, the old name was misleading.
- Rename `InitBlockAccesserThrottleOptions` → **`FillThrottleOptionsFromGFlags`** (same rationale).
- **Delete `InitBlockAccessOption`**. Callers now invoke the per-backend fill helper explicitly, after setting `type` and connection info.

Behavior fix:

- `vfs_hub.cc` now sets `type` first, then calls `FillAwsSdkConfigFromGFlags` only on the `kS3` branch and `FillThrottleOptionsFromGFlags` unconditionally. AWS SDK logs are reliably written under `FLAGS_log_dir`.
- `block_access_bench.cc` mirrors the same pattern (`type` was already set first there; the change is purely a rename + explicit fill).

## Verification

Build + unit tests on Linux:

| Target | Result |
|---|---|
| `make dingo-client` | ✅ build clean |
| `test_common` (includes blockaccess unit tests) | **21 PASSED** |
| `test_client` (includes vfs_hub) | **273 PASSED** |
| `test_cache` | **85 PASSED** |

End-to-end on dingofs-test (mounted FUSE client + pytest smoke suite):

| Mode | Result |
|---|---|
| local (file backend) | **25 passed / 1 skipped / 90 deselected in 0.07s** |
| MDS (MDS + dingo-store + minio S3 backend) | **25 passed / 1 skipped / 90 deselected in 3.24s** |

Direct verification of the fix on the MDS mode:

- glog now prints `s3_log_prefix: <log_dir>/aws_sdk_<pid>_` at startup (was absent before — proved `InitAwsSdkConfig` was being skipped)
- physical `aws_sdk_<pid>_<YYYY-MM-DD-HH>.log` files now appear under `<log_dir>/` and grow during S3 IO (140 MB observed during smoke run)
- the previously-miswritten `<cwd>/<YYYY-MM-DD-HH>.log` is empty

## Notes

- No proto, no API surface change. Pure internal refactor + ordering fix.
- The 5 call sites (`vfs_hub.cc` ×1, `block_access_bench.cc` ×4) are updated consistently — `grep -rn InitBlockAccessOption src/` returns 0 hits after this PR.