### PR TITLE
[fix][client/vfs] Invalidate readahead buffer on SetAttr(size)/Fallocate

### DIFF
--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -217,6 +218,14 @@ Status VFSImpl::SetAttr(ContextSPtr ctx, Ino ino, int set, const Attr& in_attr,
   Status s =
       meta_system_->SetAttr(ctx, TranslateIno(ino), set, in_attr, out_attr);
   if (s.ok()) RewriteRootAttr(ino, out_attr);
+
+  // Truncate (size change) must invalidate cached read buffers — readahead
+  // buffers in FileReader::requests_ are indexed by (ino, frange) and would
+  // otherwise serve stale data after the inode shrinks/grows.
+  if (s.ok() && (set & kSetAttrSize)) {
+    handle_manager_->InvalidateByIno(ino, 0,
+                                     std::numeric_limits<int64_t>::max());
+  }
 
   return s;
 }


### PR DESCRIPTION
## Summary

`FileReader::requests_` caches `ReadRequest::buffer` keyed by `(ino, frange)`, but neither `VFSImpl::SetAttr` nor `VFSImpl::Fallocate` invokes `HandleManager::InvalidateByIno` after a successful meta op. This lets a truncated / punched / zero-filled range still serve stale data through the buffer on the next read on the same fd.

Write path (`vfs_impl.cc:Write`) already calls `InvalidateByIno`; mirror that for size change in `SetAttr` and for the affected range in `Fallocate`.

## Rationale

- `SetAttr` clears `[0, INT64_MAX)` on size change — truncate is infrequent and we lack mtime/version coupling between buffer and attr, so all-clear is safer than risking a stale read after shrink+grow.
- `Fallocate` clears the exact `[offset, length)` the caller asked for (mode-independent — PUNCH_HOLE / extend / KEEP_SIZE all modify content in the same range).

## Severity

`truncate` is the underlying syscall for `rsync`, `tail -F`, log rotation, checkpoint reset, etc. Same-fd read → ftruncate → re-read returns stale bytes. This is a **correctness bug**, not a performance issue.

## Test plan

Tests live in `chuandew/dingofs-test` `functional/test_readahead_invalidate.py`:

- `test_truncate_shrink_then_grow_invalidates_readahead`
  - Scenario A: same fd → read 4 MB → ftruncate(1 MB) → ftruncate(4 MB) → re-read extended range. **Must be zeros.**
  - Pre-fix: FAIL (extended range reads original bytes).
  - Post-fix: PASS.

- `test_truncate_shrink_in_place_extends_zeros_on_pwrite`
  - Scenario A variant: read → ftruncate(1 MB) → pwrite at 3 MB → read hole `[1M, 3M)`. **Must be zeros.**
  - Pre-fix: FAIL / Post-fix: PASS.

- `test_fallocate_punch_hole_invalidates_readahead`
  - Scenario C: read → fallocate(PUNCH_HOLE | KEEP_SIZE, 2 MB, 2 MB) → re-read punched range.
  - Currently SKIPPED because `fallocate` syscall returns EOPNOTSUPP on dingofs MDS mode (separate bug, not covered by this PR).

Regression: existing `functional/test_truncate.py` (4 cases) + `test_basic_io.py` (5 cases) all PASS unchanged.

## Test plan checklist

- [x] `pytest functional/test_readahead_invalidate.py` PASS (2 PASS + 1 SKIP)
- [x] `pytest functional/test_truncate.py functional/test_basic_io.py` PASS (9/9)
- [x] Local incremental rebuild (vfs_lib + dingo-client) green
- [ ] CI green on push

## Related

- Test PR in dingofs-test repo: <https://github.com/chuandew/dingofs-test/commit/4d4ecc4>
- Follow-up audit (P2: Lookup/GetAttr passive sync, P3: ReadDir attr sync, P4: cross-client push) tracked separately
- Related but independent: `fallocate(2)` syscall returns EOPNOTSUPP on MDS mode (client `MDSMetaSystem` missing `Fallocate` override + MDS server `filesystem.cc:2505` missing PUNCH_HOLE branch) — separate issue.