### PR TITLE
[fix][fallocate] Support fallocate(2) end-to-end

### DIFF
--- a/src/client/vfs/metasystem/local/metasystem.cc
+++ b/src/client/vfs/metasystem/local/metasystem.cc
@@ -1123,9 +1123,12 @@ Status LocalMetaSystem::SetAttr(ContextSPtr, Ino ino, int to_set,
 
 Status LocalMetaSystem::Fallocate(ContextSPtr, Ino ino, int mode,
                                   uint64_t offset, uint64_t length) {
-  // Only support a subset of modes: allocate (0), KEEP_SIZE, PUNCH_HOLE,
-  // and their combinations. Others are rejected.
-  constexpr int kSupported = 0x01 /*KEEP_SIZE*/ | 0x02 /*PUNCH_HOLE*/;
+  // Supported modes: plain allocate (0), KEEP_SIZE, PUNCH_HOLE, ZERO_RANGE,
+  // and valid combinations. Both PUNCH_HOLE and ZERO_RANGE write id=0
+  // (zero/hole) slices over the target range. ZERO_RANGE without KEEP_SIZE
+  // additionally extends file length when the range reaches past EOF.
+  constexpr int kSupported =
+      0x01 /*KEEP_SIZE*/ | 0x02 /*PUNCH_HOLE*/ | 0x10 /*ZERO_RANGE*/;
   if ((mode & ~kSupported) != 0) {
     return Status::NotSupport(fmt::format("fallocate mode({}) not supported",
                                           mode));

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -1381,6 +1381,28 @@ Status MDSMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
   return Status::OK();
 }
 
+Status MDSMetaSystem::Fallocate(ContextSPtr ctx, Ino ino, int mode,
+                                uint64_t offset, uint64_t length) {
+  AssertStop();
+
+  auto status = mds_client_.Fallocate(ctx, ino, mode, offset, length);
+
+  // Invalidate caches on success OR ambiguous net error (server may have
+  // committed the txn but the response was lost — cache TTL is 3600s, so
+  // stale could persist that long). Business errors (EQUOTA / EALLOC_ID /
+  // EINTERNAL / EPERM) roll the txn back atomically on the server side —
+  // cache stays consistent, skip.
+  if (status.ok() || status.IsNetError()) {
+    chunk_memo_.Forget(ino);
+    chunk_cache_.Delete(ino);
+    DeleteInodeFromCache(ino);
+  }
+  if (status.ok()) {
+    modify_time_memo_.Remember(ino);
+  }
+  return status;
+}
+
 Status MDSMetaSystem::GetXattr(ContextSPtr ctx, Ino ino,
                                const std::string& name, std::string* value) {
   AssertStop();

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -150,6 +150,8 @@ class MDSMetaSystem : public vfs::MetaSystem {
   Status GetAttr(ContextSPtr ctx, Ino ino, Attr* attr) override;
   Status SetAttr(ContextSPtr ctx, Ino ino, int set, const Attr& attr,
                  Attr* out_attr) override;
+  Status Fallocate(ContextSPtr ctx, Ino ino, int mode, uint64_t offset,
+                   uint64_t length) override;
   Status GetXattr(ContextSPtr ctx, Ino ino, const std::string& name,
                   std::string* value) override;
   Status SetXattr(ContextSPtr ctx, Ino ino, const std::string& name,

--- a/src/client/vfs/metasystem/memory/metasystem.cc
+++ b/src/client/vfs/metasystem/memory/metasystem.cc
@@ -27,21 +27,35 @@
 #include "client/vfs/common/helper.h"
 #include "client/vfs/metasystem/mds/helper.h"
 #include "client/vfs/vfs_meta.h"
-#include "common/const.h"
 #include "common/status.h"
 #include "common/trace/context.h"
 #include "dingofs/error.pb.h"
 #include "dingofs/mds.pb.h"
 #include "fmt/format.h"
+#include "gflags/gflags.h"
 #include "glog/logging.h"
 #include "json/value.h"
 #include "utils/uuid.h"
+
+// MemoryMetaSystem keeps metadata (inodes/dentries/chunks/slices) in-process
+// but client byte data still flows through block_accesser → S3 (see
+// vfs_hub.cc:182). These flags fill the FsInfo that block_accesser consumes
+// at startup.
+DEFINE_string(vfs_memory_fs_name, "dummy_fs",
+              "Filesystem name reported in MemoryMetaSystem FsInfo");
+DEFINE_string(vfs_memory_fs_s3_ak, "UAJ1WIVF3NM5XRIL0OU2",
+              "S3 access key reported in MemoryMetaSystem FsInfo");
+DEFINE_string(vfs_memory_fs_s3_sk, "X9MxdCZslPmXADljX140iiN6r81aGgCnO61wEA3L",
+              "S3 secret key reported in MemoryMetaSystem FsInfo");
+DEFINE_string(vfs_memory_fs_s3_endpoint, "http://10.220.68.19:80",
+              "S3 endpoint reported in MemoryMetaSystem FsInfo");
+DEFINE_string(vfs_memory_fs_s3_bucket, "dummy-fs",
+              "S3 bucket name reported in MemoryMetaSystem FsInfo");
 
 static const uint32_t kFsID = 10000;
 static const uint64_t kRootIno = 1;
 static const uint64_t kDefaultBlockSize = 4 * 1024 * 1024;
 static const uint64_t kDefaultChunkSize = 64 * 1024 * 1024;
-static const std::string kDefaultFsName = "dummy_fs";
 
 namespace dingofs {
 namespace client {
@@ -261,7 +275,7 @@ static pb::mds::FsInfo GenFsInfo() {
   pb::mds::FsInfo fs_info;
 
   fs_info.set_fs_id(kFsID);
-  fs_info.set_fs_name(kDefaultFsName);
+  fs_info.set_fs_name(FLAGS_vfs_memory_fs_name);
   fs_info.set_block_size(kDefaultBlockSize);
   fs_info.set_chunk_size(kDefaultChunkSize);
   fs_info.set_fs_type(pb::mds::FsType::S3);
@@ -273,18 +287,10 @@ static pb::mds::FsInfo GenFsInfo() {
   fs_info.set_status(pb::mds::FsStatus::NORMAL);
 
   auto* s3_info = fs_info.mutable_extra()->mutable_s3_info();
-
-  std::string ak = "UAJ1WIVF3NM5XRIL0OU2";
-  s3_info->set_ak(ak);
-
-  std::string sk = "X9MxdCZslPmXADljX140iiN6r81aGgCnO61wEA3L";
-  s3_info->set_sk(sk);
-
-  std::string endpoint = "http://10.220.68.19:80";
-  s3_info->set_endpoint(endpoint);
-
-  std::string bucketname = "dummy-fs";
-  s3_info->set_bucketname(bucketname);
+  s3_info->set_ak(FLAGS_vfs_memory_fs_s3_ak);
+  s3_info->set_sk(FLAGS_vfs_memory_fs_s3_sk);
+  s3_info->set_endpoint(FLAGS_vfs_memory_fs_s3_endpoint);
+  s3_info->set_bucketname(FLAGS_vfs_memory_fs_s3_bucket);
 
   LOG(INFO) << fmt::format("gen fs info: {}", fs_info.ShortDebugString());
   return fs_info;
@@ -802,8 +808,9 @@ Status MemoryMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
 
 Status MemoryMetaSystem::Fallocate(ContextSPtr /*ctx*/, Ino ino, int mode,
                                    uint64_t offset, uint64_t length) {
-  // Only KEEP_SIZE (0x01) and PUNCH_HOLE (0x02); and plain allocate (0).
-  constexpr int kSupported = 0x01 | 0x02;
+  // Supported: plain allocate (0), KEEP_SIZE (0x01), PUNCH_HOLE (0x02),
+  // ZERO_RANGE (0x10) and valid combinations.
+  constexpr int kSupported = 0x01 | 0x02 | 0x10;
   if ((mode & ~kSupported) != 0) {
     return Status::NotSupport(
         fmt::format("fallocate mode({}) not supported", mode));
@@ -966,7 +973,7 @@ static RadosInfo ToRadosInfo(const pb::mds::RadosInfo& rados_info) {
 }
 
 Status MemoryMetaSystem::GetFsInfo(ContextSPtr, FsInfo* fs_info) {
-  fs_info->name = kDefaultFsName;
+  fs_info->name = fs_info_.fs_name();
   fs_info->id = fs_info_.fs_id();
   fs_info->chunk_size = fs_info_.chunk_size();
   fs_info->block_size = fs_info_.block_size();

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -2551,19 +2551,34 @@ Status FileSystem::Fallocate(Context& ctx, Ino ino, int32_t mode, uint64_t offse
 
   uint64_t slice_num = 0;
   uint64_t slice_id = 0;
-  if (mode == 0 || (mode & FALLOC_FL_ZERO_RANGE)) {
+  if (mode == 0) {
+    // Plain preallocate: extend file size and reserve slices for the new tail.
     uint64_t new_length = offset + len;
     if (new_length > inode->Length()) {
-      // check quota
       if (!quota_manager_.CheckQuota(trace, ino, new_length - inode->Length(), 0)) {
         return Status(pb::error::EQUOTA_EXCEED, "exceed quota limit");
       }
-
-      // prealloc slice id
-      slice_num = (new_length - inode->Length()) / fs_info_->GetChunkSize() + 1;
+      slice_num = ((new_length - inode->Length()) / fs_info_->GetChunkSize()) + 1;
       if (!slice_id_generator_->GenID(slice_num, 0, slice_id)) {
         return Status(pb::error::EALLOC_ID, "generate slice id fail");
       }
+    }
+  } else if (mode & (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_ZERO_RANGE)) {
+    // PUNCH_HOLE / ZERO_RANGE write zero slices over [offset, offset+len).
+    // Always pre-allocate slice ids covering every chunk the range touches —
+    // without this, FallocateOperation::SetZero fails with `beyond slice
+    // num(0)`. ZERO_RANGE without KEEP_SIZE may extend the file → quota check.
+    if ((mode & FALLOC_FL_ZERO_RANGE) && !(mode & FALLOC_FL_KEEP_SIZE)) {
+      uint64_t new_length = offset + len;
+      if (new_length > inode->Length()) {
+        if (!quota_manager_.CheckQuota(trace, ino, new_length - inode->Length(), 0)) {
+          return Status(pb::error::EQUOTA_EXCEED, "exceed quota limit");
+        }
+      }
+    }
+    slice_num = (len / fs_info_->GetChunkSize()) + 1;
+    if (!slice_id_generator_->GenID(slice_num, 0, slice_id)) {
+      return Status(pb::error::EALLOC_ID, "generate slice id fail");
     }
   }
 

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -1331,6 +1331,8 @@ Status FallocateOperation::PreAlloc(TxnUPtr& txn, AttrEntry& attr, uint64_t offs
 
     } else {
       max_chunk.add_slices()->Swap(&slice);
+      // bump version so ChunkCache::PutIf accepts the updated slice list.
+      max_chunk.set_version(max_chunk.version() + 1);
       txn->Put(MetaCodec::EncodeChunkKey(fs_id, ino, chunk_index), MetaCodec::EncodeChunkValue(max_chunk));
       effected_chunks.push_back(max_chunk);
     }
@@ -1341,6 +1343,11 @@ Status FallocateOperation::PreAlloc(TxnUPtr& txn, AttrEntry& attr, uint64_t offs
       return Status(pb::error::EINTERNAL, fmt::format("beyond slice num({})", slice_num));
     }
   }
+
+  // PreAlloc extends file size unconditionally (plain mode=0 semantic).
+  // Without this, fallocate(2) with mode=0 returns success but the file
+  // length never grows past the original — `ls -la` reports the old size.
+  attr.set_length(new_length);
 
   result_.effected_chunks = std::move(effected_chunks);
 
@@ -1397,6 +1404,10 @@ Status FallocateOperation::SetZero(TxnUPtr& txn, AttrEntry& attr, uint64_t offse
     } else {
       auto& chunk = it->second;
       chunk.add_slices()->Swap(&slice);
+      // bump version so ChunkCache::PutIf (filesystem.cc:2612) accepts the
+      // updated slice list — otherwise server keeps serving the pre-fallocate
+      // cached chunk and client read returns old bytes instead of zeros.
+      chunk.set_version(chunk.version() + 1);
       txn->Put(MetaCodec::EncodeChunkKey(fs_id, ino, chunk_index), MetaCodec::EncodeChunkValue(chunk));
       effected_chunks.push_back(chunk);
     }


### PR DESCRIPTION
## Summary

Make `fallocate(2)` work end-to-end across all three client metasystem variants. Tested modes: plain (`mode=0`), `PUNCH_HOLE | KEEP_SIZE`, `ZERO_RANGE`, and the `fallocate(1)` CLI.

### MDS mode (`MDSMetaSystem`) — four interlocking bugs

- **client `MDSMetaSystem::Fallocate` missing** — base class default returned `NotSupport`, so libfuse cached it as `EOPNOTSUPP` after the first call. Add the override to forward to `mds_client_.Fallocate` and invalidate `chunk_memo_` / `chunk_cache_` / `inode_cache_` on success **and on net error** (defensive: cache TTL is 3600s, so a lost response on net failure could otherwise leave stale state for that long).

- **mds `PreAllocOperation::PreAlloc` didn't set length** — updated chunk slice metadata but never called `attr.set_length(new_length)`, so `mode=0` extends silently kept the old file size. Set the new length explicitly.

- **mds Fallocate dispatcher missed slice-id pre-alloc** — only allocated for `mode=0` / `ZERO_RANGE`-extending paths. `PUNCH_HOLE` and `ZERO_RANGE | KEEP_SIZE` fell through with `slice_num=0` and then failed inside `FallocateOperation::SetZero` with ``"beyond slice num(0)"``. Allocate `len/chunk_size + 1` slice ids for these branches.

- **mds `SetZero` / `PreAlloc` didn't bump `chunk.version()`** — appended zero-id slices to existing chunks without incrementing version. `ChunkCache::PutIf` requires a strictly-greater version, so the server's cache rejected the update and kept serving the pre-fallocate slice list. Subsequent reads on the same chunk returned old bytes instead of zeros. `TruncateFileRange` already bumps the version on slice append — match that pattern.

### Local / Memory modes — feature gap

`LocalMetaSystem::Fallocate` and `MemoryMetaSystem::Fallocate` had `kSupported = KEEP_SIZE | PUNCH_HOLE`, rejecting `ZERO_RANGE (0x10)` as `NotSupport`. The existing zero-slice write logic and length-extension paths already handle ZERO_RANGE semantics correctly; just widen the supported-mode mask.

`MemoryMetaSystem` also had hardcoded S3 ak/sk/endpoint/bucket and fs_name in `GenFsInfo()` — moved to gflags so memory-mode deployments can point at a reachable S3 backend (memory mode keeps metadata in-process but byte data still flows through `block_accesser` → S3, see `vfs_hub.cc:182`).

## Test plan

Test cases live in [chuandew/dingofs-test@eb2e4d5](https://github.com/chuandew/dingofs-test/commit/eb2e4d5) (4 cases under \`functional/test_fallocate.py\` covering plain extend, PUNCH_HOLE, ZERO_RANGE, and the \`fallocate(1)\` CLI).

A follow-up PR will add a Python e2e test scaffolding (\`test/e2e/\`) to this repo so future regression tests can live alongside the code; that scaffolding is out of scope here.

| Mode | Instance | Result |
|---|---|---|
| MDS | \`bench-vs-fs\` (8821 / 10001) | 4/4 passed in 0.43s |
| Local | \`pr-verify\` | 4/4 passed in 0.04s |
| Memory | \`test-mem\` (12000) | 4/4 passed in 0.11s |

- [x] All 4 cases pass on MDS / Local / Memory mode mounts
- [x] No regression on prior smoke (mount / touch / IO)
- [x] Manual repro: write 8 MiB \`'A'\` → \`fallocate(PUNCH_HOLE | KEEP_SIZE, 2 MiB, 2 MiB)\` → read \`[2 MiB, 4 MiB)\` returns zeros; file size preserved at 8 MiB