### PR TITLE
[fix][fallocate] Invalidate readahead + handle empty file + truncate-down stale slices

### DIFF
--- a/src/client/vfs/metasystem/local/metasystem.cc
+++ b/src/client/vfs/metasystem/local/metasystem.cc
@@ -1088,13 +1088,44 @@ Status LocalMetaSystem::SetAttr(ContextSPtr, Ino ino, int to_set,
       attr_entry.set_ctime(ToTimestamp(now));
     }
 
+    std::vector<KeyValue> kvs;
+
     if (to_set & kSetAttrSize) {
       // uint64 subtraction wraps on shrink; reinterpreting the bit pattern
       // as int64 recovers the correct signed delta (valid because both
       // lengths fit in int64).
-      delta_size =
-          static_cast<int64_t>(in_attr.length - attr_entry.length());
-      attr_entry.set_length(in_attr.length);
+      const uint64_t old_length = attr_entry.length();
+      const uint64_t new_length = in_attr.length;
+      delta_size = static_cast<int64_t>(new_length - old_length);
+      attr_entry.set_length(new_length);
+
+      // On shrink, clear stale slices in [new_length, old_length) so a
+      // subsequent grow (or fallocate ZERO_RANGE / read past length-then-
+      // truncate-up) does not expose the old bytes. Mirrors the MDS-side
+      // TruncateFileRange semantics (store_operation.cc): if the new length
+      // falls inside a chunk, append an id=0 (zero) slice covering the
+      // chunk tail; then delete every chunk fully past new_length.
+      if (new_length < old_length) {
+        const uint64_t chunk_size = fs_info_.chunk_size();
+        const uint32_t old_num = static_cast<uint32_t>(
+            (old_length + chunk_size - 1) / chunk_size);
+        const uint32_t new_num = static_cast<uint32_t>(
+            (new_length + chunk_size - 1) / chunk_size);
+
+        if (new_length % chunk_size != 0) {
+          const uint64_t chunk_pos = new_length % chunk_size;
+          const uint64_t len = chunk_size - chunk_pos;
+          status = AppendZeroSliceToChunk(fs_id, ino, new_num - 1,
+                                          static_cast<uint32_t>(chunk_pos),
+                                          static_cast<uint32_t>(len), kvs);
+          if (!status.ok()) return status;
+        }
+        for (uint32_t i = new_num; i < old_num; ++i) {
+          kvs.push_back({KeyValue::OpType::kDelete,
+                         MetaCodec::EncodeChunkKey(fs_id, ino, i),
+                         std::string()});
+        }
+      }
     }
 
     if (to_set & kSetAttrFlags) {
@@ -1103,11 +1134,10 @@ Status LocalMetaSystem::SetAttr(ContextSPtr, Ino ino, int to_set,
 
     attr_entry.set_version(attr_entry.version() + 1);
 
-    // write to leveldb
-    std::vector<KeyValue> kvs = {
-        {KeyValue::OpType::kPut, inode_key,
-         MetaCodec::EncodeInodeValue(attr_entry)},
-    };
+    // write to leveldb (inode + any chunk tail/delete ops queued above
+    // for the shrink case are applied atomically by Put()).
+    kvs.push_back({KeyValue::OpType::kPut, inode_key,
+                   MetaCodec::EncodeInodeValue(attr_entry)});
     status = Put(kvs);
     if (!status.ok()) return status;
   }

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -235,7 +235,17 @@ Status VFSImpl::Fallocate(ContextSPtr ctx, Ino ino, int mode, uint64_t offset,
   if (BAIDU_UNLIKELY(ino == kStatsIno)) {
     return Status::NoPermitted("fallocate on internal node");
   }
-  return meta_system_->Fallocate(ctx, TranslateIno(ino), mode, offset, length);
+  Status s =
+      meta_system_->Fallocate(ctx, TranslateIno(ino), mode, offset, length);
+  // Mirror the SetAttr(size) path: PUNCH_HOLE / ZERO_RANGE / extending the
+  // file all change byte contents in [offset, offset+length); cached readahead
+  // buffers in FileReader::requests_ on the same fd would otherwise serve
+  // stale bytes for the affected range.
+  if (s.ok()) {
+    handle_manager_->InvalidateByIno(ino, static_cast<int64_t>(offset),
+                                     static_cast<int64_t>(length));
+  }
+  return s;
 }
 
 Status VFSImpl::CopyFileRange(ContextSPtr ctx, Ino src_ino, uint64_t src_off,

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -1296,9 +1296,21 @@ Status FallocateOperation::PreAlloc(TxnUPtr& txn, AttrEntry& attr, uint64_t offs
   const uint64_t block_size = param_.block_size;
   const uint32_t slice_num = param_.slice_num;
 
+  // GetChunk returns ENOT_FOUND when no chunk exists at the starting index —
+  // expected for an empty (0-byte) file or a chunk-aligned current length.
+  // Track existence explicitly so the loop always takes the "create new chunk"
+  // branch when there is nothing to append to (which sets chunk_size and
+  // block_size properly instead of writing a zero-init ChunkEntry back).
   ChunkEntry max_chunk;
-  auto status = GetChunk(txn, fs_id, ino, length / chunk_size, max_chunk);
-  if (!status.ok()) return status;
+  bool max_chunk_exists = false;
+  {
+    auto status = GetChunk(txn, fs_id, ino, length / chunk_size, max_chunk);
+    if (status.ok()) {
+      max_chunk_exists = true;
+    } else if (status.error_code() != pb::error::ENOT_FOUND) {
+      return status;
+    }
+  }
 
   std::vector<ChunkEntry> effected_chunks;
   uint32_t count = 0;
@@ -1315,10 +1327,12 @@ Status FallocateOperation::PreAlloc(TxnUPtr& txn, AttrEntry& attr, uint64_t offs
     slice.set_off(0);
     slice.set_len(delta_chunk_size);
 
-    CHECK(chunk_index >= max_chunk.index()) << fmt::format(
-        "chunk_index({}) should be greater than or equal to max_chunk.index({}).", chunk_index, max_chunk.index());
+    if (max_chunk_exists) {
+      CHECK(chunk_index >= max_chunk.index()) << fmt::format(
+          "chunk_index({}) should be greater than or equal to max_chunk.index({}).", chunk_index, max_chunk.index());
+    }
 
-    if (chunk_index > max_chunk.index()) {
+    if (!max_chunk_exists || chunk_index > max_chunk.index()) {
       ChunkEntry chunk;
       chunk.set_index(chunk_index);
       chunk.set_chunk_size(chunk_size);
@@ -1335,6 +1349,9 @@ Status FallocateOperation::PreAlloc(TxnUPtr& txn, AttrEntry& attr, uint64_t offs
       max_chunk.set_version(max_chunk.version() + 1);
       txn->Put(MetaCodec::EncodeChunkKey(fs_id, ino, chunk_index), MetaCodec::EncodeChunkValue(max_chunk));
       effected_chunks.push_back(max_chunk);
+      // After we append to max_chunk in this iteration, subsequent iterations
+      // will be in new chunks (chunk_index > max_chunk.index()).
+      max_chunk_exists = false;
     }
 
     length += delta_chunk_size;


### PR DESCRIPTION
## Summary

Three follow-up fixes for fallocate / truncate semantics, surfaced by porting [\`chuandew/dingofs-test\`](https://github.com/chuandew/dingofs-test) tests into a stricter regression suite. All three live in client-side code (\`vfs_impl.cc\` + Local metasystem) and the MDS-side store operation.

### Fix 1 — \`VFSImpl::Fallocate\` missing \`InvalidateByIno\` (vfs_impl.cc)

After a successful \`Fallocate\` (PUNCH_HOLE / ZERO_RANGE / extend), the cached read buffers in \`FileReader::requests_\` are not invalidated for the affected range, so a subsequent read on the same fd returns stale bytes.

#879 added the equivalent \`InvalidateByIno\` to \`VFSImpl::SetAttr\` for truncate-induced size changes but skipped \`Fallocate\` (\`fallocate(2)\` was returning \`EOPNOTSUPP\` at the time — that was fixed in #880). This PR mirrors the SetAttr pattern in Fallocate.

### Fix 2 — \`PreAllocOperation::PreAlloc\` rejects empty files (store_operation.cc)

\`fallocate(mode=0, 0, 10 MiB)\` on a freshly-\`open(O_CREAT)\`ed (0-byte) file returns \`EIO\` because \`PreAlloc\` calls \`GetChunk(txn, fs_id, ino, length / chunk_size, max_chunk)\` and propagates \`ENOT_FOUND\` straight back. For a 0-byte file (and for any chunk-aligned \`length\`) no chunk exists yet, so the operation always fails.

\`TruncateFileRange\` (line ~982) already handles this case correctly. This PR applies the same handling to \`PreAlloc\`: track \`max_chunk_exists\` explicitly and route the "no existing chunk" path through the create-new-chunk branch so \`chunk_size\` / \`block_size\` are initialized properly.

### Fix 3 — \`LocalMetaSystem::SetAttr\` ignores chunk slices on truncate-down (local/metasystem.cc)

Truncating a file down (e.g. \`ftruncate(fd, smaller)\`) only updated \`attr.length\` and left the original chunk slices intact. A subsequent grow then exposed the stale bytes:

\`\`\`python
write 10 MiB
ftruncate(5 MiB)
ftruncate(10 MiB)
read [5 MiB, 10 MiB)  # POSIX says zeros; pre-fix returns the original bytes
\`\`\`

Mirroring the MDS \`TruncateFileRange\` semantics: when \`new_length < old_length\` in \`LocalMetaSystem::SetAttr\`, append an \`id=0\` (zero) slice to the last partial chunk covering \`[new_length % chunk_size, chunk_size)\`, then delete every chunk fully past \`new_length\`. Both updates are batched into the same leveldb \`WriteBatch\` as the attr update for atomicity.

## Test plan

Verified on both deployment modes using the in-tree e2e suite (introduced in #883, depends on this PR). Post-fix:

| Mode | Mount | Result |
|---|---|---|
| MDS    | \`bench-vs-fs\` | 119 passed, 1 skipped (chown root), 0 fail, 36.45s |
| Local  | \`pr-verify\`   | 119 passed, 1 skipped, 0 fail, 4.58s |

Specific regressions:

| Test | Pre-fix | Post-fix |
|---|---|---|
| \`regression/test_regression_readahead_invalidate::test_fallocate_punch_hole_invalidates_readahead\` (MDS + Local) | FAIL — stale bytes | PASS |
| \`regression/test_regression_fallocate_basic::test_fallocate_basic\` (MDS) | FAIL — EIO | PASS |
| \`regression/test_regression_fallocate_basic::test_fallocate_extend_from_chunk_boundary\` (MDS) | FAIL — EIO | PASS |
| \`regression/test_regression_readahead_invalidate::test_truncate_shrink_then_grow_invalidates_readahead\` (Local) | FAIL — stale bytes | PASS |
| \`regression/test_regression_truncate_shrink_grow::test_truncate_shrink_grow_tail_must_be_zero\` (Local) | FAIL — stale bytes | PASS |
| \`regression/test_regression_truncate_shrink_grow::test_truncate_to_zero_and_grow\` (Local) | FAIL — stale bytes | PASS |
| \`regression/test_regression_readahead_invalidate::test_truncate_shrink_in_place_extends_zeros_on_pwrite\` (Local) | FAIL — stale bytes | PASS |

No regressions on the existing #880 acceptance suite (mode=0 / KEEP_SIZE / PUNCH_HOLE / ZERO_RANGE / CLI all pass on MDS / Local / Memory).