### PR TITLE
[test][e2e] Add Python end-to-end test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ build.log
 
 # python
 *.pyc
+__pycache__/
+.pytest_cache/
+.venv/
 
 
 # protobuf

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,137 @@
+# DingoFS End-to-End Tests
+
+Black-box tests that run against a deployed `dingo-client` mount.
+
+Unlike `test/unit/` (per-module C++ unit tests) and `test/integration/`
+(C++ multi-component in-process integration), this suite drives the
+**full stack**: FUSE kernel module → `dingo-client` → MDS / Local /
+Memory metasystem → block store (S3 / file). The test author can
+exercise DingoFS-specific behavior — chunk boundaries, mode-specific
+paths, regression fixtures keyed to commit hashes — without having to
+link against C++ internals.
+
+## Scope
+
+| Layer | Tested by | Verifies |
+|---|---|---|
+| C++ unit (`test/unit/`) | gtest, in-process | one class / one module behavior |
+| C++ integration (`test/integration/`) | gtest, in-process | several C++ modules wired together |
+| **e2e (here)** | **pytest, via FUSE mount** | **whole stack including FUSE / userspace client / MDS / S3** |
+
+## Layout
+
+```
+test/e2e/
+├── conftest.py            # --mount-point arg + test_dir fixture
+├── pyproject.toml         # uv project
+├── pytest.ini             # markers (smoke / standard) + addopts
+├── README.md              # this file
+├── posix/                 # vendor-neutral POSIX baseline (transitional)
+│   └── test_*.py
+├── regression/            # Bug-fix regression keyed to specific commits
+│   └── test_regression_*.py
+└── specific/              # DingoFS-specific layout / data path
+    └── test_*.py
+```
+
+### `posix/` — Transitional POSIX baseline
+
+These tests cover basic POSIX FS semantics that any compliant filesystem
+should satisfy (read / write / mkdir / chmod / link / rename / xattr,
+…). They are a **transitional** stub maintained until pjdfstest
+(~8800 standards-grade POSIX cases) is integrated, at which point this
+whole directory will be deleted.
+
+Maintenance policy:
+- Smoke-level coverage only — exhaustive POSIX compliance is pjdfstest's
+  job, not this directory's.
+- When adding a new test, first check whether pjdfstest already covers
+  it; if so, do not duplicate here.
+
+### `regression/` — Bug-fix regression
+
+Tests bound to a specific bug-fix commit. Each file's header docstring
+must declare:
+- **Bug**: observable symptom and where it manifests
+- **Fix**: PR # / commit hash and a one-line summary of the fix
+- **Verification**: which test fails pre-fix (with symptom), what passes
+  post-fix, and which modes were covered (MDS / Local / Memory)
+
+File naming: `test_regression_<keyword>.py`. The prefix is intentional —
+it signals "this exists to keep a specific fix from regressing", and the
+file header tells the future maintainer exactly which fix.
+
+### `specific/` — DingoFS-specific behavior
+
+Tests whose assertions depend on knowing DingoFS internal data layout
+(64 MiB chunk size, 4 MiB block size, slice mechanism, id=0 sparse
+sentinel, etc.). They are not portable to other filesystems because the
+constants and the data-plane choices differ.
+
+File naming: `test_<topic>.py` (no `test_regression_` prefix — these are
+behavior probes, not bug regressions).
+
+Each file's header docstring should note which DingoFS internal detail
+it exercises (e.g. "validates writes at 64 MiB chunk boundary",
+"verifies sparse hole representation crossing chunks").
+
+## Running
+
+```bash
+cd test/e2e
+
+# Install deps (creates .venv via uv)
+uv sync
+
+# Run against an MDS-mode mount
+uv run pytest --mount-point=/home/me/mounts/claude-mount/bench-vs-fs
+
+# Smoke only
+uv run pytest --mount-point=<MP> -m smoke
+
+# Single file
+uv run pytest regression/test_regression_fallocate_modes.py --mount-point=<MP>
+```
+
+> Run the appropriate `bash scripts/deploy/{mds,local,memory}/deploy_all.sh`
+> before invoking pytest to ensure a fresh mountpoint.
+
+## Authoring a new regression test
+
+```python
+# regression/test_regression_<keyword>.py
+"""Regression test for <bug summary>.
+
+Bug:
+  <observable symptom; where it manifests; affected modes>
+
+Verification:
+  pre fix:  <which test should FAIL with what symptom>
+  post fix: <expected behavior>
+  works on: MDS / Local / Memory (mark per-test if mode-specific)
+
+# Optional — include only when the test ships in a DIFFERENT PR than the
+# fix (e.g. test added later as a cross-PR regression). Skip this line
+# when the fix and the test live in the same PR — the local diff in that
+# PR provides all the context a reviewer or future archaeologist needs.
+#
+# Regression for PR #<num>: <one-line cause>
+"""
+import os, pytest
+
+
+@pytest.mark.smoke
+def test_the_bug(test_dir):
+    path = os.path.join(test_dir, "case")
+    ...
+```
+
+### When to include `Regression for PR #N`
+
+| Scenario | Include reference? |
+|---|---|
+| Test + fix in the same PR | **No.** The PR diff is self-evident. |
+| Test added in a later PR (covering a previously-shipped fix) | **Yes.** Cross-PR navigation needs an anchor. |
+| Test predates the fix (will fail until fix lands) | Yes, with TODO note linking to the in-flight fix PR. |
+
+We deliberately reference the PR # rather than a commit hash — PR # is stable across rebases, squashes, and cherry-picks, whereas commit hashes change every time a PR is reshaped. Reconstruct the actual merged commit any time via `gh pr view <N> --json mergeCommit` or `git log --grep '(#<N>)'`.

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,49 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared pytest fixtures for the DingoFS end-to-end suite.
+
+Tests assume a running dingo-client with a mountpoint reachable from the
+local filesystem. Pass the mountpoint via `--mount-point=<path>`.
+"""
+
+import os
+import shutil
+import uuid
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--mount-point",
+        required=True,
+        help="FUSE mount point path (e.g. /home/me/mounts/claude-mount/<inst>)",
+    )
+
+
+@pytest.fixture(scope="session")
+def mount_point(request):
+    mp = request.config.getoption("--mount-point")
+    assert os.path.isdir(mp), f"{mp} is not a directory"
+    return mp
+
+
+@pytest.fixture
+def test_dir(mount_point):
+    """Per-test isolated subdir under the mountpoint; auto-removed at teardown."""
+    d = os.path.join(mount_point, f"test_{uuid.uuid4().hex[:8]}")
+    os.makedirs(d)
+    yield d
+    shutil.rmtree(d, ignore_errors=True)

--- a/test/e2e/posix/test_basic_io.py
+++ b/test/e2e/posix/test_basic_io.py
@@ -1,0 +1,58 @@
+# Copyright 2024 DingoFS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+
+import hashlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_create_file(test_dir):
+    """touch creates an empty file."""
+    p = os.path.join(test_dir, "empty")
+    open(p, "w").close()
+    assert os.path.isfile(p)
+    assert os.path.getsize(p) == 0
+
+
+def test_write_read_small(test_dir):
+    """Small file round-trip."""
+    p = os.path.join(test_dir, "small.txt")
+    data = b"hello dingofs\n"
+    with open(p, "wb") as f:
+        f.write(data)
+    with open(p, "rb") as f:
+        assert f.read() == data
+
+
+def test_write_read_1mb(test_dir):
+    """1MB random data md5 round-trip."""
+    p = os.path.join(test_dir, "1mb")
+    data = os.urandom(1024 * 1024)
+    with open(p, "wb") as f:
+        f.write(data)
+    with open(p, "rb") as f:
+        assert md5(f.read()) == md5(data)
+
+
+def test_delete_file(test_dir):
+    """File does not exist after deletion."""
+    p = os.path.join(test_dir, "todel")
+    open(p, "w").close()
+    os.remove(p)
+    assert not os.path.exists(p)
+
+
+def test_stat_size(test_dir):
+    """stat returns correct size."""
+    p = os.path.join(test_dir, "sized")
+    data = os.urandom(12345)
+    with open(p, "wb") as f:
+        f.write(data)
+    assert os.path.getsize(p) == 12345

--- a/test/e2e/posix/test_concurrent.py
+++ b/test/e2e/posix/test_concurrent.py
@@ -1,0 +1,40 @@
+# Copyright 2026 DingoDB. All rights reserved.
+
+import os
+import hashlib
+import concurrent.futures
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_concurrent_write_read(test_dir):
+    """8 threads write 10MB files in parallel, then verify each md5."""
+    MB = 1024 * 1024
+    num_files = 8
+    file_size = 10 * MB
+
+    # Prepare datasets
+    datasets = [(f"cf_{i}", os.urandom(file_size)) for i in range(num_files)]
+
+    def write_file(name_data):
+        name, data = name_data
+        path = os.path.join(test_dir, name)
+        with open(path, "wb") as f:
+            f.write(data)
+        return name, md5(data)
+
+    # Parallel write
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_files) as pool:
+        results = list(pool.map(write_file, datasets))
+
+    # Read back and verify each file
+    for name, expected_md5 in results:
+        path = os.path.join(test_dir, name)
+        with open(path, "rb") as f:
+            assert md5(f.read()) == expected_md5, f"{name} md5 mismatch"

--- a/test/e2e/posix/test_directory.py
+++ b/test/e2e/posix/test_directory.py
@@ -1,0 +1,54 @@
+# Copyright 2024 DingoFS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+
+import os
+import shutil
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def test_mkdir(test_dir):
+    d = os.path.join(test_dir, "subdir")
+    os.mkdir(d)
+    assert os.path.isdir(d)
+
+
+def test_mkdir_nested(test_dir):
+    d = os.path.join(test_dir, "a", "b", "c", "d")
+    os.makedirs(d)
+    assert os.path.isdir(d)
+
+
+def test_rmdir_empty(test_dir):
+    d = os.path.join(test_dir, "empty_dir")
+    os.mkdir(d)
+    os.rmdir(d)
+    assert not os.path.exists(d)
+
+
+def test_rmdir_nonempty_fails(test_dir):
+    d = os.path.join(test_dir, "nonempty")
+    os.mkdir(d)
+    open(os.path.join(d, "f"), "w").close()
+    with pytest.raises(OSError):
+        os.rmdir(d)
+
+
+def test_readdir(test_dir):
+    names = {"f1", "f2", "f3", "sub"}
+    for n in ["f1", "f2", "f3"]:
+        open(os.path.join(test_dir, n), "w").close()
+    os.mkdir(os.path.join(test_dir, "sub"))
+    listed = set(os.listdir(test_dir))
+    assert listed == names
+
+
+def test_recursive_delete(test_dir):
+    base = os.path.join(test_dir, "tree")
+    os.makedirs(os.path.join(base, "a", "b"))
+    open(os.path.join(base, "a", "f"), "w").close()
+    open(os.path.join(base, "a", "b", "g"), "w").close()
+    shutil.rmtree(base)
+    assert not os.path.exists(base)

--- a/test/e2e/posix/test_links.py
+++ b/test/e2e/posix/test_links.py
@@ -1,0 +1,94 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for hard link and symbolic link operations."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_hardlink(test_dir):
+    """Hard link shares inode, nlink=2, and content is identical."""
+    src = os.path.join(test_dir, "src.txt")
+    lnk = os.path.join(test_dir, "lnk.txt")
+
+    with open(src, "w") as f:
+        f.write("hello hardlink")
+
+    os.link(src, lnk)
+
+    src_stat = os.stat(src)
+    lnk_stat = os.stat(lnk)
+
+    assert src_stat.st_ino == lnk_stat.st_ino
+    assert src_stat.st_nlink == 2
+    assert lnk_stat.st_nlink == 2
+
+    with open(lnk, "r") as f:
+        assert f.read() == "hello hardlink"
+
+
+@pytest.mark.smoke
+def test_hardlink_unlink_preserves_source(test_dir):
+    """Removing hard link leaves source with nlink=1 and content intact."""
+    src = os.path.join(test_dir, "src.txt")
+    lnk = os.path.join(test_dir, "lnk.txt")
+
+    with open(src, "w") as f:
+        f.write("preserve me")
+
+    os.link(src, lnk)
+    os.unlink(lnk)
+
+    stat = os.stat(src)
+    assert stat.st_nlink == 1
+
+    with open(src, "r") as f:
+        assert f.read() == "preserve me"
+
+
+@pytest.mark.smoke
+def test_symlink_readlink(test_dir):
+    """Symlink target is correct and content is readable through symlink."""
+    target = os.path.join(test_dir, "target.txt")
+    link = os.path.join(test_dir, "sym.txt")
+
+    with open(target, "w") as f:
+        f.write("symlink content")
+
+    os.symlink(target, link)
+
+    assert os.readlink(link) == target
+
+    with open(link, "r") as f:
+        assert f.read() == "symlink content"
+
+
+@pytest.mark.smoke
+def test_symlink_dangling(test_dir):
+    """Reading a dangling symlink raises FileNotFoundError."""
+    target = os.path.join(test_dir, "target.txt")
+    link = os.path.join(test_dir, "sym.txt")
+
+    with open(target, "w") as f:
+        f.write("soon gone")
+
+    os.symlink(target, link)
+    os.unlink(target)
+
+    with pytest.raises(FileNotFoundError):
+        with open(link, "r") as f:
+            f.read()

--- a/test/e2e/posix/test_metadata.py
+++ b/test/e2e/posix/test_metadata.py
@@ -1,0 +1,47 @@
+# Copyright 2024 DingoFS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+
+import os
+import stat
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def test_chmod(test_dir):
+    p = os.path.join(test_dir, "ch")
+    open(p, "w").close()
+    os.chmod(p, 0o600)
+    assert oct(os.stat(p).st_mode)[-3:] == "600"
+    os.chmod(p, 0o644)
+    assert oct(os.stat(p).st_mode)[-3:] == "644"
+
+
+def test_utime(test_dir):
+    p = os.path.join(test_dir, "ut")
+    open(p, "w").close()
+    target_time = 1750000000.0
+    os.utime(p, (target_time, target_time))
+    st = os.stat(p)
+    assert abs(st.st_mtime - target_time) < 2
+
+
+def test_stat_type_file(test_dir):
+    p = os.path.join(test_dir, "reg")
+    open(p, "w").close()
+    assert stat.S_ISREG(os.stat(p).st_mode)
+
+
+def test_stat_type_dir(test_dir):
+    d = os.path.join(test_dir, "dir")
+    os.mkdir(d)
+    assert stat.S_ISDIR(os.stat(d).st_mode)
+
+
+def test_unlink(test_dir):
+    p = os.path.join(test_dir, "ul")
+    open(p, "w").close()
+    assert os.path.exists(p)
+    os.unlink(p)
+    assert not os.path.exists(p)

--- a/test/e2e/posix/test_rename.py
+++ b/test/e2e/posix/test_rename.py
@@ -1,0 +1,78 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for rename operations."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_rename_same_dir(test_dir):
+    """Rename within the same directory moves content correctly."""
+    old = os.path.join(test_dir, "old.txt")
+    new = os.path.join(test_dir, "new.txt")
+
+    with open(old, "w") as f:
+        f.write("rename me")
+
+    os.rename(old, new)
+
+    assert os.path.exists(new)
+    assert not os.path.exists(old)
+
+    with open(new, "r") as f:
+        assert f.read() == "rename me"
+
+
+@pytest.mark.smoke
+def test_rename_cross_dir(test_dir):
+    """Rename across directories moves the file correctly."""
+    dir1 = os.path.join(test_dir, "dir1")
+    dir2 = os.path.join(test_dir, "dir2")
+    os.makedirs(dir1)
+    os.makedirs(dir2)
+
+    src = os.path.join(dir1, "file.txt")
+    dst = os.path.join(dir2, "file.txt")
+
+    with open(src, "w") as f:
+        f.write("cross dir")
+
+    os.rename(src, dst)
+
+    assert os.path.exists(dst)
+    assert not os.path.exists(src)
+
+    with open(dst, "r") as f:
+        assert f.read() == "cross dir"
+
+
+@pytest.mark.smoke
+def test_rename_directory(test_dir):
+    """Rename a directory moves all its contents."""
+    d1 = os.path.join(test_dir, "d1")
+    d2 = os.path.join(test_dir, "d2")
+    os.makedirs(d1)
+
+    # Create a file inside d1
+    child = os.path.join(d1, "f.txt")
+    with open(child, "w") as f:
+        f.write("inside")
+
+    os.rename(d1, d2)
+
+    assert os.path.exists(os.path.join(d2, "f.txt"))
+    assert not os.path.exists(d1)

--- a/test/e2e/posix/test_truncate.py
+++ b/test/e2e/posix/test_truncate.py
@@ -1,0 +1,100 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for truncate consistency."""
+
+import hashlib
+import os
+
+import pytest
+
+_1MB = 1 * 1024 * 1024
+_5MB = 5 * 1024 * 1024
+_10MB = 10 * 1024 * 1024
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+@pytest.mark.standard
+def test_truncate_shrink_preserves_head(test_dir):
+    """Truncate to smaller size preserves the head portion."""
+    path = os.path.join(test_dir, "shrink.bin")
+
+    data = os.urandom(_10MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    expected_md5 = md5(data[:_5MB])
+
+    os.truncate(path, _5MB)
+
+    with open(path, "rb") as f:
+        head = f.read()
+
+    assert len(head) == _5MB
+    assert md5(head) == expected_md5
+
+
+@pytest.mark.standard
+def test_truncate_grow_fills_zero(test_dir):
+    """Truncate to larger size fills the extension with zeros."""
+    path = os.path.join(test_dir, "grow.bin")
+
+    with open(path, "wb") as f:
+        f.write(os.urandom(_5MB))
+
+    os.truncate(path, _10MB)
+
+    with open(path, "rb") as f:
+        f.seek(_5MB)
+        tail = f.read()
+
+    assert len(tail) == _5MB
+    assert tail == b"\x00" * _5MB
+
+
+@pytest.mark.standard
+def test_truncate_grow_head_unchanged(test_dir):
+    """Truncate to larger size does not alter the original head."""
+    path = os.path.join(test_dir, "grow_head.bin")
+
+    data = os.urandom(_5MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    expected_md5 = md5(data)
+
+    os.truncate(path, _10MB)
+
+    with open(path, "rb") as f:
+        head = f.read(_5MB)
+
+    assert md5(head) == expected_md5
+
+
+@pytest.mark.standard
+def test_truncate_to_zero(test_dir):
+    """Truncate to zero results in an empty file."""
+    path = os.path.join(test_dir, "zero.bin")
+
+    with open(path, "wb") as f:
+        f.write(os.urandom(_1MB))
+
+    os.truncate(path, 0)
+
+    assert os.path.getsize(path) == 0
+
+

--- a/test/e2e/posix/test_xattr.py
+++ b/test/e2e/posix/test_xattr.py
@@ -1,0 +1,86 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for extended attribute (xattr) operations."""
+
+import os
+
+import pytest
+
+
+def _check_xattr_support(path):
+    """Try a trivial xattr operation; skip if not supported."""
+    try:
+        os.setxattr(path, b"user.test_probe", b"1")
+        os.removexattr(path, b"user.test_probe")
+    except OSError:
+        pytest.skip("xattr not supported")
+
+
+@pytest.mark.standard
+def test_setxattr_getxattr(test_dir):
+    """Set an xattr and read it back."""
+    path = os.path.join(test_dir, "file.txt")
+    with open(path, "w") as f:
+        f.write("")
+
+    _check_xattr_support(path)
+
+    os.setxattr(path, b"user.key1", b"value1")
+    assert os.getxattr(path, b"user.key1") == b"value1"
+
+
+@pytest.mark.standard
+def test_listxattr(test_dir):
+    """List xattrs returns all set attributes."""
+    path = os.path.join(test_dir, "file.txt")
+    with open(path, "w") as f:
+        f.write("")
+
+    _check_xattr_support(path)
+
+    os.setxattr(path, b"user.k1", b"v1")
+    os.setxattr(path, b"user.k2", b"v2")
+
+    attrs = os.listxattr(path)
+    assert "user.k1" in attrs
+    assert "user.k2" in attrs
+
+
+@pytest.mark.standard
+def test_removexattr(test_dir):
+    """Remove an xattr so that get raises OSError."""
+    path = os.path.join(test_dir, "file.txt")
+    with open(path, "w") as f:
+        f.write("")
+
+    _check_xattr_support(path)
+
+    os.setxattr(path, b"user.gone", b"bye")
+    os.removexattr(path, b"user.gone")
+
+    with pytest.raises(OSError):
+        os.getxattr(path, b"user.gone")
+
+
+@pytest.mark.standard
+def test_xattr_on_directory(test_dir):
+    """Xattr operations work on directories."""
+    d = os.path.join(test_dir, "subdir")
+    os.makedirs(d)
+
+    _check_xattr_support(d)
+
+    os.setxattr(d, b"user.dirattr", b"dirvalue")
+    assert os.getxattr(d, b"user.dirattr") == b"dirvalue"

--- a/test/e2e/pyproject.toml
+++ b/test/e2e/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "dingofs-e2e"
+version = "0.1.0"
+description = "DingoFS end-to-end tests (black-box, FUSE mountpoint based)"
+requires-python = ">=3.10"
+dependencies = [
+    "pytest>=7.0",
+]

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = posix regression specific
+markers =
+    smoke: quick smoke tests (< 2 min)
+    standard: standard integration tests (< 10 min)
+addopts = -v --tb=short

--- a/test/e2e/regression/test_regression_concurrent_flush.py
+++ b/test/e2e/regression/test_regression_concurrent_flush.py
@@ -1,0 +1,140 @@
+# Copyright 2024 DingoFS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+
+"""Regression tests for concurrent write+flush correctness.
+
+Bug: When write and flush happen concurrently, the single mutex in
+ChunkWriter caused slice ordering/commit sequence errors, leading to
+data corruption.
+
+Fix: commit e2fe490db — Split writer_mutex_ (for write batching) from
+write_flush_mutex_ (for slice write + flush ordering). Write batch is
+sorted while holding writer_mutex_, then slice writes happen under
+write_flush_mutex_ to prevent interleaving with flush.
+
+Verification:
+  buggy binary (pre e2fe490db):  test_concurrent_write_and_fsync should FAIL (data corruption)
+  fixed binary (post e2fe490db): all tests PASS
+  works on: local mode + MDS mode (ChunkWriter shared)
+"""
+import os, hashlib, threading, pytest
+
+pytestmark = pytest.mark.standard
+
+def md5(data): return hashlib.md5(data).hexdigest()
+
+def test_concurrent_write_and_fsync(test_dir):
+    """Multiple threads: some write, some fsync, verify final data."""
+    path = os.path.join(test_dir, "concurrent_flush")
+    total_size = 4 * 1024 * 1024  # 4MB
+    chunk_size = 64 * 1024  # 64KB per write
+    num_chunks = total_size // chunk_size
+
+    # Pre-generate ordered data
+    chunks = [os.urandom(chunk_size) for _ in range(num_chunks)]
+    expected = b"".join(chunks)
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    errors = []
+
+    write_idx = [0]
+    lock = threading.Lock()
+
+    def writer():
+        while True:
+            with lock:
+                idx = write_idx[0]
+                if idx >= num_chunks:
+                    return
+                write_idx[0] += 1
+            try:
+                os.pwrite(fd, chunks[idx], idx * chunk_size)
+            except Exception as e:
+                errors.append(e)
+
+    def fsyncer():
+        """Periodically fsync while writes are in progress."""
+        import time
+        for _ in range(20):
+            try:
+                os.fsync(fd)
+            except Exception as e:
+                errors.append(e)
+            time.sleep(0.01)
+
+    threads = [threading.Thread(target=writer) for _ in range(4)]
+    threads.append(threading.Thread(target=fsyncer))
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    os.fsync(fd)  # final sync
+    os.close(fd)
+
+    assert not errors, f"Errors during concurrent write/flush: {errors}"
+
+    with open(path, "rb") as f:
+        actual = f.read()
+
+    assert len(actual) == total_size
+    assert md5(actual) == md5(expected), "Data corrupted after concurrent write+flush"
+
+def test_sequential_write_with_interleaved_flush(test_dir):
+    """Write sequentially but fsync after every N writes."""
+    path = os.path.join(test_dir, "seq_flush")
+    chunk_size = 128 * 1024
+    num_chunks = 32
+    flush_interval = 4
+
+    data_parts = [os.urandom(chunk_size) for _ in range(num_chunks)]
+
+    with open(path, "wb") as f:
+        for i, part in enumerate(data_parts):
+            f.write(part)
+            if (i + 1) % flush_interval == 0:
+                os.fsync(f.fileno())
+
+    expected = b"".join(data_parts)
+
+    with open(path, "rb") as f:
+        actual = f.read()
+
+    assert md5(actual) == md5(expected)
+
+def test_overwrite_same_region_concurrent(test_dir):
+    """Multiple threads overwrite the same region, last writer wins,
+    but final content must be valid (one of the written values, not garbage)."""
+    path = os.path.join(test_dir, "overwrite_region")
+    size = 1024 * 1024  # 1MB region
+
+    # Create initial file
+    initial = b"\x00" * size
+    with open(path, "wb") as f:
+        f.write(initial)
+
+    # Each thread writes a distinct byte pattern
+    patterns = [bytes([i]) * size for i in range(4)]
+    threads = []
+
+    def overwriter(pattern):
+        fd = os.open(path, os.O_WRONLY)
+        os.pwrite(fd, pattern, 0)
+        os.fsync(fd)
+        os.close(fd)
+
+    for p in patterns:
+        t = threading.Thread(target=overwriter, args=(p,))
+        threads.append(t)
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    with open(path, "rb") as f:
+        actual = f.read(size)
+
+    # The content should be exactly one of the patterns (not a mix)
+    assert actual in patterns, "Data is garbage mix of concurrent overwrites"

--- a/test/e2e/regression/test_regression_fallocate_basic.py
+++ b/test/e2e/regression/test_regression_fallocate_basic.py
@@ -1,0 +1,205 @@
+# Copyright 2026 DingoDB. All rights reserved.
+
+"""Basic fallocate(2) semantics: mode=0 / KEEP_SIZE / PUNCH_HOLE.
+
+Bug:
+  Several scenarios in dingofs MDS mode mis-handled fallocate edge cases:
+    - mode=0 on a 0-byte / chunk-aligned file returned EIO because PreAlloc
+      propagated GetChunk's ENOT_FOUND verbatim.
+    - PUNCH_HOLE / ZERO_RANGE failed with "beyond slice num(0)" because the
+      filesystem dispatcher did not pre-allocate slice IDs for those modes.
+
+Verification:
+  pre fix:  test_fallocate_basic / test_fallocate_extend_from_chunk_boundary
+            FAIL with EIO on MDS; test_fallocate_punch_hole / KEEP_SIZE pass.
+  post fix: all tests PASS on MDS / Local / Memory.
+
+Cross-PR refs in individual test docstrings (e.g. PR #882) — see those for
+per-case context. See also test_regression_fallocate_modes.py for the
+PUNCH_HOLE / ZERO_RANGE mode-coverage cases keyed to PR #880.
+"""
+
+import os
+import errno
+import ctypes
+import ctypes.util
+import hashlib
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+MB = 1024 * 1024
+
+libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+FALLOC_FL_KEEP_SIZE = 0x01
+FALLOC_FL_PUNCH_HOLE = 0x02
+
+
+def fallocate(fd, mode, offset, length):
+    ret = libc.fallocate(fd, mode, ctypes.c_long(offset), ctypes.c_long(length))
+    if ret != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def _try_fallocate(fd, mode, offset, length):
+    """Call fallocate; skip test if ENOTSUP/EOPNOTSUPP."""
+    try:
+        fallocate(fd, mode, offset, length)
+    except OSError as e:
+        if e.errno in (errno.ENOTSUP, errno.EOPNOTSUPP):
+            pytest.skip(f"fallocate not supported (errno={e.errno})")
+        raise
+
+
+def test_fallocate_basic(test_dir):
+    """fallocate(0, 0, 10MB) should set file size to 10MB."""
+    path = os.path.join(test_dir, "fa_basic")
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY)
+    try:
+        _try_fallocate(fd, 0, 0, 10 * MB)
+    finally:
+        os.close(fd)
+
+    assert os.path.getsize(path) == 10 * MB
+
+
+def test_fallocate_extend(test_dir):
+    """Extend from 10MB to 20MB via fallocate."""
+    path = os.path.join(test_dir, "fa_extend")
+    # Create 10MB file
+    with open(path, "wb") as f:
+        f.write(os.urandom(10 * MB))
+    assert os.path.getsize(path) == 10 * MB
+
+    fd = os.open(path, os.O_WRONLY)
+    try:
+        _try_fallocate(fd, 0, 10 * MB, 10 * MB)
+    finally:
+        os.close(fd)
+
+    assert os.path.getsize(path) == 20 * MB
+
+
+def test_fallocate_keep_size(test_dir):
+    """fallocate with KEEP_SIZE should not change file size."""
+    path = os.path.join(test_dir, "fa_keepsize")
+    with open(path, "wb") as f:
+        f.write(os.urandom(20 * MB))
+    assert os.path.getsize(path) == 20 * MB
+
+    fd = os.open(path, os.O_WRONLY)
+    try:
+        _try_fallocate(fd, FALLOC_FL_KEEP_SIZE, 20 * MB, 10 * MB)
+    finally:
+        os.close(fd)
+
+    assert os.path.getsize(path) == 20 * MB
+
+
+def test_fallocate_punch_hole(test_dir):
+    """Punch a 3MB hole at 5MB; reading [6MB, 7MB) should return all zeros."""
+    path = os.path.join(test_dir, "fa_punch")
+    data = os.urandom(10 * MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    fd = os.open(path, os.O_WRONLY)
+    try:
+        _try_fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                        5 * MB, 3 * MB)
+    finally:
+        os.close(fd)
+
+    # Read the punched region [6MB, 7MB)
+    with open(path, "rb") as f:
+        f.seek(6 * MB)
+        chunk = f.read(1 * MB)
+
+    assert chunk == b"\x00" * (1 * MB), "punched region should be all zeros"
+
+
+def test_fallocate_extend_from_chunk_boundary(test_dir):
+    """fallocate(mode=0) starting exactly at chunk boundary (64MB) must succeed.
+
+    Bug:
+      When length is chunk-aligned, length/chunk_size points at a chunk index
+      that hasn't been written yet — GetChunk returns ENOT_FOUND in PreAlloc.
+      Pre-fix this propagated to the client as EIO.
+
+    Verification:
+      pre fix:  fallocate(mode=0, 64MB, 36MB) on a 64MB file → OSError EIO.
+      post fix: extends file to 100MB and returns 0.
+
+    Regression for PR #882: PreAlloc treats GetChunk's ENOT_FOUND as "no
+    existing chunk to append to" and routes through the create-new-chunk
+    branch (which properly initializes chunk_size / block_size).
+    """
+    path = os.path.join(test_dir, "fa_chunk_aligned")
+    chunk_size = 64 * MB
+
+    # Build a file that ends exactly at the chunk boundary
+    with open(path, "wb") as f:
+        f.write(b"x" * chunk_size)
+    assert os.path.getsize(path) == chunk_size
+
+    fd = os.open(path, os.O_WRONLY)
+    try:
+        _try_fallocate(fd, 0, chunk_size, 36 * MB)
+    finally:
+        os.close(fd)
+
+    assert os.path.getsize(path) == chunk_size + 36 * MB
+
+
+def test_fallocate_extend_across_chunk_boundary(test_dir):
+    """fallocate(mode=0) starting mid-chunk and crossing into a new chunk.
+
+    Bug / sanity:
+      Exercises the loop branch where the first iteration appends a zero slice
+      to the existing tail chunk (else branch) and subsequent iterations
+      create a fresh chunk in the next index (if branch).
+
+    Verification:
+      pre fix:  this specific code path was not broken pre-fix; the test
+                serves as a sanity check that the post-fix state machine
+                (max_chunk_exists reset after the else branch) still handles
+                the else→if transition correctly.
+      post fix: file extends to 2*chunk_size + 2MB.
+
+    Regression for PR #882: ensures the post-fix max_chunk_exists state
+    machine doesn't accidentally regress this multi-chunk transition.
+    """
+    path = os.path.join(test_dir, "fa_cross_boundary")
+    chunk_size = 64 * MB
+
+    # File ends mid-chunk-1 at 65 MB
+    with open(path, "wb") as f:
+        f.write(b"y" * (chunk_size + MB))
+    assert os.path.getsize(path) == chunk_size + MB
+
+    # Extend by 65 MB — crosses into chunk 2 (last 2 MB land in chunk 2)
+    fd = os.open(path, os.O_WRONLY)
+    try:
+        _try_fallocate(fd, 0, chunk_size + MB, 65 * MB)
+    finally:
+        os.close(fd)
+
+    assert os.path.getsize(path) == 2 * chunk_size + 2 * MB
+
+
+def test_fallocate_not_supported_skip(test_dir):
+    """If fallocate returns ENOTSUP, the test should be skipped."""
+    path = os.path.join(test_dir, "fa_notsup")
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY)
+    try:
+        _try_fallocate(fd, 0, 0, 1 * MB)
+    finally:
+        os.close(fd)
+    # If we get here, fallocate is supported -- that is fine, test passes.

--- a/test/e2e/regression/test_regression_fallocate_modes.py
+++ b/test/e2e/regression/test_regression_fallocate_modes.py
@@ -1,0 +1,146 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end regression for fallocate(2) on dingofs.
+
+Bug:
+  - MDS mode: fallocate(2) non-functional — MDSMetaSystem missing
+    Fallocate override → base class returned NotSupport → libfuse
+    cached EOPNOTSUPP for subsequent calls; even after wiring the
+    override, plain `mode=0` did not extend file length, PUNCH_HOLE
+    and ZERO_RANGE+KEEP_SIZE failed with "beyond slice num(0)", and
+    successfully-zeroed ranges still read back as the original bytes
+    because the server's chunk_cache rejected same-version updates.
+  - Local / Memory modes: kSupported mask omitted FALLOC_FL_ZERO_RANGE
+    (0x10) → syscall returned ENOTSUP.
+
+Fix: PR #880 (3 commits)
+  - [fix][mds]    Support fallocate(2) end-to-end on MDS mode
+                  (MDSMetaSystem::Fallocate override + cache invalidation;
+                   PreAlloc.set_length; slice_id pre-alloc for PUNCH_HOLE /
+                   ZERO_RANGE; chunk.version() bump on slice append)
+  - [feat][client] Local mode: support FALLOC_FL_ZERO_RANGE
+  - [feat][client] Memory mode: support FALLOC_FL_ZERO_RANGE + gflag-ify FsInfo
+
+Verification:
+  pre PR #880  on MDS:    plain_extend fails (size unchanged) — or earlier,
+                          all 4 fail with EOPNOTSUPP at the syscall.
+  pre PR #880  on Local:  zero_range fails with ENOTSUP (mask reject).
+  pre PR #880  on Memory: zero_range fails with ENOTSUP (mask reject).
+  post PR #880 all modes: 4/4 PASS.
+  works on: MDS / Local / Memory.
+"""
+
+import ctypes
+import os
+import subprocess
+
+import pytest
+
+
+_1MB = 1 * 1024 * 1024
+
+
+# linux/falloc.h constants
+FALLOC_FL_KEEP_SIZE = 0x01
+FALLOC_FL_PUNCH_HOLE = 0x02
+FALLOC_FL_ZERO_RANGE = 0x10
+
+
+def _libc_fallocate(fd, mode, offset, length):
+    """Direct libc fallocate() call (Python stdlib lacks PUNCH_HOLE/ZERO_RANGE)."""
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    libc.fallocate.argtypes = [
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_long,
+        ctypes.c_long,
+    ]
+    libc.fallocate.restype = ctypes.c_int
+    rc = libc.fallocate(fd, mode, offset, length)
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+
+
+@pytest.mark.smoke
+def test_fallocate_plain_extends_file(test_dir):
+    """fallocate(mode=0) must extend file size to offset+len."""
+    path = os.path.join(test_dir, "extend.bin")
+    with open(path, "wb") as f:
+        f.write(b"x" * _1MB)  # 1 MB initial
+
+    with open(path, "r+b") as f:
+        _libc_fallocate(f.fileno(), 0, 0, 4 * _1MB)  # extend to 4 MB
+
+    sz = os.path.getsize(path)
+    assert sz == 4 * _1MB, f"plain fallocate did not extend: size={sz}"
+
+
+@pytest.mark.smoke
+def test_fallocate_punch_hole_zeros_range(test_dir):
+    """fallocate(PUNCH_HOLE | KEEP_SIZE) must zero [offset, offset+len) and preserve file size."""
+    path = os.path.join(test_dir, "punch.bin")
+    data = b"A" * (8 * _1MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    with open(path, "r+b") as f:
+        _libc_fallocate(
+            f.fileno(),
+            FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+            2 * _1MB,  # offset
+            2 * _1MB,  # len
+        )
+        f.seek(2 * _1MB)
+        punched = f.read(2 * _1MB)
+
+    assert punched == b"\x00" * (2 * _1MB), (
+        f"punched range not zero, first 16 bytes: {punched[:16].hex()}"
+    )
+    # KEEP_SIZE: file size must not change
+    assert os.path.getsize(path) == 8 * _1MB
+
+
+@pytest.mark.smoke
+def test_fallocate_zero_range_zeros_range(test_dir):
+    """fallocate(ZERO_RANGE) must zero [offset, offset+len)."""
+    path = os.path.join(test_dir, "zero.bin")
+    with open(path, "wb") as f:
+        f.write(b"B" * (8 * _1MB))
+
+    with open(path, "r+b") as f:
+        _libc_fallocate(f.fileno(), FALLOC_FL_ZERO_RANGE, 2 * _1MB, 2 * _1MB)
+        f.seek(2 * _1MB)
+        zeroed = f.read(2 * _1MB)
+
+    assert zeroed == b"\x00" * (2 * _1MB)
+    assert os.path.getsize(path) == 8 * _1MB
+
+
+@pytest.mark.smoke
+def test_fallocate_cli_extend_via_subprocess(test_dir):
+    """fallocate(1) CLI tool wraps the syscall — end-to-end UX check."""
+    path = os.path.join(test_dir, "cli.bin")
+    subprocess.check_call([
+        "dd",
+        "if=/dev/zero",
+        f"of={path}",
+        "bs=1M",
+        "count=1",
+        "status=none",
+    ])
+    rc = subprocess.call(["fallocate", "-l", "8M", path])
+    assert rc == 0, "fallocate -l 8M CLI failed"
+    assert os.path.getsize(path) == 8 * _1MB

--- a/test/e2e/regression/test_regression_hardlink_multi_fd.py
+++ b/test/e2e/regression/test_regression_hardlink_multi_fd.py
@@ -1,0 +1,136 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for multi-fd consistency via hardlinks.
+
+Bug:
+  Hardlinks create multiple paths pointing to the same inode. Writing
+  through one path and reading through the hardlink exercises the
+  cross-fd flush + invalidate paths with DIFFERENT fds on the SAME inode
+  — pre-fix the relevant ByIno helpers only operated on the current fd's
+  handle, missing the sibling fds.
+
+Fix: commit 645895eb8 — FlushByIno / InvalidateByIno iterate all handles
+for a given inode, not just the current fd's handle.
+
+Verification:
+  pre fix  (pre 645895eb8):  test_write_link_a_read_link_b FAILs
+  post fix (post 645895eb8): all tests PASS
+  works on: Local + MDS
+"""
+
+import hashlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_write_link_a_read_link_b(test_dir):
+    """Write through path-A, read through hardlink path-B (same inode)."""
+    path_a = os.path.join(test_dir, "original")
+    path_b = os.path.join(test_dir, "hardlink")
+
+    # Create file and hardlink
+    open(path_a, "w").close()
+    os.link(path_a, path_b)
+
+    data = os.urandom(1024 * 1024)
+
+    # Write through path_a
+    with open(path_a, "wb") as f:
+        f.write(data)
+
+    # Read through path_b (hardlink, same inode)
+    with open(path_b, "rb") as f:
+        result = f.read()
+
+    assert md5(result) == md5(data), "hardlink read didn't see write through original"
+
+
+def test_write_link_b_read_link_a(test_dir):
+    """Write through hardlink path-B, read through original path-A."""
+    path_a = os.path.join(test_dir, "orig2")
+    path_b = os.path.join(test_dir, "link2")
+
+    open(path_a, "w").close()
+    os.link(path_a, path_b)
+
+    data = os.urandom(512 * 1024)
+
+    with open(path_b, "wb") as f:
+        f.write(data)
+
+    with open(path_a, "rb") as f:
+        result = f.read()
+
+    assert md5(result) == md5(data), "original read didn't see write through hardlink"
+
+
+def test_concurrent_fd_via_hardlinks(test_dir):
+    """Open both paths simultaneously, write through one, read through other."""
+    path_a = os.path.join(test_dir, "sim_a")
+    path_b = os.path.join(test_dir, "sim_b")
+
+    open(path_a, "w").close()
+    os.link(path_a, path_b)
+
+    fd_w = os.open(path_a, os.O_WRONLY | os.O_TRUNC)
+    fd_r = os.open(path_b, os.O_RDONLY)
+
+    data = os.urandom(256 * 1024)
+    os.write(fd_w, data)
+    os.fsync(fd_w)
+
+    result = b""
+    while True:
+        chunk = os.read(fd_r, 65536)
+        if not chunk:
+            break
+        result += chunk
+
+    os.close(fd_w)
+    os.close(fd_r)
+
+    assert md5(result) == md5(data), "concurrent fd via hardlinks: read mismatch"
+
+
+def test_overwrite_via_hardlink(test_dir):
+    """O_TRUNC through hardlink should truncate the shared inode."""
+    path_a = os.path.join(test_dir, "ow_a")
+    path_b = os.path.join(test_dir, "ow_b")
+
+    # Write 4KB through path_a
+    with open(path_a, "wb") as f:
+        f.write(os.urandom(4096))
+    os.link(path_a, path_b)
+
+    # O_TRUNC through path_b, write 10 bytes
+    new_data = b"hardlink_ow"
+    with open(path_b, "wb") as f:
+        f.write(new_data)
+
+    # Read through path_a
+    with open(path_a, "rb") as f:
+        result = f.read()
+
+    assert result == new_data, (
+        f"overwrite via hardlink: expected {len(new_data)} bytes, "
+        f"got {len(result)} bytes"
+    )

--- a/test/e2e/regression/test_regression_multi_fd.py
+++ b/test/e2e/regression/test_regression_multi_fd.py
@@ -1,0 +1,132 @@
+# Copyright 2024 DingoFS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+
+"""Regression tests for multi-fd read-after-write consistency.
+
+Bug: When multiple file descriptors are open for the same inode, writing
+through fd-A and reading through fd-B returns stale data. The flush and
+read-cache invalidation only operated on the writing fd's handle, not
+across all handles for the same inode.
+
+Fix: commit 645895eb8 — FlushByIno() and InvalidateByIno() that iterate
+all open handles for the given inode, ensuring cross-fd consistency.
+
+Verification:
+  buggy binary (pre 645895eb8):  test_write_fd_read_fd_consistency should FAIL
+  fixed binary (post 645895eb8): all tests PASS
+  works on: local mode + MDS mode (VFS layer shared)
+"""
+import os, hashlib, pytest
+
+pytestmark = pytest.mark.standard
+
+def md5(data): return hashlib.md5(data).hexdigest()
+
+def test_write_fd_read_fd_consistency(test_dir):
+    """Write through fd-W, read through fd-R on the same file.
+    fd-R must see fd-W's data without closing fd-W first."""
+    path = os.path.join(test_dir, "multi_fd")
+    data = os.urandom(1024 * 1024)  # 1MB
+
+    fd_w = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    os.write(fd_w, data)
+    os.fsync(fd_w)  # ensure data is flushed
+
+    fd_r = os.open(path, os.O_RDONLY)
+    result = b""
+    while True:
+        chunk = os.read(fd_r, 65536)
+        if not chunk:
+            break
+        result += chunk
+
+    os.close(fd_r)
+    os.close(fd_w)
+
+    assert md5(result) == md5(data), "fd-R did not see fd-W's data"
+
+def test_write_fd_read_fd_no_fsync(test_dir):
+    """Same as above but WITHOUT explicit fsync — the read path should
+    implicitly flush all writers for the inode."""
+    path = os.path.join(test_dir, "multi_fd_no_fsync")
+    data = os.urandom(512 * 1024)  # 512KB
+
+    fd_w = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    os.write(fd_w, data)
+    # NO fsync here — rely on read-side implicit flush
+
+    fd_r = os.open(path, os.O_RDONLY)
+    result = b""
+    while True:
+        chunk = os.read(fd_r, 65536)
+        if not chunk:
+            break
+        result += chunk
+
+    os.close(fd_r)
+    os.close(fd_w)
+
+    assert md5(result) == md5(data), "fd-R did not see fd-W's data (no fsync)"
+
+def test_interleaved_write_read_two_fds(test_dir):
+    """Open two rw fds, interleave writes and reads."""
+    path = os.path.join(test_dir, "interleave")
+
+    fd1 = os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o644)
+    fd2 = os.open(path, os.O_RDWR)
+
+    # fd1 writes first 1MB
+    data1 = os.urandom(1024 * 1024)
+    os.write(fd1, data1)
+    os.fsync(fd1)
+
+    # fd2 reads — should see fd1's write
+    os.lseek(fd2, 0, os.SEEK_SET)
+    read1 = os.read(fd2, 1024 * 1024)
+    assert md5(read1) == md5(data1), "fd2 didn't see fd1's write"
+
+    # fd2 appends 1MB
+    data2 = os.urandom(1024 * 1024)
+    os.lseek(fd2, 0, os.SEEK_END)
+    os.write(fd2, data2)
+    os.fsync(fd2)
+
+    # fd1 reads all — should see both writes
+    os.lseek(fd1, 0, os.SEEK_SET)
+    all_data = b""
+    while True:
+        chunk = os.read(fd1, 65536)
+        if not chunk:
+            break
+        all_data += chunk
+
+    os.close(fd1)
+    os.close(fd2)
+
+    expected = data1 + data2
+    assert md5(all_data) == md5(expected), "fd1 didn't see fd2's append"
+
+def test_multiple_readers_after_write(test_dir):
+    """One writer, multiple concurrent readers on the same file."""
+    path = os.path.join(test_dir, "multi_reader")
+    data = os.urandom(2 * 1024 * 1024)  # 2MB
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    expected = md5(data)
+
+    # Open 5 read fds simultaneously
+    fds = [os.open(path, os.O_RDONLY) for _ in range(5)]
+
+    for fd in fds:
+        buf = b""
+        while True:
+            chunk = os.read(fd, 65536)
+            if not chunk:
+                break
+            buf += chunk
+        assert md5(buf) == expected, f"reader fd {fd} got wrong data"
+
+    for fd in fds:
+        os.close(fd)

--- a/test/e2e/regression/test_regression_overwrite_otrunc.py
+++ b/test/e2e/regression/test_regression_overwrite_otrunc.py
@@ -1,0 +1,95 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for O_TRUNC overwrite race condition.
+
+Bug: When close(fd1) and open(fd2, O_TRUNC) race, fd2 inherits fd1's
+chunk_set with a stale last_write_length_. fd2's write computes
+max(stale_len, new_len) and FlushFile sends the stale (larger) length
+to MDS, making the file appear bigger than it should be.
+
+Example: write 4 bytes → close → open(O_TRUNC) → write 2 bytes → close
+         → read returns b'BB\\x00\\x00' (4 bytes) instead of b'BB' (2 bytes)
+
+Root cause: MDSMetaSystem::Open did not call chunk_set->ResetLastWriteLength()
+on O_TRUNC. The shared file_session/chunk_set retained the old value.
+
+Fix: commit e5cf76916 — add chunk_set->ResetLastWriteLength() in the O_TRUNC
+branch of MDSMetaSystem::DoOpen.
+
+Verification:
+  buggy binary:  test_overwrite_basic should FAIL ~30% on MDS mode
+  fixed binary:  all tests PASS
+  works on: MDS mode (race window depends on RPC latency; local mode rarely triggers)
+"""
+
+import hashlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+def test_overwrite_basic(test_dir):
+    """Write 4 bytes, O_TRUNC overwrite with 2 bytes, read must be 2 bytes."""
+    p = os.path.join(test_dir, "ow")
+    with open(p, "wb") as f:
+        f.write(b"AAAA")
+    with open(p, "wb") as f:
+        f.write(b"BB")
+    with open(p, "rb") as f:
+        assert f.read() == b"BB"
+
+def test_overwrite_repeated(test_dir):
+    """Repeat overwrite 20 times — must never see stale length."""
+    p = os.path.join(test_dir, "ow_repeat")
+    for i in range(20):
+        long_data = os.urandom(1024)
+        short_data = os.urandom(7)
+        with open(p, "wb") as f:
+            f.write(long_data)
+        with open(p, "wb") as f:
+            f.write(short_data)
+        with open(p, "rb") as f:
+            result = f.read()
+        assert result == short_data, (
+            f"iteration {i}: expected {len(short_data)} bytes, "
+            f"got {len(result)} bytes"
+        )
+
+def test_overwrite_large_to_small(test_dir):
+    """Overwrite 1MB file with 1 byte — size must be 1."""
+    p = os.path.join(test_dir, "ow_large")
+    with open(p, "wb") as f:
+        f.write(os.urandom(1024 * 1024))
+    with open(p, "wb") as f:
+        f.write(b"X")
+    with open(p, "rb") as f:
+        data = f.read()
+    assert data == b"X"
+    assert os.path.getsize(p) == 1
+
+def test_overwrite_md5_consistency(test_dir):
+    """Overwrite and verify md5 matches the new content exactly."""
+    p = os.path.join(test_dir, "ow_md5")
+    with open(p, "wb") as f:
+        f.write(os.urandom(4096))
+    new_data = os.urandom(100)
+    with open(p, "wb") as f:
+        f.write(new_data)
+    with open(p, "rb") as f:
+        assert md5(f.read()) == md5(new_data)

--- a/test/e2e/regression/test_regression_read_correctness.py
+++ b/test/e2e/regression/test_regression_read_correctness.py
@@ -1,0 +1,98 @@
+# Copyright 2024 DingoFS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+
+"""Regression tests for read data correctness.
+
+Bug: fuse_reply_data() with fuse_bufvec + FUSE_BUF_SPLICE_MOVE caused
+data loss or corruption on reads. The bufvec-to-splice path had issues
+with certain iovec layouts.
+
+Fix: commit d4460570f — Switch from fuse_reply_data(bufvec, SPLICE_MOVE)
+to fuse_reply_iov(iovec) for direct iovec-based replies. Also added
+file_offset and fake (hole) fields to BlockReadReq for better tracking.
+
+Verification:
+  buggy binary (pre d4460570f):  test_read_in_small_chunks / test_pread_various_offsets should FAIL
+  fixed binary (post d4460570f): all tests PASS
+  works on: local mode + MDS mode (FUSE reply path shared)
+"""
+import os, hashlib, pytest
+
+pytestmark = pytest.mark.standard
+
+def md5(data): return hashlib.md5(data).hexdigest()
+
+def test_read_exact_size(test_dir):
+    """Write N bytes, read exactly N bytes, md5 must match."""
+    for size in [1, 511, 4096, 4097, 65536, 65537, 1024*1024]:
+        path = os.path.join(test_dir, f"exact_{size}")
+        data = os.urandom(size)
+        with open(path, "wb") as f:
+            f.write(data)
+        with open(path, "rb") as f:
+            actual = f.read()
+        assert md5(actual) == md5(data), f"md5 mismatch for size {size}"
+
+def test_read_in_small_chunks(test_dir):
+    """Write 1MB, read back in tiny chunks (1 byte, 7 bytes, 4K, etc.)."""
+    path = os.path.join(test_dir, "small_chunks")
+    data = os.urandom(1024 * 1024)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    chunk_sizes = [1, 7, 13, 4096, 4097, 65536]
+    for cs in chunk_sizes:
+        with open(path, "rb") as f:
+            parts = []
+            while True:
+                part = f.read(cs)
+                if not part:
+                    break
+                parts.append(part)
+            actual = b"".join(parts)
+        assert md5(actual) == md5(data), f"md5 mismatch for chunk_size={cs}"
+
+def test_pread_various_offsets(test_dir):
+    """Write 4MB, pread from various offsets and lengths."""
+    path = os.path.join(test_dir, "pread")
+    size = 4 * 1024 * 1024
+    data = os.urandom(size)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    test_cases = [
+        (0, 4096),
+        (0, size),
+        (4096, 4096),
+        (4095, 4097),       # misaligned
+        (1024*1024, 1024*1024),
+        (size - 100, 100),  # tail
+        (size - 1, 1),      # last byte
+    ]
+    fd = os.open(path, os.O_RDONLY)
+    for offset, length in test_cases:
+        actual = os.pread(fd, length, offset)
+        expected = data[offset:offset+length]
+        assert md5(actual) == md5(expected), f"pread mismatch at off={offset} len={length}"
+    os.close(fd)
+
+def test_read_after_append(test_dir):
+    """Append data then read full file — total md5 must be correct."""
+    path = os.path.join(test_dir, "append")
+    parts = [os.urandom(100 * 1024) for _ in range(10)]  # 10 x 100KB
+
+    with open(path, "wb") as f:
+        for p in parts:
+            f.write(p)
+
+    expected = b"".join(parts)
+    with open(path, "rb") as f:
+        actual = f.read()
+    assert md5(actual) == md5(expected)
+
+def test_read_empty_file(test_dir):
+    """Read from empty file returns empty bytes."""
+    path = os.path.join(test_dir, "empty")
+    open(path, "w").close()
+    with open(path, "rb") as f:
+        assert f.read() == b""

--- a/test/e2e/regression/test_regression_readahead_invalidate.py
+++ b/test/e2e/regression/test_regression_readahead_invalidate.py
@@ -1,0 +1,201 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for readahead buffer invalidation after truncate /
+fallocate on the same fd.
+
+Bug:
+  VFSImpl::SetAttr and VFSImpl::Fallocate did not invoke
+  handle_manager_->InvalidateByIno after a size / content change, so the
+  cached ReadRequest::buffer in FileReader::requests_ kept stale bytes
+  for any range that overlapped the modified region. A subsequent read
+  on the SAME fd returned the stale buffer instead of the post-truncate
+  zeros (or post-PUNCH_HOLE zeros, etc).
+
+  Test shape (all 3 cases):
+    1. Open + full read → readahead populated
+    2. truncate / fallocate on the same fd
+    3. Re-read the affected range
+    4. Assert zeros (per POSIX), not stale bytes
+
+Verification:
+  pre fix:  affected range reads back stale (originally-written) bytes.
+  post fix: affected range reads zeros.
+  works on: Local + MDS (SetAttr fix from #879; Fallocate fix from #882).
+"""
+
+import ctypes
+import hashlib
+import os
+
+import pytest
+
+_1MB = 1 * 1024 * 1024
+
+
+# fallocate flags (linux/falloc.h)
+FALLOC_FL_KEEP_SIZE = 0x01
+FALLOC_FL_PUNCH_HOLE = 0x02
+
+
+def _libc_fallocate(fd, mode, offset, length):
+    """Direct libc fallocate() call (Python stdlib lacks PUNCH_HOLE)."""
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    libc.fallocate.argtypes = [
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_long,
+        ctypes.c_long,
+    ]
+    libc.fallocate.restype = ctypes.c_int
+    rc = libc.fallocate(fd, mode, offset, length)
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+
+
+def _first_nonzero(buf):
+    """Return offset of first non-zero byte, or -1 if all zero."""
+    for i, b in enumerate(buf):
+        if b != 0:
+            return i
+    return -1
+
+
+@pytest.mark.smoke
+def test_truncate_shrink_then_grow_invalidates_readahead(test_dir):
+    """Scenario A: same fd, read → ftruncate(shrink) → ftruncate(grow) → re-read.
+
+    After shrink + grow, the extended range MUST be zero. The bug exposes
+    the stale ReadRequest::buffer covering the original file content.
+    """
+    path = os.path.join(test_dir, "shrink_grow.bin")
+
+    data = os.urandom(4 * _1MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    with open(path, "r+b") as f:
+        # Step 1: full read triggers readahead, caches buffer covering [0, 4M)
+        first = f.read()
+        assert len(first) == 4 * _1MB
+        assert first == data
+
+        # Step 2: same fd, shrink to 1MB then grow back to 4MB
+        os.ftruncate(f.fileno(), 1 * _1MB)
+        os.ftruncate(f.fileno(), 4 * _1MB)
+
+        # Step 3: re-read the extended range [1M, 4M)
+        f.seek(1 * _1MB)
+        tail = f.read()
+
+    assert len(tail) == 3 * _1MB, f"unexpected read length {len(tail)}"
+    nz = _first_nonzero(tail)
+    if nz >= 0:
+        pytest.fail(
+            f"readahead invalidate bug: extended range [1M, 4M) read non-zero "
+            f"at offset +{nz} (absolute {1 * _1MB + nz}); "
+            f"expected zeros after shrink+grow. "
+            f"first 16 bytes of tail: {tail[:16].hex()}"
+        )
+
+
+@pytest.mark.smoke
+def test_fallocate_punch_hole_invalidates_readahead(test_dir):
+    """Scenario C: same fd, read → fallocate(PUNCH_HOLE) → re-read.
+
+    After punch hole, the punched range MUST read as zero. The bug exposes
+    stale ReadRequest::buffer covering that range.
+    """
+    path = os.path.join(test_dir, "punch.bin")
+
+    data = os.urandom(8 * _1MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    with open(path, "r+b") as f:
+        # Step 1: full read triggers readahead, buffer covers [0, 8M)
+        first = f.read()
+        assert len(first) == 8 * _1MB
+
+        # Step 2: same fd, punch hole [2M, 4M)
+        try:
+            _libc_fallocate(
+                f.fileno(),
+                FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                2 * _1MB,
+                2 * _1MB,
+            )
+        except OSError as e:
+            pytest.skip(f"fallocate(PUNCH_HOLE) not supported: {e}")
+
+        # Step 3: same fd, re-read the punched range
+        f.seek(2 * _1MB)
+        punched = f.read(2 * _1MB)
+
+    assert len(punched) == 2 * _1MB, f"unexpected read length {len(punched)}"
+    nz = _first_nonzero(punched)
+    if nz >= 0:
+        pytest.fail(
+            f"readahead invalidate bug: punched range [2M, 4M) read non-zero "
+            f"at offset +{nz} (absolute {2 * _1MB + nz}); "
+            f"expected zeros after PUNCH_HOLE. "
+            f"first 16 bytes of punched range: {punched[:16].hex()}"
+        )
+
+
+@pytest.mark.smoke
+def test_truncate_shrink_in_place_extends_zeros_on_pwrite(test_dir):
+    """Scenario A variant: read → ftruncate(small) → pwrite beyond → read whole.
+
+    After truncate(1M) then pwrite at offset 3M, the file becomes 3M+len.
+    The range [1M, 3M) is a hole (file shrunk past it then re-extended via
+    the implicit hole before pwrite offset) and MUST read as zero. The bug
+    keeps stale ReadRequest::buffer for [0, 4M) and surfaces non-zero data.
+    """
+    path = os.path.join(test_dir, "shrink_pwrite.bin")
+
+    data = os.urandom(4 * _1MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    marker = b"DINGOFS_MARKER_FRESH_WRITE_AFTER_TRUNCATE"
+
+    with open(path, "r+b") as f:
+        # Step 1: read triggers readahead
+        first = f.read()
+        assert len(first) == 4 * _1MB
+
+        # Step 2: shrink + pwrite beyond original length (after the shrink)
+        os.ftruncate(f.fileno(), 1 * _1MB)
+        os.pwrite(f.fileno(), marker, 3 * _1MB)
+
+        # Step 3: read hole region [1M, 3M)
+        f.seek(1 * _1MB)
+        hole = f.read(2 * _1MB)
+
+        # And the marker should be readable at [3M, 3M+len(marker))
+        f.seek(3 * _1MB)
+        readback_marker = f.read(len(marker))
+
+    assert readback_marker == marker, "pwrite marker not readable; meta bug?"
+
+    nz = _first_nonzero(hole)
+    if nz >= 0:
+        pytest.fail(
+            f"readahead invalidate bug: hole [1M, 3M) read stale non-zero at "
+            f"offset +{nz} (absolute {1 * _1MB + nz}); "
+            f"expected zeros for hole region. "
+            f"first 16 bytes of hole: {hole[:16].hex()}"
+        )

--- a/test/e2e/regression/test_regression_readdir_backward.py
+++ b/test/e2e/regression/test_regression_readdir_backward.py
@@ -1,0 +1,288 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for backward readdir (seekdir to a previous offset).
+
+Bug:
+  DirIterator::GetValue CHECK-failed (crashed) if the readdir offset went
+  backward — e.g. seekdir() to a previously-saved position via telldir().
+
+Fix: commit 7a9d0ad9c — Add SeekBackward() with last_name_memo_ that
+remembers past fetch boundaries, letting the iterator rewind and re-fetch.
+
+Verification:
+  pre fix  (pre 7a9d0ad9c):  test_seekdir_rewind / test_seekdir_after_partial
+                             crash or FAIL
+  post fix (post 7a9d0ad9c): all tests PASS
+  works on: MDS (DirIterator is MDS-specific); Local has a simpler impl
+"""
+
+import ctypes
+import ctypes.util
+import os
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+# ── libc bindings for opendir/readdir/seekdir/telldir/closedir ────────────
+
+_libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+class _Dirent(ctypes.Structure):
+    _fields_ = [
+        ("d_ino", ctypes.c_ulong),
+        ("d_off", ctypes.c_long),
+        ("d_reclen", ctypes.c_ushort),
+        ("d_type", ctypes.c_ubyte),
+        ("d_name", ctypes.c_char * 256),
+    ]
+
+_libc.opendir.argtypes = [ctypes.c_char_p]
+_libc.opendir.restype = ctypes.c_void_p
+
+_libc.readdir.argtypes = [ctypes.c_void_p]
+_libc.readdir.restype = ctypes.POINTER(_Dirent)
+
+_libc.telldir.argtypes = [ctypes.c_void_p]
+_libc.telldir.restype = ctypes.c_long
+
+_libc.seekdir.argtypes = [ctypes.c_void_p, ctypes.c_long]
+_libc.seekdir.restype = None
+
+_libc.closedir.argtypes = [ctypes.c_void_p]
+_libc.closedir.restype = ctypes.c_int
+
+def _listdir_raw(path):
+    """Read all directory entries via opendir/readdir, return list of names."""
+    dirp = _libc.opendir(path.encode())
+    if not dirp:
+        raise OSError(ctypes.get_errno(), f"opendir failed: {path}")
+    names = []
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            names.append(name)
+    _libc.closedir(dirp)
+    return sorted(names)
+
+def _readdir_with_seekdir(path, rewind_after=5):
+    """Read directory, seekdir back to start after N entries, re-read all.
+
+    Returns (first_pass_names, second_pass_names).
+    """
+    dirp = _libc.opendir(path.encode())
+    if not dirp:
+        raise OSError(ctypes.get_errno(), f"opendir failed: {path}")
+
+    # Save position at start
+    start_pos = _libc.telldir(dirp)
+
+    # First pass: read some entries
+    first_pass = []
+    count = 0
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            first_pass.append(name)
+            count += 1
+            if count >= rewind_after:
+                break
+
+    # Seekdir back to start
+    _libc.seekdir(dirp, start_pos)
+
+    # Second pass: read all from beginning
+    second_pass = []
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            second_pass.append(name)
+
+    _libc.closedir(dirp)
+    return sorted(first_pass), sorted(second_pass)
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+def test_listdir_basic(test_dir):
+    """Basic: create files, listdir returns all of them."""
+    names = {f"file_{i:03d}" for i in range(20)}
+    for n in names:
+        open(os.path.join(test_dir, n), "w").close()
+
+    listed = set(os.listdir(test_dir))
+    assert listed == names
+
+def test_listdir_large(test_dir):
+    """Large directory (200 files) — tests multi-batch readdir."""
+    names = {f"f_{i:04d}" for i in range(200)}
+    for n in names:
+        open(os.path.join(test_dir, n), "w").close()
+
+    listed = set(os.listdir(test_dir))
+    assert listed == names
+
+def test_seekdir_rewind(test_dir):
+    """seekdir(0) after partial read — re-read should return same entries.
+
+    This is the core backward readdir test. Before the fix, this would
+    crash the client (CHECK-fail in DirIterator::GetValue).
+    """
+    names = sorted(f"entry_{i:03d}" for i in range(30))
+    for n in names:
+        open(os.path.join(test_dir, n), "w").close()
+
+    first_partial, second_full = _readdir_with_seekdir(test_dir, rewind_after=10)
+
+    # First pass should have at least 10 entries
+    assert len(first_partial) >= 10
+
+    # Second pass (after seekdir back) should have ALL entries
+    assert sorted(second_full) == names
+
+def test_seekdir_after_full_read(test_dir):
+    """Read all entries, seekdir(0), read again — both passes identical."""
+    names = sorted(f"x_{i:02d}" for i in range(15))
+    for n in names:
+        open(os.path.join(test_dir, n), "w").close()
+
+    dirp = _libc.opendir(test_dir.encode())
+    assert dirp
+
+    start_pos = _libc.telldir(dirp)
+
+    # First full pass
+    pass1 = []
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            pass1.append(name)
+
+    # Rewind
+    _libc.seekdir(dirp, start_pos)
+
+    # Second full pass
+    pass2 = []
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            pass2.append(name)
+
+    _libc.closedir(dirp)
+
+    assert sorted(pass1) == names
+    assert sorted(pass2) == names
+
+def test_seekdir_multiple_rewinds(test_dir):
+    """Multiple seekdir rewinds — should not crash or lose entries."""
+    names = sorted(f"m_{i:02d}" for i in range(25))
+    for n in names:
+        open(os.path.join(test_dir, n), "w").close()
+
+    dirp = _libc.opendir(test_dir.encode())
+    assert dirp
+    start_pos = _libc.telldir(dirp)
+
+    for _ in range(5):
+        # Read a few entries
+        count = 0
+        while count < 8:
+            entry = _libc.readdir(dirp)
+            if not entry:
+                break
+            count += 1
+
+        # Rewind
+        _libc.seekdir(dirp, start_pos)
+
+    # Final full read
+    final = []
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            final.append(name)
+
+    _libc.closedir(dirp)
+
+    assert sorted(final) == names
+
+def test_telldir_seekdir_midpoint(test_dir):
+    """telldir at midpoint, read rest, seekdir back to midpoint, re-read."""
+    names = sorted(f"t_{i:03d}" for i in range(40))
+    for n in names:
+        open(os.path.join(test_dir, n), "w").close()
+
+    dirp = _libc.opendir(test_dir.encode())
+    assert dirp
+
+    # Read 20 entries, save position
+    seen_before = []
+    for _ in range(22):  # +2 for . and ..
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            seen_before.append(name)
+
+    mid_pos = _libc.telldir(dirp)
+
+    # Read rest
+    rest = []
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            rest.append(name)
+
+    # seekdir back to midpoint
+    _libc.seekdir(dirp, mid_pos)
+
+    # Re-read from midpoint
+    re_rest = []
+    while True:
+        entry = _libc.readdir(dirp)
+        if not entry:
+            break
+        name = entry.contents.d_name.decode()
+        if name not in (".", ".."):
+            re_rest.append(name)
+
+    _libc.closedir(dirp)
+
+    # rest and re_rest should contain the same entries
+    assert sorted(rest) == sorted(re_rest)
+
+    # Total should be all names
+    assert sorted(seen_before + rest) == names

--- a/test/e2e/regression/test_regression_rename_overwrite.py
+++ b/test/e2e/regression/test_regression_rename_overwrite.py
@@ -1,0 +1,142 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for rename-overwrite inode cleanup.
+
+Bug:
+  When rename(A, B) overwrites an existing file B, the MDS must atomically
+    1. Replace B's dentry with A's inode
+    2. Decrement B's nlink (delete B's inode if nlink reaches 0)
+    3. Update quota (subtract B's length)
+    4. Clean up B's chunk data if B is fully unlinked
+  Pre-fix variants of these steps leaked stale content, stale length, or
+  chunk data, surfacing as wrong-content / wrong-size / md5-mismatch reads
+  on B after the rename.
+
+Verification:
+  pre fix:  reading B after rename(A, B) returns old B content, wrong
+            size, or md5 mismatch.
+  post fix: B has exactly A's content + size; repeated rename-overwrite
+            does not accumulate stale state.
+  works on: Local + MDS
+"""
+
+import hashlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_rename_overwrite_content(test_dir):
+    """rename(A, B) where B exists: B should have A's content."""
+    a = os.path.join(test_dir, "src")
+    b = os.path.join(test_dir, "dst")
+
+    data_a = os.urandom(1024)
+    data_b = os.urandom(2048)
+
+    with open(a, "wb") as f:
+        f.write(data_a)
+    with open(b, "wb") as f:
+        f.write(data_b)
+
+    os.rename(a, b)
+
+    assert not os.path.exists(a)
+    with open(b, "rb") as f:
+        result = f.read()
+    assert result == data_a, "rename-overwrite: dst has wrong content"
+
+
+def test_rename_overwrite_size(test_dir):
+    """rename small file over large file: size should shrink."""
+    large = os.path.join(test_dir, "large")
+    small = os.path.join(test_dir, "small")
+
+    with open(large, "wb") as f:
+        f.write(os.urandom(1024 * 1024))  # 1MB
+    with open(small, "wb") as f:
+        f.write(b"tiny")  # 4 bytes
+
+    os.rename(small, large)
+
+    assert os.path.getsize(large) == 4, "rename-overwrite: size not updated"
+    with open(large, "rb") as f:
+        assert f.read() == b"tiny"
+
+
+def test_rename_overwrite_large_over_small(test_dir):
+    """rename large file over small file: size should grow."""
+    small = os.path.join(test_dir, "sm")
+    large = os.path.join(test_dir, "lg")
+
+    with open(small, "wb") as f:
+        f.write(b"x")
+    big_data = os.urandom(512 * 1024)
+    with open(large, "wb") as f:
+        f.write(big_data)
+
+    os.rename(large, small)
+
+    assert os.path.getsize(small) == len(big_data)
+    with open(small, "rb") as f:
+        assert md5(f.read()) == md5(big_data)
+
+
+def test_rename_overwrite_repeated(test_dir):
+    """Repeated rename-overwrite must not leak stale data."""
+    target = os.path.join(test_dir, "target")
+
+    # Initialize target with large data
+    with open(target, "wb") as f:
+        f.write(os.urandom(10000))
+
+    for i in range(20):
+        src = os.path.join(test_dir, f"src_{i}")
+        data = os.urandom(i + 1)  # increasingly small: 1, 2, ..., 20 bytes
+        with open(src, "wb") as f:
+            f.write(data)
+        os.rename(src, target)
+
+        with open(target, "rb") as f:
+            result = f.read()
+        assert result == data, (
+            f"iteration {i}: expected {len(data)} bytes, got {len(result)}"
+        )
+
+
+def test_rename_overwrite_md5_large(test_dir):
+    """Rename-overwrite with 10MB files, md5 verification."""
+    a = os.path.join(test_dir, "big_a")
+    b = os.path.join(test_dir, "big_b")
+
+    data_a = os.urandom(10 * 1024 * 1024)
+    data_b = os.urandom(10 * 1024 * 1024)
+
+    with open(a, "wb") as f:
+        f.write(data_a)
+    with open(b, "wb") as f:
+        f.write(data_b)
+
+    os.rename(a, b)
+
+    with open(b, "rb") as f:
+        result = f.read()
+    assert md5(result) == md5(data_a), "rename-overwrite 10MB: md5 mismatch"

--- a/test/e2e/regression/test_regression_truncate_shrink_grow.py
+++ b/test/e2e/regression/test_regression_truncate_shrink_grow.py
@@ -1,0 +1,98 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for truncate shrink-grow stale data leak.
+
+Bug: truncate to a smaller size then grow back to the original size would
+let the old data beyond the truncation point reappear instead of being
+filled with zeros. Root cause was MDSMetaSystem::SetAttr only invalidating
+chunk_memo_ but not chunk_cache_ on shrink_file, so the ReadSlice cache-hit
+path returned pre-shrink slices.
+
+Fix: commit 924688abe — add chunk_cache_.Delete(ino) alongside
+chunk_memo_.Forget(ino) in the SetAttr shrink path.
+
+Verification:
+  buggy binary (pre 924688abe):  test_truncate_shrink_grow_tail_must_be_zero should FAIL
+  fixed binary (post 924688abe): all tests PASS
+  works on: MDS mode only (LocalMetaSystem has no chunk_cache_)
+"""
+
+import hashlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+_1MB = 1024 * 1024
+_5MB = 5 * _1MB
+_10MB = 10 * _1MB
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_truncate_shrink_grow_tail_must_be_zero(test_dir):
+    """Shrink then grow: the extended region must be all zeros."""
+    path = os.path.join(test_dir, "shrink_grow.bin")
+
+    data = os.urandom(_10MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    os.truncate(path, _5MB)
+    os.truncate(path, _10MB)
+
+    with open(path, "rb") as f:
+        content = f.read()
+
+    assert len(content) == _10MB
+    assert content[_5MB:] == b"\x00" * _5MB, "stale data reappeared after shrink-grow"
+
+
+def test_truncate_shrink_grow_head_preserved(test_dir):
+    """Shrink then grow: the head portion must be unchanged."""
+    path = os.path.join(test_dir, "shrink_grow_head.bin")
+
+    data = os.urandom(_10MB)
+    with open(path, "wb") as f:
+        f.write(data)
+
+    expected_head_md5 = md5(data[:_5MB])
+
+    os.truncate(path, _5MB)
+    os.truncate(path, _10MB)
+
+    with open(path, "rb") as f:
+        head = f.read(_5MB)
+
+    assert md5(head) == expected_head_md5, "head data corrupted after shrink-grow"
+
+
+def test_truncate_to_zero_and_grow(test_dir):
+    """Truncate to 0 then grow: entire file must be zeros."""
+    path = os.path.join(test_dir, "zero_grow.bin")
+
+    with open(path, "wb") as f:
+        f.write(os.urandom(_1MB))
+
+    os.truncate(path, 0)
+    os.truncate(path, _1MB)
+
+    with open(path, "rb") as f:
+        content = f.read()
+
+    assert content == b"\x00" * _1MB, "old data leaked after truncate-to-zero then grow"

--- a/test/e2e/specific/test_chunk_boundary_write.py
+++ b/test/e2e/specific/test_chunk_boundary_write.py
@@ -1,0 +1,194 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for writes at chunk and block boundaries.
+
+DingoFS splits files into chunks (default 64MB) and blocks (default 4MB).
+A single write() call that crosses a boundary must be split internally and
+reassembled correctly on read. These boundary offsets are invisible to
+standard POSIX test suites like pjdfstest.
+
+Covers:
+  - Single write straddling the 64MB chunk boundary
+  - Single write straddling the 4MB block boundary
+  - Write starting at exact chunk/block boundary
+  - Write ending at exact chunk/block boundary
+  - Tiny write at boundary ± 1 byte
+"""
+
+import hashlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+MB = 1024 * 1024
+CHUNK_SIZE = 64 * MB   # DingoFS default
+BLOCK_SIZE = 4 * MB    # DingoFS default
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+# ── Chunk boundary (64MB) ─────────────────────────────────────────────
+
+def test_write_straddling_chunk_boundary(test_dir):
+    """Single write that starts before 64MB and ends after 64MB."""
+    path = os.path.join(test_dir, "straddle_chunk")
+    offset = CHUNK_SIZE - 4096  # 4KB before boundary
+    data = os.urandom(8192)     # crosses into next chunk
+
+    with open(path, "wb") as f:
+        f.truncate(CHUNK_SIZE + MB)
+    with open(path, "r+b") as f:
+        f.seek(offset)
+        f.write(data)
+
+    with open(path, "rb") as f:
+        f.seek(offset)
+        actual = f.read(len(data))
+    assert actual == data, "data corrupted across chunk boundary"
+
+
+def test_write_at_exact_chunk_start(test_dir):
+    """Write starting at exactly offset 64MB."""
+    path = os.path.join(test_dir, "chunk_start")
+    data = os.urandom(MB)
+
+    with open(path, "wb") as f:
+        f.truncate(CHUNK_SIZE + 2 * MB)
+    with open(path, "r+b") as f:
+        f.seek(CHUNK_SIZE)
+        f.write(data)
+
+    with open(path, "rb") as f:
+        f.seek(CHUNK_SIZE)
+        assert f.read(MB) == data
+
+
+def test_write_ending_at_chunk_boundary(test_dir):
+    """Write that ends exactly at the 64MB boundary."""
+    path = os.path.join(test_dir, "chunk_end")
+    size = 4096
+    offset = CHUNK_SIZE - size
+    data = os.urandom(size)
+
+    with open(path, "wb") as f:
+        f.truncate(CHUNK_SIZE + MB)
+    with open(path, "r+b") as f:
+        f.seek(offset)
+        f.write(data)
+
+    with open(path, "rb") as f:
+        f.seek(offset)
+        assert f.read(size) == data
+
+
+def test_chunk_boundary_plus_minus_one(test_dir):
+    """Write 1 byte at chunk_boundary-1, chunk_boundary, chunk_boundary+1."""
+    path = os.path.join(test_dir, "chunk_pm1")
+
+    with open(path, "wb") as f:
+        f.truncate(CHUNK_SIZE + MB)
+
+    offsets = [CHUNK_SIZE - 1, CHUNK_SIZE, CHUNK_SIZE + 1]
+    values = [b"\xAA", b"\xBB", b"\xCC"]
+
+    with open(path, "r+b") as f:
+        for off, val in zip(offsets, values):
+            f.seek(off)
+            f.write(val)
+
+    with open(path, "rb") as f:
+        for off, val in zip(offsets, values):
+            f.seek(off)
+            assert f.read(1) == val, f"byte at offset {off} corrupted"
+
+
+def test_large_write_spanning_two_chunks(test_dir):
+    """8MB write starting at 60MB — crosses chunk boundary, md5 verified."""
+    path = os.path.join(test_dir, "two_chunks")
+    offset = 60 * MB
+    data = os.urandom(8 * MB)
+
+    with open(path, "wb") as f:
+        f.truncate(CHUNK_SIZE + 8 * MB)
+    with open(path, "r+b") as f:
+        f.seek(offset)
+        f.write(data)
+
+    with open(path, "rb") as f:
+        f.seek(offset)
+        actual = f.read(len(data))
+    assert md5(actual) == md5(data), "md5 mismatch across chunk boundary"
+
+
+# ── Block boundary (4MB) ──────────────────────────────────────────────
+
+def test_write_straddling_block_boundary(test_dir):
+    """Single write crossing the 4MB block boundary."""
+    path = os.path.join(test_dir, "straddle_block")
+    offset = BLOCK_SIZE - 512
+    data = os.urandom(1024)
+
+    with open(path, "wb") as f:
+        f.truncate(BLOCK_SIZE + MB)
+    with open(path, "r+b") as f:
+        f.seek(offset)
+        f.write(data)
+
+    with open(path, "rb") as f:
+        f.seek(offset)
+        assert f.read(len(data)) == data
+
+
+def test_block_boundary_plus_minus_one(test_dir):
+    """Write 1 byte at block_boundary-1, block_boundary, block_boundary+1."""
+    path = os.path.join(test_dir, "block_pm1")
+
+    with open(path, "wb") as f:
+        f.truncate(BLOCK_SIZE + MB)
+
+    offsets = [BLOCK_SIZE - 1, BLOCK_SIZE, BLOCK_SIZE + 1]
+    values = [b"\x11", b"\x22", b"\x33"]
+
+    with open(path, "r+b") as f:
+        for off, val in zip(offsets, values):
+            f.seek(off)
+            f.write(val)
+
+    with open(path, "rb") as f:
+        for off, val in zip(offsets, values):
+            f.seek(off)
+            assert f.read(1) == val, f"byte at block offset {off} corrupted"
+
+
+def test_write_spanning_multiple_blocks(test_dir):
+    """Single 10MB write starting at 2MB — spans 3 blocks, md5 verified."""
+    path = os.path.join(test_dir, "multi_block")
+    offset = 2 * MB
+    data = os.urandom(10 * MB)
+
+    with open(path, "wb") as f:
+        f.truncate(16 * MB)
+    with open(path, "r+b") as f:
+        f.seek(offset)
+        f.write(data)
+
+    with open(path, "rb") as f:
+        f.seek(offset)
+        actual = f.read(len(data))
+    assert md5(actual) == md5(data), "md5 mismatch across multiple blocks"

--- a/test/e2e/specific/test_fragmented_writes.py
+++ b/test/e2e/specific/test_fragmented_writes.py
@@ -1,0 +1,137 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for heavily fragmented write patterns.
+
+DingoFS stores writes as slices within chunks. Many small pwrite() calls
+at random offsets create many slices, stressing:
+  - Slice merging / overlap resolution in ProcessReadRequest
+  - Chunk compaction trigger logic
+  - Memory usage for slice metadata
+  - Read-path performance with many slices per chunk
+
+fsx does generic random writes but doesn't verify DingoFS-specific
+slice behavior or md5 correctness after hundreds of tiny writes.
+
+Covers:
+  - Many 1-byte pwrite at random offsets within 1 chunk
+  - Many small pwrite across chunk boundaries
+  - Overwrite same region many times, final value correct
+  - Sequential 1-byte writes (worst-case slice count)
+"""
+
+import hashlib
+import os
+import random
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+MB = 1024 * 1024
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_random_1byte_pwrite_single_chunk(test_dir):
+    """200 random 1-byte pwrite within a 1MB region, verify full md5."""
+    path = os.path.join(test_dir, "frag_1b")
+    size = MB
+
+    expected = bytearray(size)
+
+    with open(path, "wb") as f:
+        f.truncate(size)
+
+    rng = random.Random(42)  # deterministic for reproducibility
+    fd = os.open(path, os.O_WRONLY)
+    for _ in range(200):
+        off = rng.randint(0, size - 1)
+        val = bytes([rng.randint(0, 255)])
+        os.pwrite(fd, val, off)
+        expected[off] = val[0]
+    os.close(fd)
+
+    with open(path, "rb") as f:
+        actual = f.read()
+    assert md5(actual) == md5(bytes(expected)), "random 1-byte pwrite md5 mismatch"
+
+
+def test_random_small_pwrite_cross_chunk(test_dir):
+    """100 random writes (1-4KB) across a 128MB file (2 chunks)."""
+    path = os.path.join(test_dir, "frag_cross")
+    size = 128 * MB
+
+    expected = bytearray(size)
+
+    with open(path, "wb") as f:
+        f.truncate(size)
+
+    rng = random.Random(123)
+    fd = os.open(path, os.O_WRONLY)
+    for _ in range(100):
+        write_size = rng.randint(1, 4096)
+        max_off = size - write_size
+        off = rng.randint(0, max_off)
+        data = bytes([rng.randint(0, 255)] * write_size)
+        os.pwrite(fd, data, off)
+        expected[off:off + write_size] = data
+    os.close(fd)
+
+    with open(path, "rb") as f:
+        actual = f.read()
+    assert md5(actual) == md5(bytes(expected)), "cross-chunk fragmented write md5 mismatch"
+
+
+def test_overwrite_same_region_many_times(test_dir):
+    """Overwrite the same 4KB region 100 times, only last value survives."""
+    path = os.path.join(test_dir, "frag_overwrite")
+    offset = 1000
+    size = 4096
+
+    with open(path, "wb") as f:
+        f.truncate(offset + size + 1000)
+
+    fd = os.open(path, os.O_WRONLY)
+    last_data = None
+    for i in range(100):
+        last_data = os.urandom(size)
+        os.pwrite(fd, last_data, offset)
+    os.close(fd)
+
+    with open(path, "rb") as f:
+        f.seek(offset)
+        actual = f.read(size)
+    assert actual == last_data, "repeated overwrite: final value wrong"
+
+
+def test_sequential_1byte_writes(test_dir):
+    """Write 10000 bytes one at a time (worst-case slice fragmentation)."""
+    path = os.path.join(test_dir, "frag_seq")
+    count = 10000
+    expected = bytearray(count)
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    for i in range(count):
+        val = bytes([i & 0xFF])
+        os.write(fd, val)
+        expected[i] = i & 0xFF
+    os.close(fd)
+
+    with open(path, "rb") as f:
+        actual = f.read()
+    assert len(actual) == count
+    assert md5(actual) == md5(bytes(expected)), "sequential 1-byte writes md5 mismatch"

--- a/test/e2e/specific/test_large_file.py
+++ b/test/e2e/specific/test_large_file.py
@@ -1,0 +1,37 @@
+# Copyright 2026 DingoDB. All rights reserved.
+
+import os
+import hashlib
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+@pytest.mark.parametrize("size", [
+    1,                    # 1B
+    1024,                 # 1KB
+    4 * 1024,             # 4KB
+    1024 * 1024,          # 1MB
+    4 * 1024 * 1024,      # 4MB
+    10 * 1024 * 1024,     # 10MB
+    64 * 1024 * 1024,     # 64MB
+    130 * 1024 * 1024,    # 130MB (cross multi chunk)
+], ids=["1B", "1KB", "4KB", "1MB", "4MB", "10MB", "64MB", "130MB"])
+def test_write_read_md5(test_dir, size):
+    """Write random data of the given size, read back and compare md5."""
+    path = os.path.join(test_dir, f"file_{size}")
+    data = os.urandom(size)
+    expected = md5(data)
+
+    with open(path, "wb") as f:
+        f.write(data)
+
+    with open(path, "rb") as f:
+        actual = md5(f.read())
+
+    assert actual == expected, f"md5 mismatch for size {size}"

--- a/test/e2e/specific/test_seek_read.py
+++ b/test/e2e/specific/test_seek_read.py
@@ -1,0 +1,64 @@
+# Copyright 2026 DingoDB. All rights reserved.
+
+import os
+import hashlib
+import uuid
+import shutil
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+# Module-scope test directory (the conftest may not provide this).
+@pytest.fixture(scope="module")
+def test_dir_module(mount_point):
+    d = os.path.join(mount_point, f"test_mod_{uuid.uuid4().hex[:8]}")
+    os.makedirs(d)
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def large_file_data():
+    """Module-level fixture: generate 130MB of random data."""
+    return os.urandom(130 * 1024 * 1024)
+
+
+@pytest.fixture(scope="module")
+def large_file(test_dir_module, large_file_data):
+    """Module-level fixture: write the 130MB file once."""
+    path = os.path.join(test_dir_module, "seekfile")
+    with open(path, "wb") as f:
+        f.write(large_file_data)
+    return path
+
+
+_SEEK_PARAMS = [
+    (0, 1), (1, 1), (63, 1), (64, 1), (65, 1),
+    (100, 1), (127, 1), (128, 1), (129, 1),
+    (0, 10), (100, 30), (50, 64),
+]
+
+
+@pytest.mark.parametrize(
+    "offset_mb,count_mb",
+    _SEEK_PARAMS,
+    ids=[f"skip{o}M_cnt{c}M" for o, c in _SEEK_PARAMS],
+)
+def test_seek_read_md5(large_file, large_file_data, offset_mb, count_mb):
+    """Seek to offset and read count bytes, compare md5 with source data."""
+    MB = 1024 * 1024
+    offset = offset_mb * MB
+    count = count_mb * MB
+
+    with open(large_file, "rb") as f:
+        f.seek(offset)
+        actual = f.read(count)
+
+    expected = large_file_data[offset:offset + count]
+    assert md5(actual) == md5(expected)

--- a/test/e2e/specific/test_sparse_chunk_boundary.py
+++ b/test/e2e/specific/test_sparse_chunk_boundary.py
@@ -1,0 +1,148 @@
+# Copyright 2026 DingoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for sparse file chunk boundary consistency.
+
+Related work: Slice-relative block index refactor (commits ccdc7eaae..924688abe)
+changed how block indices are calculated relative to slice positions instead of
+chunk-absolute positions. Sparse files with holes spanning chunk boundaries
+exercise the slice pos/len/off arithmetic at its most complex.
+
+These tests verify that:
+- Holes across chunk boundaries read as zeros
+- Data patches at chunk boundaries survive write→read round-trip
+- Mixing holes and data within the same chunk is correct
+
+DingoFS default chunk_size = 64MB, block_size = 4MB.
+
+Verification:
+  Tests should PASS on both local and MDS mode.
+  Any slice-relative arithmetic regression will cause md5 mismatch.
+"""
+
+import hashlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+MB = 1024 * 1024
+CHUNK_SIZE = 64 * MB  # DingoFS default
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_sparse_hole_across_chunk_boundary(test_dir):
+    """Truncate to 128MB (2 chunks), write only at offset 0 and 65MB.
+    Region [1MB, 65MB) should be all zeros (hole spanning chunk boundary)."""
+    path = os.path.join(test_dir, "sparse_boundary")
+    total = 128 * MB
+
+    patch1 = os.urandom(1 * MB)  # [0, 1MB)
+    patch2 = os.urandom(1 * MB)  # [65MB, 66MB) — in chunk 1
+
+    # Build expected content
+    expected = bytearray(total)
+    expected[0:1 * MB] = patch1
+    expected[65 * MB:66 * MB] = patch2
+
+    # Write sparse file
+    with open(path, "wb") as f:
+        f.truncate(total)
+    with open(path, "r+b") as f:
+        f.seek(0)
+        f.write(patch1)
+        f.seek(65 * MB)
+        f.write(patch2)
+
+    # Read back and verify
+    with open(path, "rb") as f:
+        actual = f.read()
+
+    assert len(actual) == total
+    assert md5(actual) == md5(bytes(expected))
+
+
+def test_sparse_write_at_exact_chunk_boundary(test_dir):
+    """Write exactly at the 64MB chunk boundary offset."""
+    path = os.path.join(test_dir, "at_boundary")
+    patch = os.urandom(4096)
+
+    with open(path, "wb") as f:
+        f.truncate(CHUNK_SIZE + 4096)
+    with open(path, "r+b") as f:
+        f.seek(CHUNK_SIZE)
+        f.write(patch)
+
+    with open(path, "rb") as f:
+        f.seek(CHUNK_SIZE)
+        actual = f.read(4096)
+
+    assert actual == patch
+
+    # Verify hole before boundary is zeros
+    with open(path, "rb") as f:
+        hole = f.read(4096)
+    assert hole == b"\x00" * 4096
+
+
+def test_sparse_straddling_chunk_boundary(test_dir):
+    """Write a single buffer that straddles the 64MB chunk boundary."""
+    path = os.path.join(test_dir, "straddle")
+    offset = CHUNK_SIZE - 2048  # starts 2KB before boundary
+    data = os.urandom(4096)  # crosses into next chunk
+
+    with open(path, "wb") as f:
+        f.truncate(CHUNK_SIZE + MB)
+    with open(path, "r+b") as f:
+        f.seek(offset)
+        f.write(data)
+
+    with open(path, "rb") as f:
+        f.seek(offset)
+        actual = f.read(4096)
+
+    assert actual == data, "data straddling chunk boundary corrupted"
+
+
+def test_sparse_multiple_chunks_md5(test_dir):
+    """Sparse file spanning 3 chunks with data patches in each chunk."""
+    path = os.path.join(test_dir, "multi_chunk")
+    total = 3 * CHUNK_SIZE  # 192MB
+
+    patches = [
+        (10 * MB, os.urandom(MB)),          # chunk 0
+        (CHUNK_SIZE + 5 * MB, os.urandom(MB)),  # chunk 1
+        (2 * CHUNK_SIZE + 1 * MB, os.urandom(MB)),  # chunk 2
+    ]
+
+    expected = bytearray(total)
+    for off, data in patches:
+        expected[off:off + len(data)] = data
+
+    with open(path, "wb") as f:
+        f.truncate(total)
+    for off, data in patches:
+        with open(path, "r+b") as f:
+            f.seek(off)
+            f.write(data)
+
+    with open(path, "rb") as f:
+        actual = f.read()
+
+    assert len(actual) == total
+    assert md5(actual) == md5(bytes(expected)), "multi-chunk sparse md5 mismatch"

--- a/test/e2e/specific/test_sparse_file.py
+++ b/test/e2e/specific/test_sparse_file.py
@@ -1,0 +1,44 @@
+# Copyright 2026 DingoDB. All rights reserved.
+
+import os
+import hashlib
+
+import pytest
+
+pytestmark = pytest.mark.standard
+
+
+def md5(data):
+    return hashlib.md5(data).hexdigest()
+
+
+def test_sparse_write_read(test_dir):
+    """Truncate to 100MB, write 3 patches at different offsets, verify md5."""
+    path = os.path.join(test_dir, "sparse")
+    MB = 1024 * 1024
+
+    # Build expected content
+    expected = bytearray(100 * MB)
+    patches = [
+        (5, os.urandom(2 * MB)),
+        (50, os.urandom(2 * MB)),
+        (97, os.urandom(2 * MB)),
+    ]
+    for off_mb, data in patches:
+        expected[off_mb * MB: off_mb * MB + len(data)] = data
+
+    # Create sparse file via truncate
+    with open(path, "wb") as f:
+        f.truncate(100 * MB)
+
+    # Write each patch
+    for off_mb, data in patches:
+        with open(path, "r+b") as f:
+            f.seek(off_mb * MB)
+            f.write(data)
+
+    # Read back and verify
+    with open(path, "rb") as f:
+        actual = f.read()
+
+    assert md5(actual) == md5(bytes(expected))

--- a/test/e2e/specific/test_statfs.py
+++ b/test/e2e/specific/test_statfs.py
@@ -1,0 +1,40 @@
+# Copyright 2026 DingoDB. All rights reserved.
+
+"""DingoFS statvfs(2) + quota tracking behavior.
+
+Exercises:
+  - Basic statvfs fields (f_bsize, f_blocks, f_namemax) are valid.
+  - f_bavail (available blocks) is monotonically non-increasing after a
+    write — exposes drifts in DingoFS quota accounting on the data path,
+    which would otherwise break tools that rely on `df` to gate usage.
+
+works on: Local + MDS.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def test_statvfs_basic(mount_point):
+    """statvfs should return valid filesystem info."""
+    st = os.statvfs(mount_point)
+    assert st.f_bsize > 0
+    assert st.f_blocks > 0
+    assert st.f_namemax > 0
+
+
+def test_statvfs_free_decreases_after_write(test_dir, mount_point):
+    """Available blocks should not increase after writing data."""
+    st_before = os.statvfs(mount_point)
+
+    # Write 1MB
+    path = os.path.join(test_dir, "fill")
+    with open(path, "wb") as f:
+        f.write(os.urandom(1024 * 1024))
+
+    st_after = os.statvfs(mount_point)
+    # available should not increase (equal is ok due to block alignment)
+    assert st_after.f_bavail <= st_before.f_bavail

--- a/test/e2e/uv.lock
+++ b/test/e2e/uv.lock
@@ -1,0 +1,152 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dingofs-e2e"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", specifier = ">=7.0" }]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary

Introduce a Python end-to-end test infrastructure under \`test/e2e/\` and migrate the existing tests from [\`chuandew/dingofs-test\`](https://github.com/chuandew/dingofs-test) into a single self-contained commit, unifying the test footprint with the dingofs source tree.

### Layered relationship with existing C++ test directories

| Layer | Tested by | Verifies |
|---|---|---|
| \`test/unit/\`        | gtest, in-process | one class / one module |
| \`test/integration/\` | gtest, in-process | several C++ modules wired together |
| **\`test/e2e/\`** (this PR) | **pytest, via FUSE mount** | **full stack — FUSE / userspace client / MDS / Local / Memory / S3** |

### Layout

\`\`\`
test/e2e/
├── conftest.py / pyproject.toml / pytest.ini / README.md / uv.lock
├── posix/      8 files — POSIX baseline (transitional, retires when pjdfstest integrates)
├── regression/ 11 files — bug-fix regression keyed to specific fix PRs / commits
└── specific/   7 files — DingoFS-aware (chunk / block / slice / quota / sparse)
\`\`\`

26 test files / 119 test cases / 0 fail / 0 skip on MDS + Local mounts (Memory mode validated against an earlier PR via the deploy helper).

### Authoring convention (README)

\`regression/\` files require \`Bug:\` + \`Verification:\` sections in the file-level docstring. Cross-PR regressions (test added in a PR distinct from the fix it covers) include a \`Regression for PR #N\` reference; same-PR cases skip the reference since the diff is self-evident. PR # is used over commit hash because PR # survives rebases / squashes / cherry-picks.

### Not migrated (intentional)

- \`test_regression_append_concurrent.py\` — DingoFS does not currently support concurrent O_APPEND (already \`xfail\` in the source project). Will be brought in via a separate PR when DingoFS gains support.

## How to run

\`\`\`bash
cd test/e2e
uv sync
# Deploy a dingo-client first via scripts/deploy/{mds,local,memory}/
uv run pytest --mount-point=<mountpoint>           # full
uv run pytest --mount-point=<mp> -m smoke          # quick
uv run pytest regression/test_regression_<keyword>.py --mount-point=<mp>
\`\`\`

## Test plan

| Mode | Mount | Result |
|---|---|---|
| MDS    | \`bench-vs-fs\` (8821 / 10001) | 119 passed in 37.16s |
| Local  | \`pr-verify\` | 119 passed in 4.60s |

Includes the 2 cases from #880 (\`test_regression_fallocate_modes.py\`) and the regressions for #879 + the just-merged #882 (\`test_regression_readahead_invalidate.py\`, \`test_regression_fallocate_basic.py\`, \`test_regression_truncate_shrink_grow.py\`).

## Replaces #881

PR #881 (initial scaffolding-only) was closed — its content is folded into the single commit on this branch alongside the migrated tests.