### PR TITLE
[fix][ci] Drop pr-check.yml paths-ignore to unblock doc-only PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,11 +3,6 @@ name: PR Check
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - '.gitignore'
-      - 'LICENSE'
   merge_group:
     branches: [main]
 


### PR DESCRIPTION
## Problem

Combination of these two settings created a deadlock for doc-only PRs:

1. `pr-check.yml` had `paths-ignore: ['docs/**', '**.md', '.gitignore', 'LICENSE']` on `pull_request:` trigger
2. branch protection `required_status_checks` requires `unit-test` / `build / release-build` / `e2e` to be green

When a PR only touches `**.md` (e.g. README rename), GitHub completely skips the workflow → no jobs run → required status checks never appear → PR is permanently stuck in BLOCKED state, even after maintainer approval.

This was hit by #888 (rename `.github/README.md` to `CICD.md`), which had to be admin-merged to bypass.

## Fix

Drop `paths-ignore` from `pr-check.yml` entirely. All PRs now run the full pipeline (unit-test → build → e2e).

## Trade-off

- **Cost**: doc-only PRs now spend ~15 min of GHA time (was: ~0 min). dingofs is a public repo with unlimited free GHA minutes, so monetary cost = 0.
- **Frequency**: doc-only PRs are <1/week historically → annual overhead ~12-20 hours of CI time.
- **Benefit**: `.github/` config changes (CI yaml / scripts / dockerfiles) now also run the full pipeline, catching CI regressions that the old `**.md` filter would have masked (e.g. CICD.md edits, README rename).

## Alternatives considered

| Option | Why not |
|---|---|
| Use `dorny/paths-filter` + job-level `if:` to skip code jobs | nested status check `build / release-build` (from reusable `_release-build.yml`) still wouldn't appear when `build` job is skipped, since reusable workflows aren't invoked for skipped jobs → same deadlock |
| Remove required status checks from branch protection | weakens CI gate |
| Keep paths-ignore + handle deadlock by admin-merge each time | manual toil, defeats branch protection |

Drop is the simplest and safest.

## Note on release.yml

`release.yml`'s `paths-ignore` on `push:` trigger is kept — release workflow doesn't gate any merge button, so no deadlock risk; skipping doc-only push commits from triggering docker/pypi build is desirable.