### PR TITLE
[feat][client] Add block_access_logging flag to silence access log in bench mode

### DIFF
--- a/src/common/blockaccess/block_access_log.h
+++ b/src/common/blockaccess/block_access_log.h
@@ -25,6 +25,8 @@
 #include <cstdint>
 #include <string>
 
+#include "common/options/blockaccess.h"
+
 namespace dingofs {
 namespace blockaccess {
 
@@ -40,7 +42,7 @@ struct BlockAccessLogGuard {
       : start_us(p_start_us), handler(handler) {}
 
   ~BlockAccessLogGuard() {
-    if (initialized) {
+    if (initialized && FLAGS_block_access_logging) {
       block_access_logger->info("{0} <{1:.6f}>", handler(),
                                 (butil::cpuwide_time_us() - start_us) / 1e6);
     }

--- a/src/common/options/blockaccess.cc
+++ b/src/common/options/blockaccess.cc
@@ -16,10 +16,15 @@
 
 #include "common/options/blockaccess.h"
 
+#include <brpc/reloadable_flags.h>
 #include <gflags/gflags.h>
 
 namespace dingofs {
 namespace blockaccess {
+
+// access log
+DEFINE_bool(block_access_logging, true, "enable block access log");
+DEFINE_validator(block_access_logging, brpc::PassValidate);
 
 // rados option
 DEFINE_int32(rados_op_timeout, 120, "rados operation timeout in seconds");

--- a/src/common/options/blockaccess.h
+++ b/src/common/options/blockaccess.h
@@ -22,6 +22,9 @@
 namespace dingofs {
 namespace blockaccess {
 
+// access log
+DECLARE_bool(block_access_logging);
+
 DECLARE_int32(rados_op_timeout);
 
 // aws option


### PR DESCRIPTION
## Motivation

`dingofs-client` has 5 access-log layers. 4 of them already expose an enable flag so they can be silenced during performance benchmarking:

| Layer | Existing flag | Default |
|---|---|---|
| FUSE access | `vfs_access_logging` | true |
| VFS meta | `vfs_meta_access_logging` | true |
| Block store | `vfs_block_store_access_log_enable` | false |
| AWS SDK | `s3_loglevel` (int, 0=off) | 4 (INFO) |
| **Block access** | **none** | always on |

`block_access` was the only layer without a switch — during a 3-minute bench run it still writes ~16 MB. This PR adds the missing flag.

## Change

Three files, ~10 lines:

- `src/common/options/blockaccess.cc`: `DEFINE_bool(block_access_logging, true, ...)` + `DEFINE_validator(..., brpc::PassValidate)` (matches `vfs_access_logging` style — runtime-reloadable via brpc `/flags`).
- `src/common/options/blockaccess.h`: `DECLARE_bool(block_access_logging)`.
- `src/common/blockaccess/block_access_log.h`: include the options header and guard `BlockAccessLogGuard`'s destructor with `if (initialized && FLAGS_block_access_logging)`.

Default stays **true** for backward compatibility — existing users and troubleshooting paths keep their current behavior.

## Verification

End-to-end runtime test on `block-log-verify` instance with `BENCH_MODE=1` deploy:

- `dingo-client --help` shows the new flag registered.
- `curl /flags/block_access_logging` reports `(R) false (default:true)` — reloadable validator active.
- 10 MB `dd` write + read + 3× touch/rm → `block_access_*.log` stays 0 bytes (alongside `access_*.log`, `vfs_meta_*.log`, `block_store_access_*.log` all 0).
- Negative test: flip the flag to `true` via `/flags` at runtime, repeat the same 10 MB write → 3 `async_put_block` lines appear in `block_access_*.log` (4 MB + 4 MB + 2 MB block splits); flip back to false → silent again.

No regressions when the flag is left at its default `true`.