### PR TITLE
[feat] uid/gid: per-fs UID/GID auto map

### DIFF
--- a/src/client/vfs/components/CMakeLists.txt
+++ b/src/client/vfs/components/CMakeLists.txt
@@ -16,9 +16,21 @@ add_library(vfs_components
     file_suffix_watcher.cc
     prefetch_manager.cc
     warmup_manager.cc
+    uid_gid_mapper.cc
+    passwd_watcher.cc
 )
 
 target_link_libraries(vfs_components
+    dingofs_common
+    dingofs_utils
+
+    gflags::gflags
     glog::glog
+    fmt::fmt
+    jsoncpp
+    spdlog::spdlog
+    OpenSSL::Crypto
+    absl::strings
+    absl::synchronization
     absl::str_format
 )

--- a/src/client/vfs/components/passwd_watcher.cc
+++ b/src/client/vfs/components/passwd_watcher.cc
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "client/vfs/components/passwd_watcher.h"
+
+#include <fmt/format.h>
+#include <poll.h>
+#include <pthread.h>
+#include <sys/eventfd.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+#include "common/logging.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+namespace {
+// A single useradd touches passwd/shadow/group/gshadow in quick succession;
+// coalesce the burst so we rebuild the snapshot once, not four times.
+constexpr int kDebounceMs = 300;
+// Upper bound on a single dirent name (Linux NAME_MAX); sizing the inotify
+// read buffer locally avoids pulling in the deprecated <limits.h>.
+constexpr size_t kMaxNameLen = 255;
+}  // namespace
+
+PasswdWatcher::PasswdWatcher(std::string dir, std::vector<std::string> names,
+                             std::function<void()> on_change)
+    : dir_(std::move(dir)),
+      names_(std::move(names)),
+      on_change_(std::move(on_change)) {}
+
+PasswdWatcher::~PasswdWatcher() { Stop(); }
+
+bool PasswdWatcher::Start() {
+  inotify_fd_ = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+  if (inotify_fd_ < 0) {
+    LOG(WARNING) << fmt::format("[passwd.watch] inotify_init1 fail: {}",
+                                strerror(errno));
+    return false;
+  }
+
+  // Watch the directory (not the files) so an atomic rename(2) replacement of
+  // passwd/group still reaches us as IN_MOVED_TO; IN_CLOSE_WRITE covers an
+  // in-place edit.
+  if (inotify_add_watch(inotify_fd_, dir_.c_str(),
+                        IN_CLOSE_WRITE | IN_MOVED_TO) < 0) {
+    LOG(WARNING) << fmt::format("[passwd.watch] add_watch '{}' fail: {}", dir_,
+                                strerror(errno));
+    close(inotify_fd_);
+    inotify_fd_ = -1;
+    return false;
+  }
+
+  wake_fd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  if (wake_fd_ < 0) {
+    LOG(WARNING) << fmt::format("[passwd.watch] eventfd fail: {}",
+                                strerror(errno));
+    close(inotify_fd_);
+    inotify_fd_ = -1;
+    return false;
+  }
+
+  stop_.store(false);
+  thread_ = std::thread(&PasswdWatcher::Run, this);
+  LOG(INFO) << fmt::format("[passwd.watch] watching '{}' for changes.", dir_);
+  return true;
+}
+
+void PasswdWatcher::Stop() {
+  stop_.store(true);
+
+  if (wake_fd_ >= 0) {
+    uint64_t one = 1;
+    // Best effort — a failed write only matters if the thread is blocked, and
+    // stop_ plus a closed fd will still tear it down on the next iteration.
+    write(wake_fd_, &one, sizeof(one));
+  }
+
+  if (thread_.joinable()) thread_.join();
+
+  if (wake_fd_ >= 0) {
+    close(wake_fd_);
+    wake_fd_ = -1;
+  }
+  if (inotify_fd_ >= 0) {
+    close(inotify_fd_);
+    inotify_fd_ = -1;
+  }
+}
+
+void PasswdWatcher::Run() {
+  // Name the thread so it stands out in top -H / gdb (Linux caps at 15 chars).
+  pthread_setname_np(pthread_self(), "passwd-watch");
+  LOG(INFO) << fmt::format("[passwd.watch] event loop started, dir '{}'.",
+                           dir_);
+
+  // Room for a healthy batch of events; we loop on read() until EAGAIN anyway.
+  std::vector<char> buf(64 * (sizeof(struct inotify_event) + kMaxNameLen + 1));
+  bool pending = false;
+
+  while (true) {
+    struct pollfd fds[2];
+    fds[0] = {inotify_fd_, POLLIN, 0};
+    fds[1] = {wake_fd_, POLLIN, 0};
+
+    // Block indefinitely when idle; once an event is pending, wait only the
+    // debounce window so trailing events of the same burst collapse into one
+    // callback when the window elapses.
+    int timeout = pending ? kDebounceMs : -1;
+    int n = poll(fds, 2, timeout);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      LOG(ERROR) << fmt::format("[passwd.watch] poll fail: {}",
+                                strerror(errno));
+      break;
+    }
+
+    if (n == 0) {  // debounce window elapsed
+      if (pending) {
+        on_change_();
+        pending = false;
+      }
+      continue;
+    }
+
+    if (fds[1].revents & POLLIN) break;  // Stop() woke us
+    if (stop_.load()) break;
+
+    if (fds[0].revents & POLLIN) {
+      while (true) {
+        ssize_t len = read(inotify_fd_, buf.data(), buf.size());
+        if (len <= 0) break;  // EAGAIN (drained) or error — stop reading
+        for (char* p = buf.data(); p < buf.data() + len;) {
+          auto* ev = reinterpret_cast<struct inotify_event*>(p);
+          if (ev->len > 0 && std::find(names_.begin(), names_.end(),
+                                       std::string(ev->name)) != names_.end()) {
+            pending = true;
+          }
+          p += sizeof(struct inotify_event) + ev->len;
+        }
+      }
+    }
+  }
+
+  LOG(INFO) << fmt::format("[passwd.watch] event loop exited, dir '{}'.", dir_);
+}
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/vfs/components/passwd_watcher.h
+++ b/src/client/vfs/components/passwd_watcher.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DINGOFS_SRC_CLIENT_VFS_COMPONENTS_PASSWD_WATCHER_H_
+#define DINGOFS_SRC_CLIENT_VFS_COMPONENTS_PASSWD_WATCHER_H_
+
+#include <atomic>
+#include <functional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+// Watches a directory (default /etc) for changes to a set of file names
+// (default passwd, group) and fires a debounced callback on change. Lets the
+// uid/gid mapper rebuild its snapshot the moment useradd/userdel touches the
+// local NSS files, instead of polling on a timer.
+//
+// We watch the directory rather than the files themselves because useradd and
+// vipw replace /etc/passwd via a rename() over the target, which would
+// invalidate a watch placed on the file. A directory watch catches both the
+// atomic rename (IN_MOVED_TO) and an in-place edit (IN_CLOSE_WRITE).
+class PasswdWatcher {
+ public:
+  PasswdWatcher(std::string dir, std::vector<std::string> names,
+                std::function<void()> on_change);
+
+  PasswdWatcher(const PasswdWatcher&) = delete;
+  PasswdWatcher& operator=(const PasswdWatcher&) = delete;
+
+  ~PasswdWatcher();
+
+  // Creates the inotify watch and spawns the watch thread. Returns false if
+  // inotify setup fails; the caller should log and continue (degraded: the
+  // snapshot is still primed once and the outbound miss path covers new ids).
+  bool Start();
+
+  // Signals the watch thread to exit, joins it, and closes the fds.
+  // Idempotent — safe to call more than once and from the destructor.
+  void Stop();
+
+ private:
+  void Run();
+
+  const std::string dir_;
+  const std::vector<std::string> names_;
+  const std::function<void()> on_change_;
+
+  int inotify_fd_{-1};
+  int wake_fd_{-1};  // eventfd used to unblock the poll loop on Stop().
+  std::atomic<bool> stop_{false};
+  std::thread thread_;
+};
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_VFS_COMPONENTS_PASSWD_WATCHER_H_

--- a/src/client/vfs/components/uid_gid_mapper.cc
+++ b/src/client/vfs/components/uid_gid_mapper.cc
@@ -1,0 +1,396 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "client/vfs/components/uid_gid_mapper.h"
+
+#include <fmt/format.h>
+#include <grp.h>
+#include <openssl/evp.h>
+#include <pwd.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "common/logging.h"
+#include "utils/time.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+// MD5(salt + name + salt) folded to uint32, mapped to [kLocalUidMax,
+// UINT32_MAX].
+static uint32_t HashToReserved(std::string_view salt, std::string_view name) {
+  std::array<uint8_t, EVP_MAX_MD_SIZE> digest{};
+  unsigned int digest_len = 0;
+  EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+  CHECK(ctx != nullptr);
+  CHECK(EVP_DigestInit_ex(ctx, EVP_md5(), nullptr) == 1);
+  CHECK(EVP_DigestUpdate(ctx, salt.data(), salt.size()) == 1);
+  CHECK(EVP_DigestUpdate(ctx, name.data(), name.size()) == 1);
+  CHECK(EVP_DigestUpdate(ctx, salt.data(), salt.size()) == 1);
+  CHECK(EVP_DigestFinal_ex(ctx, digest.data(), &digest_len) == 1);
+  EVP_MD_CTX_free(ctx);
+  CHECK_GE(digest_len, 16u);
+
+  uint64_t lo = 0, hi = 0;
+  std::memcpy(&lo, digest.data(), sizeof(lo));
+  std::memcpy(&hi, digest.data() + 8, sizeof(hi));
+  uint32_t h = static_cast<uint32_t>(lo ^ hi);
+  constexpr uint64_t span =
+      static_cast<uint64_t>(UINT32_MAX) - UidGidMapper::kLocalUidMax + 1ULL;
+  return UidGidMapper::kLocalUidMax +
+         static_cast<uint32_t>(static_cast<uint64_t>(h) % span);
+}
+
+std::vector<std::pair<std::string, uint32_t>> LibcPasswdSource::ListGroups() {
+  utils::WriteLockGuard lk(nss_lock_);
+  std::vector<std::pair<std::string, uint32_t>> out;
+  setgrent();
+  while (auto* ent = getgrent()) {
+    if (ent->gr_name != nullptr) {
+      out.emplace_back(ent->gr_name, static_cast<uint32_t>(ent->gr_gid));
+    }
+  }
+  endgrent();
+  return out;
+}
+
+std::vector<PasswdSource::UserRecord>
+LibcPasswdSource::ListUsersWithPrimaryGid() {
+  // One sweep returns name + uid + pw_gid (primary gid) so Refresh can build
+  // the user→pgid cookie without a second NSS pass. Shares nss_lock_ with the
+  // other enumerators since getpwent() / setpwent() / endpwent() reuse the
+  // same MT-Unsafe glibc iterator state.
+  utils::WriteLockGuard lk(nss_lock_);
+  std::vector<UserRecord> out;
+  setpwent();
+  while (auto* ent = getpwent()) {
+    if (ent->pw_name != nullptr) {
+      out.push_back({ent->pw_name, static_cast<uint32_t>(ent->pw_uid),
+                     static_cast<uint32_t>(ent->pw_gid)});
+    }
+  }
+  endpwent();
+  return out;
+}
+
+UidGidMapper::UidGidMapper(bool enabled, std::string salt,
+                           std::unique_ptr<PasswdSource> passwd)
+    : enabled_(enabled), salt_(std::move(salt)), passwd_(std::move(passwd)) {}
+
+void UidGidMapper::Init() {
+  if (!IsEnabled()) {
+    // Disabled: the snapshot is never consulted and nothing translates, so
+    // skip both the priming Refresh and the /etc inotify watch entirely.
+    LOG(INFO) << "[uid_gid_mapper] uid/gid map disabled for this fs.";
+    return;
+  }
+  Refresh();
+  LOG(INFO) << "[uid_gid_mapper] uid/gid map enabled for this fs.";
+  StartWatching("/etc", {"passwd", "group"});
+}
+
+void UidGidMapper::StartWatching(std::string dir,
+                                 std::vector<std::string> names) {
+  watcher_ = std::make_unique<PasswdWatcher>(std::move(dir), std::move(names),
+                                             [this] { Refresh(); });
+  if (!watcher_->Start()) {
+    LOG(WARNING) << "[uid_gid_mapper] passwd watcher failed to start; snapshot "
+                    "will not auto-refresh on /etc/passwd changes.";
+  }
+}
+
+void UidGidMapper::StopWatching() {
+  if (watcher_ != nullptr) {
+    watcher_->Stop();
+  }
+}
+
+uint32_t UidGidMapper::Hash(std::string_view name) const {
+  return HashToReserved(salt_, name);
+}
+
+void UidGidMapper::Refresh() {
+  if (!enabled_.load(std::memory_order_relaxed)) return;
+
+  auto users = passwd_->ListUsersWithPrimaryGid();
+  auto groups = passwd_->ListGroups();
+
+  // Sort ascending by id so on hash collision the smaller local id wins
+  // (first push_back into the reverse vector takes position 0; later
+  // duplicates land after it).
+  std::sort(users.begin(), users.end(),
+            [](const auto& a, const auto& b) { return a.uid < b.uid; });
+  std::sort(groups.begin(), groups.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  // First a pre-pass over groups builds a gid → group-name index so the user
+  // pass below can compute paired_hash without a second NSS sweep. We keep the
+  // first (smallest-gid) name on collision, consistent with the reverse table.
+  absl::flat_hash_map<uint32_t, std::string> gid_to_gname;
+  gid_to_gname.reserve(groups.size());
+  for (const auto& [gname, gid] : groups) {
+    if (gid == 0 || gid >= kLocalUidMax) continue;
+    gid_to_gname.try_emplace(gid, gname);
+  }
+
+  absl::flat_hash_map<Key, LocalEntry, KeyHash> fresh_local;
+  absl::flat_hash_map<uint32_t, HashedEntry> fresh_hashed;
+
+  // Pass 1: users → {uid, kUid} entry. paired_local_id is pw_gid; paired_hash
+  // is H(group-name-for-pw_gid) when that group is present in the snapshot.
+  size_t mapped_users = 0;
+  for (const auto& u : users) {
+    if (u.uid == 0 || u.uid >= kLocalUidMax) continue;
+
+    const uint32_t h = Hash(u.name);
+    LocalEntry e;
+    e.hash = h;
+    e.paired_local_id = u.primary_gid;
+    if (u.primary_gid != 0 && u.primary_gid < kLocalUidMax) {
+      auto it = gid_to_gname.find(u.primary_gid);
+      if (it != gid_to_gname.end()) {
+        e.paired_hash = Hash(it->second);
+      }
+    }
+    fresh_local.try_emplace(Key{u.uid, Kind::kUid}, e);
+
+    auto& vec = fresh_hashed[h].uid_locals;
+    vec.push_back({u.name, u.uid});
+    ++mapped_users;
+    if (vec.size() > 1) {
+      LOG(ERROR) << fmt::format(
+          "[uidgid.refresh] hash collision (user, refresh): keeping "
+          "existing='{}' (uid={}) over new='{}' (uid={}) hash={} — smaller "
+          "local uid wins",
+          vec.front().name, vec.front().local_id, u.name, u.uid, h);
+    }
+  }
+
+  // Pass 2: groups → {gid, kGid} entry. paired_local_id stays 0 — groups have
+  // no canonical "primary user".
+  size_t mapped_groups = 0;
+  for (const auto& [gname, gid] : groups) {
+    if (gid == 0 || gid >= kLocalUidMax) continue;
+
+    const uint32_t h = Hash(gname);
+    LocalEntry e;
+    e.hash = h;
+    fresh_local.try_emplace(Key{gid, Kind::kGid}, e);
+
+    auto& vec = fresh_hashed[h].gid_locals;
+    vec.push_back({gname, gid});
+    ++mapped_groups;
+    if (vec.size() > 1) {
+      LOG(ERROR) << fmt::format(
+          "[uidgid.refresh] hash collision (group, refresh): keeping "
+          "existing='{}' (gid={}) over new='{}' (gid={}) hash={} — smaller "
+          "local gid wins",
+          vec.front().name, vec.front().local_id, gname, gid, h);
+    }
+  }
+
+  {
+    utils::WriteLockGuard lk(mu_);
+    local_table_ = std::move(fresh_local);
+    hashed_table_ = std::move(fresh_hashed);
+    last_refresh_time_ms_.store(utils::TimestampMs(),
+                                std::memory_order_relaxed);
+  }
+
+  LOG(INFO) << fmt::format(
+      "[uidgid.refresh] snapshot rebuilt: {} users, {} groups mapped "
+      "(of {}/{} listed; root and id>={} skipped).",
+      mapped_users, mapped_groups, users.size(), groups.size(), kLocalUidMax);
+}
+
+uint32_t UidGidMapper::LocalIdToHashedId(Kind kind, uint32_t local_id) const {
+  if (!enabled_.load(std::memory_order_relaxed)) return local_id;
+  if (local_id == 0) return 0;
+  if (local_id >= kLocalUidMax) return local_id;
+
+  utils::ReadLockGuard lk(mu_);
+  auto it = local_table_.find(Key{local_id, kind});
+  if (it == local_table_.end()) return local_id;
+  return it->second.hash;
+}
+
+void UidGidMapper::LocalPairToHashed(uint32_t uid, uint32_t gid,
+                                     uint32_t& out_uid,
+                                     uint32_t& out_gid) const {
+  if (!enabled_.load(std::memory_order_relaxed)) {
+    out_uid = uid;
+    out_gid = gid;
+    return;
+  }
+  auto in_range = [](uint32_t x) { return x != 0 && x < kLocalUidMax; };
+
+  utils::ReadLockGuard lk(mu_);
+
+  // Fast path: uid==gid in mappable range AND the user entry's paired_local_id
+  // cookie matches the inbound gid — typical UPG where pw_gid agrees with the
+  // process's effective gid. One find returns both hashes.
+  if (in_range(uid) && in_range(gid)) {
+    auto it = local_table_.find(Key{uid, Kind::kUid});
+    if (it != local_table_.end() && it->second.paired_local_id == gid &&
+        it->second.paired_hash != 0) {
+      out_uid = it->second.hash;
+      out_gid = it->second.paired_hash;
+      return;
+    }
+    // Cookie miss (admin switched alice's primary gid; snapshot stale; or the
+    // paired group is not in /etc/group). Fall through to the per-element find
+    // path — it still consults this same snapshot but resolves gid via the
+    // {gid, kGid} entry directly.
+  }
+
+  auto translate = [&](uint32_t id, Kind kind) -> uint32_t {
+    if (!in_range(id)) {
+      return id;
+    }
+    auto it = local_table_.find(Key{id, kind});
+    return it != local_table_.end() ? it->second.hash : id;
+  };
+  out_uid = translate(uid, Kind::kUid);
+  out_gid = translate(gid, Kind::kGid);
+}
+
+uint32_t UidGidMapper::HashedIdToLocalId(Kind kind, uint32_t hashed_id) const {
+  if (!enabled_.load(std::memory_order_relaxed)) return hashed_id;
+  if (hashed_id == 0) return 0;
+  if (hashed_id < kLocalUidMax) return hashed_id;
+
+  utils::ReadLockGuard lk(mu_);
+  auto it = hashed_table_.find(hashed_id);
+  if (it == hashed_table_.end()) return hashed_id;
+  const auto& vec =
+      (kind == Kind::kUid) ? it->second.uid_locals : it->second.gid_locals;
+  if (vec.empty()) return hashed_id;
+  return vec.front().local_id;
+}
+
+void UidGidMapper::HashedPairToLocal(uint32_t hashed_uid, uint32_t hashed_gid,
+                                     uint32_t& out_uid,
+                                     uint32_t& out_gid) const {
+  if (!enabled_.load(std::memory_order_relaxed)) {
+    out_uid = hashed_uid;
+    out_gid = hashed_gid;
+    return;
+  }
+  auto in_range = [](uint32_t x) { return x >= kLocalUidMax; };
+
+  utils::ReadLockGuard lk(mu_);
+  if (hashed_uid == hashed_gid && in_range(hashed_uid)) {
+    auto it = hashed_table_.find(hashed_uid);
+    if (it == hashed_table_.end()) {
+      out_uid = hashed_uid;
+      out_gid = hashed_gid;
+      return;
+    }
+    out_uid = !it->second.uid_locals.empty()
+                  ? it->second.uid_locals.front().local_id
+                  : hashed_uid;
+    out_gid = !it->second.gid_locals.empty()
+                  ? it->second.gid_locals.front().local_id
+                  : hashed_gid;
+    return;
+  }
+  // Per-element path.
+  auto translate = [&](uint32_t hid, Kind kind) -> uint32_t {
+    if (!in_range(hid)) {
+      return hid;
+    }
+    auto it = hashed_table_.find(hid);
+    if (it == hashed_table_.end()) return hid;
+    const auto& vec =
+        (kind == Kind::kUid) ? it->second.uid_locals : it->second.gid_locals;
+    return vec.empty() ? hid : vec.front().local_id;
+  };
+  out_uid = translate(hashed_uid, Kind::kUid);
+  out_gid = translate(hashed_gid, Kind::kGid);
+}
+
+void UidGidMapper::Summary(Json::Value& value) const {
+  utils::ReadLockGuard lk(mu_);
+  value["name"] = "uidgidmap";
+  value["count"] = static_cast<Json::UInt64>(local_table_.size());
+}
+
+void UidGidMapper::Dump(Json::Value& value) const {
+  Json::Value root = Json::objectValue;
+  root["enabled"] = enabled_.load(std::memory_order_relaxed);
+  root["salt"] = salt_;
+  root["last_refresh_time_ms"] = static_cast<Json::UInt64>(
+      last_refresh_time_ms_.load(std::memory_order_relaxed));
+
+  utils::ReadLockGuard lk(mu_);
+
+  uint64_t uid_count = 0;
+  uint64_t gid_count = 0;
+  for (const auto& kv : local_table_) {
+    if (kv.first.kind == Kind::kUid)
+      ++uid_count;
+    else
+      ++gid_count;
+  }
+  root["uid_count"] = static_cast<Json::UInt64>(uid_count);
+  root["gid_count"] = static_cast<Json::UInt64>(gid_count);
+
+  // Dashboard snapshot; row order is not guaranteed.
+  Json::Value entries(Json::arrayValue);
+  bool any_collision = false;
+  auto emit_row = [&](uint32_t hashed_id, const char* type, Kind kind,
+                      const std::vector<ReverseEntry>& vec) {
+    if (vec.empty()) return;
+    Json::Value row;
+    row["hashed_id"] = static_cast<Json::UInt64>(hashed_id);
+    row["type"] = type;
+    Json::Value mappings(Json::arrayValue);
+    for (const auto& e : vec) {
+      Json::Value m;
+      m["name"] = e.name;
+      m["local_id"] = e.local_id;
+      // For user rows surface the paired_local_id cookie so the dashboard can
+      // distinguish "cookie matches process gid" vs "stale snapshot" cases.
+      if (kind == Kind::kUid) {
+        auto it = local_table_.find(Key{e.local_id, Kind::kUid});
+        if (it != local_table_.end()) {
+          m["paired_local_id"] = it->second.paired_local_id;
+        }
+      }
+      mappings.append(m);
+    }
+    row["mappings"] = mappings;
+    entries.append(row);
+    if (vec.size() > 1) any_collision = true;
+  };
+
+  for (const auto& [hashed_id, entry] : hashed_table_) {
+    emit_row(hashed_id, "uid", Kind::kUid, entry.uid_locals);
+    emit_row(hashed_id, "gid", Kind::kGid, entry.gid_locals);
+  }
+
+  root["entries"] = entries;
+  root["has_collisions"] = any_collision;
+  value["uid_gid_map"] = root;
+}
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/vfs/components/uid_gid_mapper.h
+++ b/src/client/vfs/components/uid_gid_mapper.h
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DINGOFS_SRC_CLIENT_VFS_COMPONENTS_UID_GID_MAPPER_H_
+#define DINGOFS_SRC_CLIENT_VFS_COMPONENTS_UID_GID_MAPPER_H_
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "client/vfs/components/passwd_watcher.h"
+#include "json/value.h"
+#include "utils/concurrent/concurrent.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+class PasswdSource {
+ public:
+  // Each user record carries the primary gid (pwd struct's pw_gid) so the
+  // mapper can populate LocalEntry::paired_local_id without a second NSS pass.
+  struct UserRecord {
+    std::string name;
+    uint32_t    uid;
+    uint32_t    primary_gid;
+  };
+
+  virtual ~PasswdSource() = default;
+  virtual std::vector<UserRecord> ListUsersWithPrimaryGid() = 0;
+  virtual std::vector<std::pair<std::string, uint32_t>> ListGroups() = 0;
+};
+
+class LibcPasswdSource : public PasswdSource {
+ public:
+  std::vector<UserRecord> ListUsersWithPrimaryGid() override;
+  std::vector<std::pair<std::string, uint32_t>> ListGroups() override;
+
+ private:
+  // setpwent/getpwent/endpwent (and the setgr* family) share process-wide
+  // glibc iterator state and are MT-Unsafe (POSIX: race:pwent / race:grent).
+  // Multiple UidGidMapper::Refresh() invocations can land here concurrently
+  // (the startup priming Refresh() at VFSHub::Start(), an inotify-triggered
+  // Refresh() from PasswdWatcher, and the heartbeat-driven toggle-on Refresh()
+  // when enable_uid_gid_map flips to true), so serialize the NSS-enumerating
+  // methods. utils::RWLock is bthread-aware so contention yields the bthread
+  // instead of pinning the pthread worker; we only ever use it in write mode.
+  utils::RWLock nss_lock_;
+};
+
+class UidGidMapper {
+ public:
+  static constexpr uint32_t kLocalUidMax = 10000;
+
+  enum class Kind : uint8_t { kUid = 0, kGid = 1 };
+
+  UidGidMapper(bool enabled, std::string salt,
+               std::unique_ptr<PasswdSource> passwd);
+
+  UidGidMapper(const UidGidMapper&) = delete;
+  UidGidMapper& operator=(const UidGidMapper&) = delete;
+
+  // Runtime toggle. Map* fast-path checks IsEnabled() lock-free.
+  void SetEnabled(bool v) { enabled_.store(v, std::memory_order_relaxed); }
+  bool IsEnabled() const { return enabled_.load(std::memory_order_relaxed); }
+
+  // Synchronously rebuild forward/reverse tables from the PasswdSource.
+  // No-op when disabled — snapshot is never consulted in that state, and the
+  // outbound miss path will lazily fill entries via NSS fallback once
+  // SetEnabled(true) is called.
+  void Refresh();
+
+  // Production entry point. When enabled, primes the snapshot once and starts
+  // an inotify watch on the local NSS files (/etc passwd, group) so the mapping
+  // auto-refreshes the moment useradd/userdel changes them; a failed watch
+  // start is logged and tolerated (the snapshot is still primed once). When
+  // disabled, does nothing — no snapshot, no watch. Tests that inject a mock
+  // PasswdSource skip Init() and so never spawn a real watch.
+  void Init();
+
+  // Stops the inotify watch and joins its thread. Idempotent; the destructor
+  // also stops it via the watcher_ member.
+  void StopWatching();
+
+  // Translation entry points (lock-free fast path when disabled).
+  // LocalIdToHashedId: local-host uid/gid -> hashed id used by MDS (sending out).
+  // HashedIdToLocalId: hashed id used by MDS -> local-host uid/gid (reading back).
+  uint32_t LocalIdToHashedId(Kind kind, uint32_t local_id) const;
+  uint32_t HashedIdToLocalId(Kind kind, uint32_t hashed_id) const;
+
+  // Paired translation: translate (uid, gid) under a single read lock.
+  // When the inputs are equal and in the mappable range, a single hash-table
+  // find serves both; otherwise falls back to two finds (same single lock).
+  // The returned hashed values are independent — never reuse one for both.
+  void LocalPairToHashed(uint32_t uid, uint32_t gid,
+                         uint32_t& out_uid, uint32_t& out_gid) const;
+  void HashedPairToLocal(uint32_t hashed_uid, uint32_t hashed_gid,
+                         uint32_t& out_uid, uint32_t& out_gid) const;
+
+  // ClientStatService dashboard hooks. Summary() fills a Summary-table row
+  // (name/count/...); Dump() emits the full mapper snapshot under
+  // value["uid_gid_map"], with one entries[] row per hashed_id (containing
+  // mappings[] = [{name, local_id}], multi-element when a hash collision
+  // exists; mappings[0] is the winner, smallest local_id).
+  void Summary(Json::Value& value) const;
+  void Dump(Json::Value& value) const;
+
+ private:
+  // Builds the inotify watcher (callback = Refresh) and starts it. Called only
+  // by Init(); failure is logged and tolerated.
+  void StartWatching(std::string dir, std::vector<std::string> names);
+
+  // Forward table is keyed by (local_id, kind) so a numeric id that is both a
+  // user and a group lives as two independent entries — making the user/group
+  // domain split explicit in the key, not implicit in a per-kind field.
+  struct Key {
+    uint32_t local_id;
+    Kind     kind;
+    bool operator==(const Key& o) const noexcept {
+      return local_id == o.local_id && kind == o.kind;
+    }
+  };
+  struct KeyHash {
+    size_t operator()(const Key& k) const noexcept {
+      // (local_id < kLocalUidMax) fits in 14 bits; shift kind into bit 16 so
+      // the two components occupy disjoint bit ranges before mixing.
+      uint32_t v = k.local_id | (static_cast<uint32_t>(k.kind) << 16);
+      return std::hash<uint32_t>{}(v);
+    }
+  };
+
+  // Forward entry: H(name) for this (local_id, kind), plus a paired-entity
+  // cookie used by LocalPairToHashed's fast path. paired_local_id is the
+  // configured pair on the other kind:
+  //   - kind == kUid: the user's primary gid from /etc/passwd's pw_gid;
+  //   - kind == kGid: 0 (groups have no canonical "primary user" notion).
+  // paired_hash caches H(paired group's name) so a cookie-match outbound call
+  // returns both hashes in a single find. 0 in either paired field disables
+  // the cookie for that entry and degrades to the per-element find path.
+  // hash != 0 always when the entry exists (Hash() guarantees output ≥
+  // kLocalUidMax); entry absent ≡ "this (id, kind) is unmapped".
+  struct LocalEntry {
+    uint32_t hash = 0;
+    uint32_t paired_local_id = 0;
+    uint32_t paired_hash = 0;
+  };
+
+  // One reverse hit (name → local id) for a given kind list.
+  struct ReverseEntry {
+    std::string name;
+    uint32_t    local_id;
+  };
+
+  // Reverse entry keyed by hashed id; uid_locals/gid_locals are separate
+  // sorted-by-local_id lists of names that hash to this hashed_id when used
+  // as the respective kind. Collisions within one kind grow that kind's
+  // vector; the smallest local_id (front()) wins. Cross-kind same-hash
+  // (Hash(uname) == Hash(gname)) is by design — uid/gid share the hash
+  // domain and the two vectors keep their results separate.
+  struct HashedEntry {
+    std::vector<ReverseEntry> uid_locals;
+    std::vector<ReverseEntry> gid_locals;
+  };
+
+  // Hash a user/group name into the reserved id range. User and group names
+  // share one hash domain; the per-kind fields/vectors in LocalEntry and
+  // HashedEntry keep their results distinct.
+  uint32_t Hash(std::string_view name) const;
+
+  std::atomic<bool> enabled_;
+  const std::string salt_;
+  std::unique_ptr<PasswdSource> passwd_;
+
+  // Wall-clock timestamp of the last successful Refresh(). 0 = never.
+  std::atomic<uint64_t> last_refresh_time_ms_{0};
+
+  mutable utils::RWLock mu_;
+
+  // Local view: (local_id, kind) -> LocalEntry. Populated only by Refresh();
+  // local_id is always in [1, kLocalUidMax). A numeric id that is both a user
+  // and a group occupies two independent entries here.
+  mutable absl::flat_hash_map<Key, LocalEntry, KeyHash> local_table_;
+
+  // MDS view: hashed_id -> {uid_locals, gid_locals reverse-hit lists}.
+  mutable absl::flat_hash_map<uint32_t /*hashed_id*/, HashedEntry> hashed_table_;
+
+  // Declared last so it is destroyed first: ~PasswdWatcher() joins the watch
+  // thread before the snapshot tables / passwd_ that its Refresh() callback
+  // touches are torn down. Null until StartWatching() is called.
+  std::unique_ptr<PasswdWatcher> watcher_;
+};
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_VFS_COMPONENTS_UID_GID_MAPPER_H_

--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -178,6 +178,17 @@ Status VFSHubImpl::Start(bool skip_mount) {
     }
   }
 
+  // uid/gid mapper + passwd watcher
+  {
+    // salt = fs uuid; enabled comes from fs_info and is immutable after fs
+    // creation, so there is no runtime toggle. Init() primes the snapshot and
+    // starts the /etc passwd/group inotify watch.
+    uid_gid_mapper_ = std::make_unique<UidGidMapper>(
+        fs_info_.enable_uid_gid_map, fs_info_.uuid,
+        std::make_unique<LibcPasswdSource>());
+    uid_gid_mapper_->Init();
+  }
+
   // block accesser
   {
     // 1) decide backend type from fs_info and set per-backend connection
@@ -310,8 +321,8 @@ Status VFSHubImpl::Start(bool skip_mount) {
           prefetch_manager_->Start(FLAGS_vfs_prefetch_threads));
 
     } else {
-      LOG(INFO)
-          << "[vfs.hub] block cache not enable, skip prefetch manager start.";
+      LOG(INFO) << fmt::format(
+          "[vfs.hub] block cache not enable, skip prefetch manager start.");
     }
   }
 
@@ -349,6 +360,10 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
 
   LOG(INFO) << fmt::format("[vfs.hub] stopping vfs hub, skip_unmount({}).",
                            skip_unmount);
+
+  if (uid_gid_mapper_ != nullptr) {
+    uid_gid_mapper_->StopWatching();
+  }
 
   if (compactor_ != nullptr) {
     compactor_->Stop();

--- a/src/client/vfs/hub/vfs_hub.h
+++ b/src/client/vfs/hub/vfs_hub.h
@@ -27,6 +27,7 @@
 #include "client/vfs/compaction/compactor.h"
 #include "client/vfs/components/file_suffix_watcher.h"
 #include "client/vfs/components/prefetch_manager.h"
+#include "client/vfs/components/uid_gid_mapper.h"
 #include "client/vfs/components/warmup_manager.h"
 #include "client/vfs/handle/handle_manager.h"
 #include "client/vfs/metasystem/meta_wrapper.h"
@@ -94,6 +95,8 @@ class VFSHub {
   virtual FsInfo GetFsInfo() = 0;
 
   virtual blockaccess::BlockAccessOptions GetBlockAccesserOptions() = 0;
+
+  virtual UidGidMapper* GetUidGidMapper() = 0;
 };
 
 class VFSHubImpl : public VFSHub {
@@ -195,6 +198,11 @@ class VFSHubImpl : public VFSHub {
     return blockaccess_options_;
   }
 
+  UidGidMapper* GetUidGidMapper() override {
+    CHECK_NOTNULL(uid_gid_mapper_);
+    return uid_gid_mapper_.get();
+  }
+
  private:
   std::atomic_bool started_{false};
 
@@ -225,6 +233,8 @@ class VFSHubImpl : public VFSHub {
   std::unique_ptr<PrefetchManager> prefetch_manager_;
   std::unique_ptr<WarmupManager> warmup_manager_;
   std::unique_ptr<utils::LogCleanManager> logclean_manager_;
+  // Owns its own /etc passwd/group inotify watch internally (see Init).
+  std::unique_ptr<UidGidMapper> uid_gid_mapper_;
 };
 
 }  // namespace vfs

--- a/src/client/vfs/metasystem/local/metasystem.cc
+++ b/src/client/vfs/metasystem/local/metasystem.cc
@@ -518,9 +518,9 @@ Status LocalMetaSystem::WriteSlice(ContextSPtr, Ino ino, uint64_t index,
     const uint64_t chunk_start = index * fs_info_.chunk_size();
     uint64_t new_length = 0;
     for (const auto& slice : slices) {
-      new_length = std::max(
-          new_length,
-          chunk_start + static_cast<uint64_t>(slice.pos) + slice.len);
+      new_length =
+          std::max(new_length,
+                   chunk_start + static_cast<uint64_t>(slice.pos) + slice.len);
 
       auto* slice_entry = chunk_entry.add_slices();
 
@@ -1107,10 +1107,10 @@ Status LocalMetaSystem::SetAttr(ContextSPtr, Ino ino, int to_set,
       // chunk tail; then delete every chunk fully past new_length.
       if (new_length < old_length) {
         const uint64_t chunk_size = fs_info_.chunk_size();
-        const uint32_t old_num = static_cast<uint32_t>(
-            (old_length + chunk_size - 1) / chunk_size);
-        const uint32_t new_num = static_cast<uint32_t>(
-            (new_length + chunk_size - 1) / chunk_size);
+        const uint32_t old_num =
+            static_cast<uint32_t>((old_length + chunk_size - 1) / chunk_size);
+        const uint32_t new_num =
+            static_cast<uint32_t>((new_length + chunk_size - 1) / chunk_size);
 
         if (new_length % chunk_size != 0) {
           const uint64_t chunk_pos = new_length % chunk_size;
@@ -1160,8 +1160,8 @@ Status LocalMetaSystem::Fallocate(ContextSPtr, Ino ino, int mode,
   constexpr int kSupported =
       0x01 /*KEEP_SIZE*/ | 0x02 /*PUNCH_HOLE*/ | 0x10 /*ZERO_RANGE*/;
   if ((mode & ~kSupported) != 0) {
-    return Status::NotSupport(fmt::format("fallocate mode({}) not supported",
-                                          mode));
+    return Status::NotSupport(
+        fmt::format("fallocate mode({}) not supported", mode));
   }
   if (length == 0) return Status::OK();
 
@@ -1208,8 +1208,7 @@ Status LocalMetaSystem::Fallocate(ContextSPtr, Ino ino, int mode,
       const uint64_t chunk_index = cursor / chunk_size;
       const uint64_t chunk_pos = cursor % chunk_size;
       const uint64_t remain = end_offset - cursor;
-      const uint64_t delta =
-          std::min(remain, chunk_size - chunk_pos);
+      const uint64_t delta = std::min(remain, chunk_size - chunk_pos);
 
       status = AppendZeroSliceToChunk(fs_id, ino, chunk_index,
                                       static_cast<uint32_t>(chunk_pos),
@@ -1799,8 +1798,8 @@ Status LocalMetaSystem::InitFsQuota() {
     // sign-flip in downstream consumers (e.g. ReplyStatfs computes
     // total_blocks - used_blocks in uint64 and underflows when either
     // side approaches 2^63).
-    fs_quota_.set_max_bytes(1LL << 50);     // 1 PiB
-    fs_quota_.set_max_inodes(1LL << 40);    // 1T inodes
+    fs_quota_.set_max_bytes(1LL << 50);   // 1 PiB
+    fs_quota_.set_max_inodes(1LL << 40);  // 1T inodes
     fs_quota_.set_used_bytes(0);
     fs_quota_.set_used_inodes(1);
 

--- a/src/client/vfs/metasystem/mds/CMakeLists.txt
+++ b/src/client/vfs/metasystem/mds/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(vfs_metasystem_mds_lib
     jsoncpp
     spdlog::spdlog
     brpc::brpc
+    OpenSSL::Crypto
     absl::memory
     absl::strings
     absl::synchronization

--- a/src/client/vfs/metasystem/mds/mds_client.cc
+++ b/src/client/vfs/metasystem/mds/mds_client.cc
@@ -205,10 +205,16 @@ Status MDSClient::GetFsInfo(RPC& rpc, uint32_t fs_id,
   return DoGetFsInfo(rpc, request, fs_info);
 }
 
+Status MDSClient::RefreshFsInfo(mds::FsInfoEntry& fs_info) {
+  return MDSClient::GetFsInfo(rpc_, fs_info_.GetName(), fs_info);
+}
+
 RPC& MDSClient::GetRpc() { return rpc_; }
 
 Status MDSClient::Heartbeat(
-    const std::map<Ino, std::vector<std::string>>& need_keep_alive_sessions) {
+    const std::map<Ino, std::vector<std::string>>& need_keep_alive_sessions,
+    uint64_t& last_fs_version) {
+  last_fs_version = 0;
   if (client_id_.ID().empty()) {
     return Status::InvalidParam("client id is empty");
   }
@@ -252,6 +258,10 @@ Status MDSClient::Heartbeat(
     return status;
   }
 
+  // When the response doesn't carry a ClientReply (oneof unset — e.g.
+  // unknown fs on MDS), response.client() returns the default instance
+  // and last_fs_version() returns 0, matching the "no signal" semantic.
+  last_fs_version = response.client().last_fs_version();
   return Status::OK();
 }
 

--- a/src/client/vfs/metasystem/mds/mds_client.h
+++ b/src/client/vfs/metasystem/mds/mds_client.h
@@ -70,10 +70,21 @@ class MDSClient {
                           mds::FsInfoEntry& fs_info);
   static Status GetFsInfo(RPC& rpc, uint32_t fs_id, mds::FsInfoEntry& fs_info);
 
+  // Refresh the cached fs info from MDS via this client's RPC handle and
+  // current fs name. Caller is responsible for applying side effects (e.g.
+  // propagating to fs_info_).
+  Status RefreshFsInfo(mds::FsInfoEntry& fs_info);
+
   RPC& GetRpc();
 
+  // Out param `last_fs_version` receives the FsInfo.version echoed by MDS
+  // in HeartbeatResponse.client.last_fs_version (zero when the response did
+  // not carry a client reply, e.g. heartbeat for a non-client role or
+  // unknown fs). Callers compare against their locally-held version to
+  // detect runtime-mutable fs changes. Zero on failure.
   Status Heartbeat(
-      const std::map<Ino, std::vector<std::string>>& need_keep_alive_sessions);
+      const std::map<Ino, std::vector<std::string>>& need_keep_alive_sessions,
+      uint64_t& last_fs_version);
 
   Status MountFs(const std::string& name,
                  const pb::mds::MountPoint& mount_point);

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -378,41 +378,43 @@ bool MDSMetaSystem::Load(ContextSPtr, const Json::Value& value) {
   return true;
 }
 
-Status MDSMetaSystem::GetFsInfo(ContextSPtr, FsInfo* fs_info) {
-  auto temp_fs_info = fs_info_.Get();
+Status MDSMetaSystem::ToVfsFsInfo(const mds::FsInfoEntry& src,
+                                  FsInfo* dst) const {
+  dst->name = name_;
+  dst->id = src.fs_id();
+  dst->chunk_size = src.chunk_size();
+  dst->block_size = src.block_size();
+  dst->uuid = src.uuid();
+  dst->status = Helper::ToFsStatus(src.status());
+  dst->create_time_s = src.create_time_s();
+  dst->trash_days = src.trash_days();
+  dst->enable_uid_gid_map = src.enable_uid_gid_map();
 
-  fs_info->name = name_;
-  fs_info->id = temp_fs_info.fs_id();
-  fs_info->chunk_size = temp_fs_info.chunk_size();
-  fs_info->block_size = temp_fs_info.block_size();
-  fs_info->uuid = temp_fs_info.uuid();
-  fs_info->status = Helper::ToFsStatus(temp_fs_info.status());
-  fs_info->create_time_s = temp_fs_info.create_time_s();
-  fs_info->trash_days = temp_fs_info.trash_days();
-
-  fs_info->storage_info.store_type =
-      Helper::ToStoreType(temp_fs_info.fs_type());
-  if (fs_info->storage_info.store_type == StoreType::kS3) {
-    CHECK(temp_fs_info.extra().has_s3_info())
+  dst->storage_info.store_type = Helper::ToStoreType(src.fs_type());
+  if (dst->storage_info.store_type == StoreType::kS3) {
+    CHECK(src.extra().has_s3_info())
         << "fs type is S3, but s3 info is not set";
 
-    fs_info->storage_info.s3_info =
-        Helper::ToS3Info(temp_fs_info.extra().s3_info());
+    dst->storage_info.s3_info = Helper::ToS3Info(src.extra().s3_info());
 
-  } else if (fs_info->storage_info.store_type == StoreType::kRados) {
-    CHECK(temp_fs_info.extra().has_rados_info())
+  } else if (dst->storage_info.store_type == StoreType::kRados) {
+    CHECK(src.extra().has_rados_info())
         << "fs type is Rados, but rados info is not set";
 
-    fs_info->storage_info.rados_info =
-        Helper::ToRadosInfo(temp_fs_info.extra().rados_info());
+    dst->storage_info.rados_info =
+        Helper::ToRadosInfo(src.extra().rados_info());
 
   } else {
     LOG(ERROR) << fmt::format("[meta.fs] unknown fs type: {}.",
-                              pb::mds::FsType_Name(temp_fs_info.fs_type()));
+                              pb::mds::FsType_Name(src.fs_type()));
     return Status::InvalidParam("unknown fs type");
   }
 
   return Status::OK();
+}
+
+Status MDSMetaSystem::GetFsInfo(ContextSPtr, FsInfo* fs_info) {
+  return ToVfsFsInfo(fs_info_.Get(), fs_info);
 }
 
 bool MDSMetaSystem::MountFs() {
@@ -454,14 +456,42 @@ void MDSMetaSystem::Heartbeat() {
   static std::atomic<bool> is_running{false};
   if (is_running.exchange(true)) return;
 
-  auto status =
-      mds_client_.Heartbeat(file_session_map_.GetNeedKeepAliveSession());
+  uint64_t last_fs_version = 0;
+  auto status = mds_client_.Heartbeat(
+      file_session_map_.GetNeedKeepAliveSession(), last_fs_version);
   if (!status.IsOK()) {
     LOG(ERROR) << fmt::format("[meta.fs] heartbeat fail, error({}).",
                               status.ToString());
+    is_running = false;
+    return;
+  }
+
+  // Piggyback: if MDS reports a newer fs version, trigger a one-shot
+  // GetFsInfo to pull the full record and refresh the cached fs_info.
+  // last_fs_version == 0 means MDS did not echo a ClientReply (e.g.
+  // pre-feature server or no fs match); fall back to no-op rather than
+  // thrashing.
+  if (last_fs_version > 0 && last_fs_version > fs_info_.GetVersion()) {
+    RefreshCachedFsInfo();
   }
 
   is_running = false;
+}
+
+void MDSMetaSystem::RefreshCachedFsInfo() {
+  // Only ever called from Heartbeat(), which is already serialized by its
+  // own re-entrancy guard, so no guard is needed here.
+  mds::FsInfoEntry new_fs_info;
+  auto status = mds_client_.RefreshFsInfo(new_fs_info);
+  if (!status.ok()) {
+    LOG(WARNING) << fmt::format(
+        "[meta.fs] refresh fs info fail, error({}).", status.ToString());
+    return;
+  }
+
+  // Update() is a no-op when the incoming version is not newer, so it is
+  // safe to call on every tick.
+  fs_info_.Update(new_fs_info);
 }
 
 void MDSMetaSystem::CleanExpiredModifyTimeMemo() {
@@ -525,6 +555,10 @@ bool MDSMetaSystem::InitCrontab() {
       },
   });
 
+  // Note: the cached fs_info refreshes via the 5s heartbeat path — MDS echoes
+  // the current FsInfo.version, and MDSMetaSystem::Heartbeat triggers
+  // RefreshCachedFsInfo on diff. No separate poll crontab is needed.
+
   crontab_manager_.AddCrontab(crontab_configs_);
 
   return true;
@@ -565,9 +599,8 @@ Status MDSMetaSystem::Lookup(ContextSPtr ctx, Ino parent,
     return status;
   }
 
-  *attr = Helper::ToAttr(attr_entry);
-
-  PutInodeToCache(attr_entry);
+  auto inode = PutInodeToCache(attr_entry);
+  *attr = inode->ToAttr();
 
   return Status::OK();
 }
@@ -584,10 +617,9 @@ Status MDSMetaSystem::Create(ContextSPtr ctx, Ino parent,
                                    session_id, attr_entry, parent_attr_entry);
   if (!status.ok()) return status;
 
-  *attr = Helper::ToAttr(attr_entry);
-
   InodeSPtr inode = PutInodeToCache(attr_entry);
   PutInodeToCache(parent_attr_entry);
+  *attr = inode->ToAttr();
   if (FLAGS_vfs_tiny_file_data_enable) {
     tiny_file_data_cache_.Create(attr_entry.ino());
   }
@@ -642,10 +674,9 @@ Status MDSMetaSystem::MkNod(ContextSPtr ctx, Ino parent,
     if (!status.ok()) return status;
   }
 
-  *attr = Helper::ToAttr(attr_entry);
-
-  PutInodeToCache(attr_entry);
+  auto inode = PutInodeToCache(attr_entry);
   PutInodeToCache(parent_attr_entry);
+  *attr = inode->ToAttr();
 
   return Status::OK();
 }
@@ -1175,10 +1206,9 @@ Status MDSMetaSystem::MkDir(ContextSPtr ctx, Ino parent,
     if (!status.ok()) return status;
   }
 
-  *attr = Helper::ToAttr(attr_entry);
-
-  PutInodeToCache(attr_entry);
+  auto inode = PutInodeToCache(attr_entry);
   PutInodeToCache(parent_attr_entry);
+  *attr = inode->ToAttr();
 
   return Status::OK();
 }
@@ -1251,7 +1281,12 @@ Status MDSMetaSystem::ReadDir(ContextSPtr ctx, Ino ino, uint64_t fh,
       CorrectAttr(ctx, dir_iterator->LastFetchTimeNs(), entry.attr, is_amend,
                   "readdir");
 
-      PutInodeToCache(Helper::ToAttr(entry.attr));
+      // entry.attr carries raw hashed uid/gid from the upstream RPC. Route it
+      // through PutInodeToCache so the Inode is created/updated, then
+      // overwrite entry.attr from inode->ToAttr(). ToAttr() now emits hashed
+      // ids as-is; the VFS layer performs the local-host translation.
+      auto inode = PutInodeToCache(Helper::ToAttr(entry.attr));
+      entry.attr = inode->ToAttr();
     }
 
     if (!handler(entry, offset)) {
@@ -1295,10 +1330,9 @@ Status MDSMetaSystem::Link(ContextSPtr ctx, Ino ino, Ino new_parent,
     return status;
   }
 
-  *attr = Helper::ToAttr(attr_entry);
-
-  PutInodeToCache(attr_entry);
+  auto inode = PutInodeToCache(attr_entry);
   PutInodeToCache(parent_attr_entry);
+  *attr = inode->ToAttr();
 
   return Status::OK();
 }
@@ -1354,10 +1388,9 @@ Status MDSMetaSystem::Symlink(ContextSPtr ctx, Ino parent,
     return status;
   }
 
-  *attr = Helper::ToAttr(attr_entry);
-
-  PutInodeToCache(attr_entry);
+  auto inode = PutInodeToCache(attr_entry);
   PutInodeToCache(parent_attr_entry);
+  *attr = inode->ToAttr();
 
   return Status::OK();
 }
@@ -1380,19 +1413,19 @@ Status MDSMetaSystem::GetAttr(ContextSPtr ctx, Ino ino, Attr* attr) {
 
   CHECK(ctx != nullptr) << "context is null";
 
-  AttrEntry attr_entry;
-
   auto inode = GetInodeFromCache(ino);
-  if (inode != nullptr) {
-    attr_entry = inode->ToAttrEntry();
-    // ctx->hit_cache = true;
-
-  } else {
+  if (inode == nullptr) {
+    // Cold path: pull a fresh AttrEntry (carries hashed uid/gid) and
+    // route it through PutInodeToCache so the inode cache is populated/refreshed
+    // before inode->ToAttr() emits the hashed-id attr.  The VFS layer above
+    // (not ToAttr) performs the local-host uid/gid translation.
+    AttrEntry attr_entry;
     auto status = mds_client_.GetAttr(ctx, ino, attr_entry);
     if (!status.ok()) return status;
+    inode = PutInodeToCache(attr_entry);
   }
 
-  *attr = Helper::ToAttr(attr_entry);
+  *attr = inode->ToAttr();
 
   bool is_amend = false;
   auto status =
@@ -1443,7 +1476,8 @@ Status MDSMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
     return status;
   }
 
-  *out_attr = Helper::ToAttr(attr_entry);
+  auto inode = PutInodeToCache(attr_entry);
+  *out_attr = inode->ToAttr();
 
   bool is_amend = false;
   status = CorrectAttr(ctx, ctx->start_time_ns, *out_attr, is_amend, "setattr");
@@ -1460,8 +1494,6 @@ Status MDSMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
     chunk_memo_.Forget(ino);
     chunk_cache_.Delete(ino);
   }
-
-  PutInodeToCache(attr_entry);
 
   return Status::OK();
 }
@@ -1777,7 +1809,8 @@ Status MDSMetaSystem::CorrectAttr(ContextSPtr ctx, uint64_t time_ns, Attr& attr,
           attr.ino, caller, status.ToString());
       return status;
     }
-    attr = Helper::ToAttr(attr_entry);
+    auto inode = PutInodeToCache(attr_entry);
+    attr = inode->ToAttr();
     is_amend = true;
   }
 

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "client/vfs/common/client_id.h"
 #include "client/vfs/compaction/compactor.h"
@@ -44,6 +45,7 @@
 #include "json/value.h"
 #include "mds/common/crontab.h"
 #include "mds/common/type.h"
+#include "utils/concurrent/concurrent.h"
 
 namespace dingofs {
 namespace client {
@@ -183,12 +185,19 @@ class MDSMetaSystem : public vfs::MetaSystem {
  private:
   friend class OpenTask;
 
+  // Convert the backend-specific mds::FsInfoEntry into the backend-agnostic
+  // vfs::FsInfo consumed by upper layers (GetFsInfo).
+  Status ToVfsFsInfo(const mds::FsInfoEntry& src, FsInfo* dst) const;
+
   bool SetRandomEndpoint();
   bool SetEndpoints();
   bool MountFs();
   bool UnmountFs();
 
   void Heartbeat();
+  // Refresh the cached fs_info from MDS. Driven by the heartbeat when MDS
+  // reports a newer fs version.
+  void RefreshCachedFsInfo();
   void CleanExpiredModifyTimeMemo();
   void CleanExpiredChunkMemo();
   void CleanExpiredChunkCache();

--- a/src/client/vfs/metasystem/meta_system.h
+++ b/src/client/vfs/metasystem/meta_system.h
@@ -18,6 +18,7 @@
 #define DINGODB_CLIENT_VFS_META_META_SYSTEM_H
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 

--- a/src/client/vfs/metasystem/meta_wrapper.h
+++ b/src/client/vfs/metasystem/meta_wrapper.h
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "client/vfs/metasystem/meta_system.h"

--- a/src/client/vfs/service/client_stat_service.cc
+++ b/src/client/vfs/service/client_stat_service.cc
@@ -288,6 +288,7 @@ static void RenderSummary(Json::Value& json_value, butil::IOBufBuilder& os) {
       {"rpc", "show rpc info at meta."},
       {"blockcache", "show block cache info at meta."},
       {"tinyfiledatacache", "show tiny file data cache info."},
+      {"uidgidmap", "show uid/gid mapper info at meta."},
   };
 
   for (const auto& item : json_value) {
@@ -1418,6 +1419,81 @@ static void RenderBlockCachePage(const Json::Value& json_value,
   os << "<br>";
 }
 
+static void RenderUidGidMapperPage(const Json::Value& json_value,
+                                   butil::IOBufBuilder& os,
+                                   std::string& client_name) {
+  os << "<!DOCTYPE html><html>";
+  os << "<head>" << RenderHead("dingofs uid/gid mapper") << "</head>";
+  os << "<body>";
+  os << fmt::format(
+      R"(<h1 style="text-align:center;">Client({}) UID/GID Mapper</h1>)",
+      client_name);
+
+  const Json::Value& m = json_value["uid_gid_map"];
+  if (!m.isObject()) {
+    LOG(ERROR) << fmt::format("uid_gid_map is not an object.");
+    os << "</body></html>";
+    return;
+  }
+
+  const bool enabled = m["enabled"].asBool();
+  const std::string salt = m["salt"].asString();
+  const uint64_t last_refresh_ms = m["last_refresh_time_ms"].asUInt64();
+  const uint64_t uid_count = m["uid_count"].asUInt64();
+  const uint64_t gid_count = m["gid_count"].asUInt64();
+  const Json::Value& entries = m["entries"];
+
+  // Status card.
+  os << R"(<div style="margin:12px;font-size:smaller;">)";
+  os << R"(<h3>Status</h3>)";
+  os << fmt::format("enabled: {}", enabled ? "true" : "false");
+  os << "<br>";
+  os << fmt::format("salt: {}", salt);
+  os << "<br>";
+  os << fmt::format(
+      "last refresh: {}",
+      last_refresh_ms == 0 ? std::string("never")
+                           : utils::FormatMsTime(last_refresh_ms));
+  os << "<br>";
+  os << fmt::format("uid entries: {}", uid_count);
+  os << "<br>";
+  os << fmt::format("gid entries: {}", gid_count);
+  os << "</div>";
+
+  // Unified entries table.
+  os << R"(<div style="margin:12px;font-size:smaller;">)";
+  os << fmt::format(R"(<h3>Entries [{}]</h3>)", entries.size());
+  os << R"(<table class="gridtable sortable" border=1 style="width:50%;min-width:500px;white-space:nowrap;">)";
+  os << R"(<tr><th style="padding:4px 10px;">Hashed ID</th><th style="padding:4px 4px;width:48px;">Type</th><th style="padding:4px 10px;">Details<br>(uid|gid, name)</th></tr>)";
+  for (const auto& row : entries) {
+    const Json::Value& mappings = row["mappings"];
+    os << "<tr>";
+    os << "<td>" << row["hashed_id"].asUInt64() << "</td>";
+    os << "<td>" << row["type"].asString() << "</td>";
+    os << "<td>";
+    for (Json::ArrayIndex i = 0; i < mappings.size(); ++i) {
+      const auto& m_entry = mappings[i];
+      // mappings[0] = winner (black); mappings[1..] = collision losers (red).
+      const bool loser = (i > 0);
+      const std::string line = fmt::format("{}, {}",
+                                            m_entry["local_id"].asUInt(),
+                                            m_entry["name"].asString());
+      if (loser) {
+        os << fmt::format(R"(<span class="red-text">{}</span>)", line);
+      } else {
+        os << line;
+      }
+      if (i + 1 < mappings.size()) os << "<br>";
+    }
+    os << "</td>";
+    os << "</tr>";
+  }
+  os << "</table></div>";
+
+  os << "<br>";
+  os << "</body></html>";
+}
+
 void ClientStatServiceImpl::RenderMainPage(const brpc::Server* server,
                                            butil::IOBufBuilder& os) {
   os << "<!DOCTYPE html><html>\n";
@@ -1454,6 +1530,10 @@ void ClientStatServiceImpl::RenderMainPage(const brpc::Server* server,
     os << "</html>";
     return;
   }
+
+  Json::Value uid_gid_mapper_value = Json::objectValue;
+  vfs_hub_->GetUidGidMapper()->Summary(uid_gid_mapper_value);
+  summary_value.append(uid_gid_mapper_value);
 
   // client info
   RenderClientInfo(meta_value, os);
@@ -1581,6 +1661,10 @@ void ClientStatServiceImpl::default_method(
       if (blockcache != nullptr && blockcache->Dump(json_value)) {
         RenderBlockCachePage(json_value, os, client_name);
       }
+    } else if (api_name == "uidgidmap") {
+      // /ClientStatService/uidgidmap
+      vfs_hub_->GetUidGidMapper()->Dump(json_value);
+      RenderUidGidMapperPage(json_value, os, client_name);
     } else {
       return cntl->SetFailed("unknown path: " + path);  // NOLINT
     }

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -32,6 +32,7 @@
 #include "client/vfs/data/writer/file_writer.h"
 #include "client/vfs/data_buffer.h"
 #include "client/vfs/handle/handle_manager.h"
+#include "client/vfs/components/uid_gid_mapper.h"
 #include "client/vfs/vfs_fh.h"
 #include "client/vfs/vfs_xattr.h"
 #include "common/blockaccess/accesser_common.h"
@@ -57,6 +58,42 @@
 namespace dingofs {
 namespace client {
 namespace vfs {
+
+// Translate a single host-local uid/gid to the hashed id used by MDS
+// (client->mds).
+static uint32_t LocalIdToHashedId(UidGidMapper* mapper,
+                                  UidGidMapper::Kind kind,
+                                  uint32_t local_id) {
+  return mapper != nullptr ? mapper->LocalIdToHashedId(kind, local_id)
+                           : local_id;
+}
+
+uint32_t VFSImpl::LocalUidToHashed(uint32_t uid) const {
+  return LocalIdToHashedId(vfs_hub_->GetUidGidMapper(),
+                           UidGidMapper::Kind::kUid, uid);
+}
+
+uint32_t VFSImpl::LocalGidToHashed(uint32_t gid) const {
+  return LocalIdToHashedId(vfs_hub_->GetUidGidMapper(),
+                           UidGidMapper::Kind::kGid, gid);
+}
+
+void VFSImpl::TranslateAttrToLocal(Attr* attr) const {
+  auto* mapper = vfs_hub_->GetUidGidMapper();
+  if (mapper == nullptr) return;
+  mapper->HashedPairToLocal(attr->uid, attr->gid, attr->uid, attr->gid);
+}
+
+void VFSImpl::LocalPairToHashed(uint32_t uid, uint32_t gid,
+                                uint32_t& out_uid, uint32_t& out_gid) const {
+  auto* mapper = vfs_hub_->GetUidGidMapper();
+  if (mapper == nullptr) {
+    out_uid = uid;
+    out_gid = gid;
+    return;
+  }
+  mapper->LocalPairToHashed(uid, gid, out_uid, out_gid);
+}
 
 VFSImpl::VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id)
     : client_id_(client_id),
@@ -237,6 +274,7 @@ Status VFSImpl::Lookup(ContextSPtr ctx, Ino parent, const std::string& name,
 
   Status s = meta_system_->Lookup(ctx, TranslateIno(parent), name, attr);
   if (s.ok()) {
+    TranslateAttrToLocal(attr);
     vfs_hub_->GetFileSuffixWatcher()->Remeber(*attr, name);
   }
   return s;
@@ -255,7 +293,10 @@ Status VFSImpl::GetAttr(ContextSPtr ctx, Ino ino, Attr* attr) {
   }
 
   Status s = meta_system_->GetAttr(ctx, TranslateIno(ino), attr);
-  if (s.ok()) RewriteRootAttr(ino, attr);
+  if (s.ok()) {
+    RewriteRootAttr(ino, attr);
+    TranslateAttrToLocal(attr);
+  }
 
   return s;
 }
@@ -266,9 +307,16 @@ Status VFSImpl::SetAttr(ContextSPtr ctx, Ino ino, int set, const Attr& in_attr,
     return Status::OK();
   }
 
+  Attr send_attr = in_attr;
+  if (set & kSetAttrUid) send_attr.uid = LocalUidToHashed(in_attr.uid);
+  if (set & kSetAttrGid) send_attr.gid = LocalGidToHashed(in_attr.gid);
+
   Status s =
-      meta_system_->SetAttr(ctx, TranslateIno(ino), set, in_attr, out_attr);
-  if (s.ok()) RewriteRootAttr(ino, out_attr);
+      meta_system_->SetAttr(ctx, TranslateIno(ino), set, send_attr, out_attr);
+  if (s.ok()) {
+    RewriteRootAttr(ino, out_attr);
+    TranslateAttrToLocal(out_attr);
+  }
 
   // Truncate (size change) must invalidate cached read buffers — readahead
   // buffers in FileReader::requests_ are indexed by (ino, frange) and would
@@ -344,6 +392,8 @@ Status VFSImpl::CopyFileRange(ContextSPtr ctx, Ino src_ino, uint64_t src_off,
                                   bytes_copied, &dst_attr);
   if (!s.ok()) return s;
 
+  TranslateAttrToLocal(&dst_attr);
+
   // Invalidate any in-flight reader caches for the rewritten dst range.
   if (*bytes_copied > 0) {
     handle_manager_->InvalidateByIno(dst_ino, static_cast<int64_t>(dst_off),
@@ -364,9 +414,12 @@ Status VFSImpl::MkNod(ContextSPtr ctx, Ino parent, const std::string& name,
     return Status::NoPermitted("cannot mknod in trash");
   }
 
-  Status s = meta_system_->MkNod(ctx, TranslateIno(parent), name, uid, gid,
+  uint32_t s_uid = 0, s_gid = 0;
+  LocalPairToHashed(uid, gid, s_uid, s_gid);
+  Status s = meta_system_->MkNod(ctx, TranslateIno(parent), name, s_uid, s_gid,
                                  mode, dev, attr);
   if (s.ok()) {
+    TranslateAttrToLocal(attr);
     vfs_hub_->GetFileSuffixWatcher()->Remeber(*attr, name);
   }
 
@@ -410,8 +463,12 @@ Status VFSImpl::Symlink(ContextSPtr ctx, Ino parent, const std::string& name,
     return Status::NoPermitted("Can not symlink to internal node");
   }
 
-  return meta_system_->Symlink(ctx, TranslateIno(parent), name, uid, gid, link,
-                               attr);
+  uint32_t s_uid = 0, s_gid = 0;
+  LocalPairToHashed(uid, gid, s_uid, s_gid);
+  Status s = meta_system_->Symlink(ctx, TranslateIno(parent), name, s_uid,
+                                   s_gid, link, attr);
+  if (s.ok()) TranslateAttrToLocal(attr);
+  return s;
 }
 
 Status VFSImpl::Rename(ContextSPtr ctx, Ino old_parent,
@@ -456,6 +513,7 @@ Status VFSImpl::Link(ContextSPtr ctx, Ino ino, Ino new_parent,
   Status s = meta_system_->Link(ctx, TranslateIno(ino),
                                 TranslateIno(new_parent), new_name, attr);
   if (s.ok()) {
+    TranslateAttrToLocal(attr);
     vfs_hub_->GetFileSuffixWatcher()->Forget(ino);
   }
 
@@ -523,9 +581,12 @@ Status VFSImpl::Create(ContextSPtr ctx, Ino parent, const std::string& name,
   }
 
   uint64_t gfh = vfs::FhGenerator::GenFh();
-  Status s = meta_system_->Create(ctx, TranslateIno(parent), name, uid, gid,
+  uint32_t s_uid = 0, s_gid = 0;
+  LocalPairToHashed(uid, gid, s_uid, s_gid);
+  Status s = meta_system_->Create(ctx, TranslateIno(parent), name, s_uid, s_gid,
                                   mode, flags, attr, gfh);
   if (s.ok()) {
+    TranslateAttrToLocal(attr);
     CHECK_GT(attr->ino, 0) << "ino in attr is null";
     Ino ino = attr->ino;
 
@@ -754,8 +815,12 @@ Status VFSImpl::MkDir(ContextSPtr ctx, Ino parent, const std::string& name,
     return Status::NoPermitted("cannot mkdir in trash");
   }
 
-  return meta_system_->MkDir(ctx, TranslateIno(parent), name, uid, gid, mode,
-                             attr);
+  uint32_t s_uid = 0, s_gid = 0;
+  LocalPairToHashed(uid, gid, s_uid, s_gid);
+  Status s = meta_system_->MkDir(ctx, TranslateIno(parent), name, s_uid, s_gid,
+                                 mode, attr);
+  if (s.ok()) TranslateAttrToLocal(attr);
+  return s;
 }
 
 Status VFSImpl::OpenDir(ContextSPtr ctx, Ino ino, uint64_t* fh,
@@ -780,8 +845,19 @@ Status VFSImpl::ReadDir(ContextSPtr ctx, Ino ino, uint64_t fh, uint64_t offset,
     }
   }
 
+  auto* mapper = vfs_hub_->GetUidGidMapper();
+  ReadDirHandler wrapped =
+      (with_attr && mapper != nullptr)
+          ? ReadDirHandler(
+                [this, &handler](const DirEntry& entry, uint64_t off) {
+                  DirEntry e = entry;
+                  TranslateAttrToLocal(&e.attr);
+                  return handler(e, off);
+                })
+          : handler;
+
   return meta_system_->ReadDir(ctx, TranslateIno(ino), fh, offset, with_attr,
-                               handler, count);
+                               wrapped, count);
 }
 
 Status VFSImpl::ReleaseDir(ContextSPtr ctx, Ino ino, uint64_t fh) {

--- a/src/client/vfs/vfs_impl.h
+++ b/src/client/vfs/vfs_impl.h
@@ -169,6 +169,19 @@ class VFSImpl : public VFS {
     return (ino == kRootIno) ? mount_root_ino_ : ino;
   }
 
+  // Translate a host-local uid/gid to the hashed id used by MDS, using this
+  // mount's UidGidMapper. Identity when uid/gid mapping is disabled.
+  uint32_t LocalUidToHashed(uint32_t uid) const;
+  uint32_t LocalGidToHashed(uint32_t gid) const;
+
+  // Translate a (uid, gid) outbound pair under a single read lock.
+  void LocalPairToHashed(uint32_t uid, uint32_t gid,
+                         uint32_t& out_uid, uint32_t& out_gid) const;
+
+  // Rewrite an Attr's uid/gid from MDS hashed ids back to host-local, using
+  // this mount's UidGidMapper. No-op when uid/gid mapping is disabled.
+  void TranslateAttrToLocal(Attr* attr) const;
+
   // If `ino` matches the real mount-root inode in subdir mode, rewrite
   // `attr->ino` back to `kRootIno` so FUSE sees a stable root.
   void RewriteRootAttr(Ino req_ino, Attr* attr) const {

--- a/src/client/vfs/vfs_meta.h
+++ b/src/client/vfs/vfs_meta.h
@@ -144,6 +144,8 @@ struct FsInfo {
   // Trash retention days; 0 means trash is disabled. Pinned at mount time;
   // runtime `updatefs --trash_days=...` requires remount to take effect.
   uint32_t trash_days{0};
+  // 是否对本 fs 启用 uid/gid 自动映射（runtime-mutable，可经心跳热切换）。
+  bool enable_uid_gid_map{false};
 };
 
 using DoneClosure = std::function<void(const Status& status)>;

--- a/src/mds/client/main.cc
+++ b/src/mds/client/main.cc
@@ -97,6 +97,11 @@ DEFINE_bool(immediate_trash_quota, true,
             "(credited back on restore); when false, the debit is deferred to GC. "
             "Applied at createfs only and immutable thereafter.");
 
+DEFINE_bool(enable_uid_gid_map, true,
+            "per-fs: when true, client hashes local user/group names into "
+            "internal ids in [10000, 2^32). "
+            "ALL mounting clients of this fs must support the feature.");
+
 static std::string GetDefaultCoorAddrPath() {
   if (!FLAGS_coor_addr.empty()) {
     return FLAGS_coor_addr;
@@ -227,6 +232,7 @@ int main(int argc, char* argv[]) {
 
     options.trash_days = FLAGS_trash_days;
     options.immediate_trash_quota = FLAGS_immediate_trash_quota;
+    options.enable_uid_gid_map = FLAGS_enable_uid_gid_map;
     // trash restore
     options.trash_put_back = FLAGS_put_back;
     options.trash_threads = FLAGS_restore_threads;

--- a/src/mds/client/mds.cc
+++ b/src/mds/client/mds.cc
@@ -151,6 +151,7 @@ CreateFsResponse MDSClient::CreateFs(const std::string& fs_name, const CreateFsP
   request.set_recycle_time_hour(1);
   request.set_trash_days(params.trash_days);
   request.set_immediate_trash_quota(params.immediate_trash_quota);
+  request.set_enable_uid_gid_map(params.enable_uid_gid_map);
 
   if (params.partition_type == "mono") {
     request.set_partition_type(::dingofs::pb::mds::PartitionType::MONOLITHIC_PARTITION);
@@ -1558,6 +1559,27 @@ void MDSClient::UpdateFsTrashDays(const std::string& fs_name, uint32_t trash_day
   UpdateFs(fs_name, fs_info);
 }
 
+void MDSClient::UpdateFsEnableUidGidMap(const std::string& fs_name, bool enable) {
+  if (fs_name.empty()) {
+    std::cerr << "fs_name is empty\n";
+    return;
+  }
+
+  auto fs_response = GetFs(fs_name);
+  pb::mds::FsInfo fs_info;
+  fs_info.CopyFrom(fs_response.fs_info());
+  if (fs_info.fs_id() == 0) {
+    std::cerr << "not found fs: " << fs_name << "\n";
+    return;
+  }
+
+  // Read-modify-write: every UpdateFsInfo call must round-trip the full
+  // current FsInfo. Only flip the one field; the server merges all known
+  // runtime-mutable fields including this one (store_operation.cc:594).
+  fs_info.set_enable_uid_gid_map(enable);
+  UpdateFs(fs_name, fs_info);
+}
+
 bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr, const std::string& cmd,
                            uint32_t fs_id) {
   static std::set<std::string> mds_cmd = {
@@ -1599,6 +1621,7 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr, 
       "deletemember",
       "restoretrash",
       "updatefstrashdays",
+      "updatefsenableuidgidmap",
   };
 
   if (mds_cmd.count(cmd) == 0) return false;
@@ -1629,6 +1652,7 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr, 
     params.expect_mds_num = options.num;
     params.trash_days = options.trash_days;
     params.immediate_trash_quota = options.immediate_trash_quota;
+    params.enable_uid_gid_map = options.enable_uid_gid_map;
 
     mds_client.CreateFs(options.fs_name, params);
 
@@ -1646,6 +1670,9 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr, 
 
   } else if (cmd == Helper::ToLowerCase("UpdateFsTrashDays")) {
     mds_client.UpdateFsTrashDays(options.fs_name, options.trash_days);
+
+  } else if (cmd == Helper::ToLowerCase("UpdateFsEnableUidGidMap")) {
+    mds_client.UpdateFsEnableUidGidMap(options.fs_name, options.enable_uid_gid_map);
 
   } else if (cmd == Helper::ToLowerCase("GetFs")) {
     mds_client.GetFs(options.fs_name);

--- a/src/mds/client/mds.h
+++ b/src/mds/client/mds.h
@@ -212,6 +212,9 @@ class MDSClient {
     uint32_t trash_days;
     // Create-time only. When true, trash-move debits parent quota immediately.
     bool immediate_trash_quota{true};
+    // See FsInfo.enable_uid_gid_map. Runtime-mutable (clients hot-apply via
+    // heartbeat).
+    bool enable_uid_gid_map{false};
   };
 
   CreateFsResponse CreateFs(const std::string& fs_name, const CreateFsParams& params);
@@ -296,6 +299,7 @@ class MDSClient {
   void UpdateFsS3Info(const std::string& fs_name, const S3Info& s3_info);
   void UpdateFsRadosInfo(const std::string& fs_name, const RadosInfo& rados_info);
   void UpdateFsTrashDays(const std::string& fs_name, uint32_t trash_days);
+  void UpdateFsEnableUidGidMap(const std::string& fs_name, bool enable);
 
  private:
   uint32_t fs_id_{0};
@@ -339,6 +343,7 @@ class MdsCommandRunner {
     //trash
     uint32_t trash_days{0};
     bool immediate_trash_quota{true};
+    bool enable_uid_gid_map{false};
 
     // trash restore (`restoretrash` subcommand)
     std::vector<std::string> trash_hours;

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -3804,6 +3804,7 @@ FsInfoEntry FileSystemSet::GenFsInfo(uint32_t fs_id, const CreateFsParam& param)
                                                             : FLAGS_mds_filesystem_recycle_time_hour);
   fs_info.set_trash_days(param.trash_days);
   fs_info.set_immediate_trash_quota(param.immediate_trash_quota);
+  fs_info.set_enable_uid_gid_map(param.enable_uid_gid_map);
   fs_info.mutable_extra()->CopyFrom(param.fs_extra);
   fs_info.set_uuid(utils::GenerateUUID());
 

--- a/src/mds/filesystem/filesystem.h
+++ b/src/mds/filesystem/filesystem.h
@@ -457,6 +457,9 @@ class FileSystemSet {
     // Create-time only. true = debit parent/ancestor quota immediately at
     // trash-move (restore credits back); false = defer to CleanTrashTask.
     bool immediate_trash_quota{false};
+    // Runtime-mutable. true = clients hash username/groupname into reserved
+    // segment [10000, 2^32). Stored uid/gid become internal IDs.
+    bool enable_uid_gid_map{false};
     pb::mds::PartitionType partition_type;
     uint32_t expect_mds_num{0};  // for hash partition
     std::vector<uint64_t> candidate_mds_ids;

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -591,6 +591,10 @@ Status UpdateFsOperation::Run(TxnUPtr& txn) {
   if (fs_info_.recycle_time_hour() > 0) new_fs_info.set_recycle_time_hour(fs_info_.recycle_time_hour());
   new_fs_info.set_trash_days(fs_info_.trash_days());
   // immediate_trash_quota is create-time only: deliberately not merged here.
+  // enable_uid_gid_map is a runtime-mutable toggle: callers are expected to
+  // GetFsInfo, flip the flag, and UpdateFsInfo with the full record (the
+  // same read-modify-write convention used for trash_days above).
+  new_fs_info.set_enable_uid_gid_map(fs_info_.enable_uid_gid_map());
   if (fs_info_.has_extra() && fs_info_.extra().has_s3_info()) {
     const auto& s3_info = fs_info_.extra().s3_info();
     auto* mut_s3_info = new_fs_info.mutable_extra()->mutable_s3_info();

--- a/src/mds/service/fsstat_service.cc
+++ b/src/mds/service/fsstat_service.cc
@@ -247,6 +247,7 @@ static void RenderFsInfo(const std::vector<pb::mds::FsInfo>& fs_infoes, butil::I
   os << "<th>Owner</th>";
   os << "<th>Navigation</th>";
   os << "<th>Time</th>";
+  os << "<th>EnableUidGidMap</th>";
   os << "<th>Trash</th>";
   os << "<th>RecycleTime</th>";
   os << "<th>MountPoint</th>";
@@ -272,6 +273,7 @@ static void RenderFsInfo(const std::vector<pb::mds::FsInfo>& fs_infoes, butil::I
     os << "<td>" << fs_info.owner() << "</td>";
     os << "<td>" << render_navigation_func(fs_info) << "</td>";
     os << "<td>" << render_time_func(fs_info) << "</td>";
+    os << "<td>" << (fs_info.enable_uid_gid_map() ? "On" : "Off") << "</td>";
     os << "<td>"
        << fmt::format("trash_days: {}<br>immediate_trash_quota: {}", fs_info.trash_days(),
                       fs_info.immediate_trash_quota() ? "true" : "false")

--- a/src/mds/service/mds_service.cc
+++ b/src/mds/service/mds_service.cc
@@ -207,6 +207,14 @@ void MDSServiceImpl::DoHeartbeat(google::protobuf::RpcController*, const pb::mds
       file_system->AsyncKeepAliveFileSession(Helper::PbRepeatedToVector(client_info.file_sessions()));
     }
 
+    // Piggyback FsInfo.version so the client can detect runtime-mutable
+    // field changes (e.g. enable_uid_gid_map) without a separate poll.
+    auto file_system = GetFileSystem(client_info.fs_id());
+    if (file_system != nullptr) {
+      response->mutable_client()->set_last_fs_version(
+          file_system->GetFsInfo().version());
+    }
+
   } else if (request->role() == pb::mds::ROLE_CACHE_MEMBER) {
     auto span = StartSpan("MDSServiceImpl::CacheMemberSendHeartbeat", request->info());
     auto cache_member = request->cache_group_member();
@@ -294,6 +302,7 @@ void MDSServiceImpl::DoCreateFs(google::protobuf::RpcController*, const pb::mds:
   param.recycle_time_hour = request->recycle_time_hour();
   param.trash_days = request->trash_days();
   param.immediate_trash_quota = request->immediate_trash_quota();
+  param.enable_uid_gid_map = request->enable_uid_gid_map();
   param.partition_type = request->partition_type();
   param.expect_mds_num = request->expect_mds_num();
   param.candidate_mds_ids = Helper::PbRepeatedToVector(request->candidate_mds_ids());

--- a/test/unit/client/vfs/components/passwd_watcher_test.cc
+++ b/test/unit/client/vfs/components/passwd_watcher_test.cc
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/vfs/components/passwd_watcher.h"
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+namespace test {
+
+namespace {
+
+// Counts callback invocations and lets a test block until at least `n` fire.
+class Latch {
+ public:
+  void Fire() {
+    std::lock_guard<std::mutex> lk(mu_);
+    ++count_;
+    cv_.notify_all();
+  }
+
+  // Returns true once count_ >= n within the timeout.
+  bool WaitFor(int n, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lk(mu_);
+    return cv_.wait_for(lk, timeout, [&] { return count_ >= n; });
+  }
+
+  int Count() {
+    std::lock_guard<std::mutex> lk(mu_);
+    return count_;
+  }
+
+ private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+  int count_ = 0;
+};
+
+// Writes `name` inside `dir` by creating a temp file and rename()-ing it over
+// the target — mirrors how useradd/vipw replace /etc/passwd (IN_MOVED_TO).
+void RenameInto(const std::string& dir, const std::string& name) {
+  std::string tmp = dir + "/." + name + ".tmp";
+  std::string dst = dir + "/" + name;
+  int fd = ::open(tmp.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  ASSERT_GE(fd, 0) << std::strerror(errno);
+  ASSERT_EQ(::write(fd, "x\n", 2), 2);
+  ASSERT_EQ(::close(fd), 0);
+  ASSERT_EQ(::rename(tmp.c_str(), dst.c_str()), 0) << std::strerror(errno);
+}
+
+}  // namespace
+
+class PasswdWatcherTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    char tmpl[] = "/tmp/dingofs_pwwatch_XXXXXX";
+    char* p = ::mkdtemp(tmpl);
+    ASSERT_NE(p, nullptr) << std::strerror(errno);
+    dir_ = p;
+  }
+
+  void TearDown() override {
+    if (dir_.empty()) return;
+    // Best-effort cleanup of the entries a test might have created.
+    for (const char* name : {"passwd", "group", "unrelated"}) {
+      ::unlink((dir_ + "/" + name).c_str());
+    }
+    ::rmdir(dir_.c_str());
+  }
+
+  std::string dir_;
+};
+
+TEST_F(PasswdWatcherTest, FiresOnWatchedFileChange) {
+  Latch latch;
+  PasswdWatcher watcher(dir_, {"passwd", "group"}, [&] { latch.Fire(); });
+  ASSERT_TRUE(watcher.Start());
+
+  RenameInto(dir_, "passwd");
+
+  EXPECT_TRUE(latch.WaitFor(1, std::chrono::seconds(3)))
+      << "callback did not fire after watched file changed";
+  watcher.Stop();
+}
+
+TEST_F(PasswdWatcherTest, IgnoresUnwatchedFile) {
+  Latch latch;
+  PasswdWatcher watcher(dir_, {"passwd", "group"}, [&] { latch.Fire(); });
+  ASSERT_TRUE(watcher.Start());
+
+  RenameInto(dir_, "unrelated");
+
+  // Give the watcher ample time; an unwatched name must never trigger.
+  EXPECT_FALSE(latch.WaitFor(1, std::chrono::milliseconds(800)));
+  EXPECT_EQ(latch.Count(), 0);
+  watcher.Stop();
+}
+
+TEST_F(PasswdWatcherTest, CoalescesBurstIntoOneCallback) {
+  Latch latch;
+  PasswdWatcher watcher(dir_, {"passwd", "group"}, [&] { latch.Fire(); });
+  ASSERT_TRUE(watcher.Start());
+
+  // One useradd touches passwd + group back to back; expect a single rebuild.
+  RenameInto(dir_, "passwd");
+  RenameInto(dir_, "group");
+
+  ASSERT_TRUE(latch.WaitFor(1, std::chrono::seconds(3)));
+  // Let any stragglers arrive, then assert the burst collapsed.
+  EXPECT_FALSE(latch.WaitFor(2, std::chrono::milliseconds(800)));
+  EXPECT_EQ(latch.Count(), 1);
+  watcher.Stop();
+}
+
+TEST_F(PasswdWatcherTest, StopIsIdempotent) {
+  PasswdWatcher watcher(dir_, {"passwd"}, [] {});
+  ASSERT_TRUE(watcher.Start());
+  watcher.Stop();
+  watcher.Stop();  // must not hang or crash
+}
+
+}  // namespace test
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/vfs/components/uid_gid_mapper_concurrent_test.cc
+++ b/test/unit/client/vfs/components/uid_gid_mapper_concurrent_test.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "client/vfs/components/uid_gid_mapper.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+namespace test {
+
+class CycleSource : public PasswdSource {
+ public:
+  std::vector<UserRecord> ListUsersWithPrimaryGid() override {
+    return {{"alice", 1001, 1001}, {"bob", 1002, 1002}, {"carol", 1003, 0}};
+  }
+  std::vector<std::pair<std::string, uint32_t>> ListGroups() override {
+    return {{"alice", 1001}, {"bob", 1002}};
+  }
+};
+
+// Source whose ListUsersWithPrimaryGid/ListGroups always return empty so every
+// Rebuild() produces an empty snapshot. Outbound lookups therefore always miss
+// and pass through, exercising the reader read-lock against the refresher's
+// table swap.
+class EmptyListSource : public PasswdSource {
+ public:
+  std::vector<UserRecord> ListUsersWithPrimaryGid() override { return {}; }
+  std::vector<std::pair<std::string, uint32_t>> ListGroups() override {
+    return {};
+  }
+};
+
+TEST(UidGidMapperConcurrent, ReadersAndRefresherRace) {
+  UidGidMapper m(true, "salt", std::make_unique<CycleSource>());
+  m.Refresh();
+  // Precompute the real hashed IDs for alice so the full inbound lookup path
+  // (uid_reverse_ + uid_name_to_local_) is exercised under contention.
+  // Refresh() synchronously primes the snapshot so LocalIdToHashedId below hits
+  // the fast path.
+  const uint32_t alice_uid_hash = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  const uint32_t alice_gid_hash = m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1001);
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> readers;
+  for (int i = 0; i < 64; ++i) {
+    readers.emplace_back([&] {
+      while (!stop.load(std::memory_order_relaxed)) {
+        // Hit path: exercises reverse_ + name_to_local_ under contention.
+        (void)m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+        (void)m.HashedIdToLocalId(UidGidMapper::Kind::kUid, alice_uid_hash);
+        (void)m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1001);
+        (void)m.HashedIdToLocalId(UidGidMapper::Kind::kGid, alice_gid_hash);
+        // Miss path: short-circuits at reverse_ map lookup.
+        (void)m.HashedIdToLocalId(UidGidMapper::Kind::kUid, 0xCAFEBABEu);
+        (void)m.HashedIdToLocalId(UidGidMapper::Kind::kGid, 0xDEADBEEFu);
+      }
+    });
+  }
+  std::thread refresher([&] {
+    for (int i = 0; i < 50 && !stop.load(); ++i) {
+      m.Refresh();
+    }
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  stop.store(true);
+  for (auto& t : readers) t.join();
+  refresher.join();
+}
+
+TEST(UidGidMapperConcurrent, OutboundMissVsRebuildRace) {
+  // ListUsers returns empty so every outbound call misses the snapshot and
+  // passes through under the read lock. The refresher repeatedly swaps the
+  // tables under the write lock. ASan/TSan pick up any data race between the
+  // reader's read-lock and the refresher's table swap; functional check is
+  // "no crash".
+  UidGidMapper m(true, "salt", std::make_unique<EmptyListSource>());
+  m.Refresh();
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> readers;
+  for (int i = 0; i < 32; ++i) {
+    readers.emplace_back([&, i] {
+      uint32_t seed = static_cast<uint32_t>(i) * 7919u + 17u;
+      while (!stop.load(std::memory_order_relaxed)) {
+        // Spread queries across uids in [1, kLocalUidMax) to exercise both
+        // newly-inserted and previously-inserted entries against the
+        // refresher's wipe.
+        uint32_t uid = 1 + (seed % (UidGidMapper::kLocalUidMax - 1));
+        seed = seed * 1103515245u + 12345u;
+        (void)m.LocalIdToHashedId(UidGidMapper::Kind::kUid, uid);
+        (void)m.LocalIdToHashedId(UidGidMapper::Kind::kGid, uid);
+      }
+    });
+  }
+  std::thread refresher([&] {
+    for (int i = 0; i < 200 && !stop.load(); ++i) {
+      m.Refresh();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  stop.store(true);
+  for (auto& t : readers) t.join();
+  refresher.join();
+}
+
+}  // namespace test
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/vfs/components/uid_gid_mapper_test.cc
+++ b/test/unit/client/vfs/components/uid_gid_mapper_test.cc
@@ -1,0 +1,655 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "client/vfs/components/uid_gid_mapper.h"
+#include "json/value.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+namespace test {
+
+namespace {
+
+// Shared helper: snapshot is table-driven so tests can configure the
+// per-uid/gid presence Refresh() will install. Pgid is always 0 — tests that
+// care about the fast-path cookie should use PgidAwareSource further below.
+class TableSource : public PasswdSource {
+ public:
+  explicit TableSource(std::vector<std::pair<std::string, uint32_t>> users = {},
+                       std::vector<std::pair<std::string, uint32_t>> groups = {})
+      : users_(std::move(users)), groups_(std::move(groups)) {}
+
+  std::vector<UserRecord> ListUsersWithPrimaryGid() override {
+    std::vector<UserRecord> out;
+    out.reserve(users_.size());
+    for (const auto& [name, uid] : users_) {
+      out.push_back({name, uid, 0});
+    }
+    return out;
+  }
+  std::vector<std::pair<std::string, uint32_t>> ListGroups() override {
+    return groups_;
+  }
+
+  void SetUsers(std::vector<std::pair<std::string, uint32_t>> v) {
+    users_ = std::move(v);
+  }
+  void SetGroups(std::vector<std::pair<std::string, uint32_t>> v) {
+    groups_ = std::move(v);
+  }
+
+ private:
+  std::vector<std::pair<std::string, uint32_t>> users_;
+  std::vector<std::pair<std::string, uint32_t>> groups_;
+};
+
+}  // namespace
+
+TEST(UidGidMapperTest, DisabledIsPassthrough) {
+  UidGidMapper m(/*enabled=*/false, "salt", std::make_unique<LibcPasswdSource>());
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), 1001u);
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, 0xDEADBEEFu), 0xDEADBEEFu);
+}
+
+TEST(UidGidMapperTest, EnabledOutbound_HashesIntoReservedRange) {
+  UidGidMapper m(/*enabled=*/true, "salt-X",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}}));
+  m.Refresh();
+  uint32_t a = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  uint32_t b = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  EXPECT_EQ(a, b);
+  EXPECT_GE(a, UidGidMapper::kLocalUidMax);
+}
+
+TEST(UidGidMapperTest, EnabledOutbound_DifferentSaltDifferentId) {
+  auto make = [] {
+    return std::make_unique<TableSource>(
+        std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}});
+  };
+  UidGidMapper m1(true, "salt-A", make());
+  m1.Refresh();
+  UidGidMapper m2(true, "salt-B", make());
+  m2.Refresh();
+  EXPECT_NE(m1.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), m2.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001));
+}
+
+TEST(UidGidMapperTest, OutboundRoot_AlwaysZero) {
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"root", 0}},
+                     std::vector<std::pair<std::string, uint32_t>>{{"root", 0}}));
+  m.Refresh();
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 0), 0u);
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 0), 0u);
+}
+
+TEST(UidGidMapperTest, OutboundRangeFuzz_AllInReservedRange) {
+  std::vector<std::pair<std::string, uint32_t>> users;
+  for (uint32_t i = 0; i < 1000; ++i) {
+    users.emplace_back("user_" + std::to_string(i), 2000 + i);
+  }
+  UidGidMapper m(true, "salt-X",
+                 std::make_unique<TableSource>(std::move(users)));
+  m.Refresh();
+  for (uint32_t i = 0; i < 1000; ++i) {
+    uint32_t h = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 2000 + i);
+    EXPECT_GE(h, UidGidMapper::kLocalUidMax);
+  }
+}
+
+namespace {
+// Convenience: TableSource pre-populated with alice@local_uid in both users
+// and groups.
+std::unique_ptr<TableSource> MakeAliceSource(uint32_t local_uid) {
+  return std::make_unique<TableSource>(
+      std::vector<std::pair<std::string, uint32_t>>{{"alice", local_uid}},
+      std::vector<std::pair<std::string, uint32_t>>{{"alice", local_uid}});
+}
+}  // namespace
+
+TEST(UidGidMapperTest, InboundRoot_AlwaysZero) {
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, 0), 0u);
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kGid, 0), 0u);
+}
+
+TEST(UidGidMapperTest, InboundBelowReserved_Passthrough) {
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, 1001), 1001u);  // raw caller uid stored by old client
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, 9999), 9999u);
+}
+
+TEST(UidGidMapperTest, InboundRoundtrip_AliceMapsBackToLocalUid) {
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  uint32_t hashed = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  ASSERT_GE(hashed, UidGidMapper::kLocalUidMax);
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, hashed), 1001u);
+}
+
+TEST(UidGidMapperTest, InboundDifferentHost_AliceMapsToHostLocalUid) {
+  UidGidMapper writer(true, "salt", MakeAliceSource(1001));
+  writer.Refresh();
+  uint32_t hashed = writer.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+
+  // simulate "host B" where alice=2002, same fs (same salt)
+  UidGidMapper reader(true, "salt", MakeAliceSource(2002));
+  reader.Refresh();
+  EXPECT_EQ(reader.HashedIdToLocalId(UidGidMapper::Kind::kUid, hashed), 2002u);
+}
+
+TEST(UidGidMapperTest, InboundReverseHitButGetpwnamMiss_ReturnsStoredId) {
+  // writer knows alice; reader knows no one
+  UidGidMapper writer(true, "salt", MakeAliceSource(1001));
+  writer.Refresh();
+  uint32_t hashed = writer.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+
+  UidGidMapper reader(true, "salt", std::make_unique<TableSource>());
+  reader.Refresh();
+  EXPECT_EQ(reader.HashedIdToLocalId(UidGidMapper::Kind::kUid, hashed), hashed);  // bare hash visible
+}
+
+TEST(UidGidMapperTest, InboundReverseMiss_ReturnsStoredId) {
+  UidGidMapper reader(true, "salt", MakeAliceSource(1001));
+  reader.Refresh();
+  EXPECT_EQ(reader.HashedIdToLocalId(UidGidMapper::Kind::kUid, 123456789u), 123456789u);
+}
+
+TEST(UidGidMapperTest, OutboundUnmappedLocalUid_Passthrough) {
+  // The snapshot only knows alice@1001; an outbound lookup for a uid that
+  // Refresh() never installed is a pure miss and passes through untranslated.
+  // There is no NSS fallback — the id is only translated once a Refresh()
+  // (PasswdWatcher-driven in production) installs it.
+  auto src = std::make_unique<TableSource>(
+      std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}});
+  UidGidMapper m(true, "salt", std::move(src));
+  m.Refresh();
+
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1500), 1500u);
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1500), 1500u);
+}
+
+TEST(UidGidMapperTest, OutboundMiss_LaterRebuildFindsIt) {
+  // After a miss, the source becomes aware of the user; the next Rebuild
+  // installs it into the snapshot so the subsequent lookup hashes it.
+  auto src = std::make_unique<TableSource>();
+  auto* src_raw = src.get();
+  UidGidMapper m(true, "salt", std::move(src));
+
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1500), 1500u);  // miss
+  src_raw->SetUsers({{"alice", 1500}});
+  m.Refresh();
+  uint32_t hashed = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1500);
+  EXPECT_GE(hashed, UidGidMapper::kLocalUidMax);
+}
+
+TEST(UidGidMapperTest, OutboundAboveReserved_Passthrough) {
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 12345), 12345u);
+}
+
+TEST(UidGidMapperTest, SetEnabled_HotToggleRoundtrip) {
+  auto src = std::make_unique<TableSource>(
+      std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}});
+  UidGidMapper m(true, "salt", std::move(src));
+  m.Refresh();
+
+  uint32_t hashed = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  ASSERT_GE(hashed, UidGidMapper::kLocalUidMax);
+
+  m.SetEnabled(false);
+  EXPECT_FALSE(m.IsEnabled());
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), 1001u);          // passthrough
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, hashed), hashed);        // passthrough
+
+  m.SetEnabled(true);
+  EXPECT_TRUE(m.IsEnabled());
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), hashed);         // translated again
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, hashed), 1001u);
+}
+
+TEST(LibcPasswdSourceTest, ListUsersWithPrimaryGidIncludesRoot) {
+  LibcPasswdSource src;
+  auto users = src.ListUsersWithPrimaryGid();
+  bool found_root = false;
+  for (const auto& u : users) {
+    if (u.name == "root" && u.uid == 0) {
+      found_root = true;
+      EXPECT_EQ(u.primary_gid, 0u) << "root's primary gid should be 0";
+      break;
+    }
+  }
+  EXPECT_TRUE(found_root) << "expected root user in /etc/passwd";
+}
+
+TEST(LibcPasswdSourceTest, ListGroupsIncludesRoot) {
+  LibcPasswdSource src;
+  auto groups = src.ListGroups();
+  bool found_root = false;
+  for (auto& [name, gid] : groups) {
+    if (name == "root" && gid == 0) { found_root = true; break; }
+  }
+  EXPECT_TRUE(found_root) << "expected root group in /etc/group";
+}
+
+TEST(UidGidMapperTest, Disabled_RefreshNoOps_ThenToggleOnRefreshFills) {
+  // Refresh() is a no-op while disabled — the snapshot stays empty, so even
+  // after SetEnabled(true) the first outbound still misses and passes through
+  // (no NSS fallback). A Refresh() after enabling — which production drives
+  // off the enable toggle via the heartbeat — installs the entry and the
+  // outbound then translates.
+  auto src = std::make_unique<TableSource>(
+      std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}});
+  UidGidMapper m(false, "salt", std::move(src));
+  m.Refresh();
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), 1001u);  // disabled: passthrough
+
+  m.SetEnabled(true);
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), 1001u);  // enabled but snapshot still empty
+  m.Refresh();
+  EXPECT_GE(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), UidGidMapper::kLocalUidMax);
+}
+
+namespace {
+
+// Lookup an entries[] row by (type, name) for tests. Searches `mappings`
+// inside each row so this also finds rows whose entry shares a hash with
+// another row (collision row's losers).
+const Json::Value* FindMapping(const Json::Value& entries, const char* type,
+                               const std::string& name) {
+  for (const auto& row : entries) {
+    if (row["type"].asString() != type) continue;
+    for (const auto& m : row["mappings"]) {
+      if (m["name"].asString() == name) return &m;
+    }
+  }
+  return nullptr;
+}
+
+const Json::Value* FindRowByHash(const Json::Value& entries, const char* type,
+                                 uint64_t hash) {
+  for (const auto& row : entries) {
+    if (row["type"].asString() == type &&
+        row["hashed_id"].asUInt64() == hash) {
+      return &row;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TEST(UidGidMapper, Dump_NoCollision_ProducesEntriesWithSingletonMappings) {
+  auto src = std::make_unique<TableSource>(
+      std::vector<std::pair<std::string, uint32_t>>{
+          {"bob", 2002}, {"alice", 1001}},
+      std::vector<std::pair<std::string, uint32_t>>{{"dev", 500}});
+  UidGidMapper m(true, "salt", std::move(src));
+  m.Refresh();
+
+  Json::Value out;
+  m.Dump(out);
+  const Json::Value& d = out["uid_gid_map"];
+  ASSERT_TRUE(d.isObject());
+  EXPECT_TRUE(d["enabled"].asBool());
+  EXPECT_EQ(d["salt"].asString(), "salt");
+  EXPECT_GT(d["last_refresh_time_ms"].asUInt64(), 0u);
+  EXPECT_EQ(d["uid_count"].asUInt64(), 2u);
+  EXPECT_EQ(d["gid_count"].asUInt64(), 1u);
+  EXPECT_FALSE(d["has_collisions"].asBool());
+
+  const Json::Value& entries = d["entries"];
+  ASSERT_EQ(entries.size(), 3u);
+
+  // Each row holds exactly one mapping when there is no collision.
+  for (const auto& row : entries) {
+    ASSERT_EQ(row["mappings"].size(), 1u) << row.toStyledString();
+  }
+
+  // Lookups by name across all entries (sort order is by encoded key,
+  // so we don't assert index positions).
+  const Json::Value* alice = FindMapping(entries, "uid", "alice");
+  ASSERT_NE(alice, nullptr);
+  EXPECT_EQ((*alice)["local_id"].asUInt(), 1001u);
+
+  const Json::Value* bob = FindMapping(entries, "uid", "bob");
+  ASSERT_NE(bob, nullptr);
+  EXPECT_EQ((*bob)["local_id"].asUInt(), 2002u);
+
+  const Json::Value* dev = FindMapping(entries, "gid", "dev");
+  ASSERT_NE(dev, nullptr);
+  EXPECT_EQ((*dev)["local_id"].asUInt(), 500u);
+}
+
+TEST(UidGidMapper, Dump_HashCollision_ReportsMappingsWithWinnerAndLoser) {
+  constexpr const char* kCollideU1 = "u_18475";
+  constexpr const char* kCollideU2 = "u_210073";
+  constexpr uint32_t kCollideUHash = 350950541u;
+
+  auto src = std::make_unique<TableSource>(
+      std::vector<std::pair<std::string, uint32_t>>{
+          {kCollideU1, 2002}, {kCollideU2, 1001}});
+  UidGidMapper m(true, "test-salt", std::move(src));
+  m.Refresh();
+
+  Json::Value out;
+  m.Dump(out);
+  const Json::Value& d = out["uid_gid_map"];
+  EXPECT_TRUE(d["has_collisions"].asBool());
+
+  const Json::Value* row =
+      FindRowByHash(d["entries"], "uid", kCollideUHash);
+  ASSERT_NE(row, nullptr);
+  const Json::Value& mappings = (*row)["mappings"];
+  ASSERT_EQ(mappings.size(), 2u);
+  // mappings[0] is the winner (smallest local_id).
+  EXPECT_EQ(mappings[0]["local_id"].asUInt(), 1001u);
+  EXPECT_EQ(mappings[0]["name"].asString(), kCollideU2);
+  EXPECT_EQ(mappings[1]["local_id"].asUInt(), 2002u);
+  EXPECT_EQ(mappings[1]["name"].asString(), kCollideU1);
+}
+
+// Hash-collision fixture: offline birthday search (Python + hashlib) on
+// HashToReserved(salt="test-salt", name="u_<i>") found the pair below
+// both folding to kCollideUHash. Re-run the search if the algorithm or
+// salt convention changes.
+TEST(UidGidMapper, Refresh_HashCollision_SmallerLocalUidWins) {
+  constexpr const char* kCollideU1 = "u_18475";
+  constexpr const char* kCollideU2 = "u_210073";
+  constexpr uint32_t kCollideUHash = 350950541u;
+
+  // Deliberately list the larger uid first to prove ListUsers ordering
+  // does not influence the outcome — the ascending sort in Refresh()
+  // should make the smaller local uid win the reverse table.
+  auto src = std::make_unique<TableSource>(
+      std::vector<std::pair<std::string, uint32_t>>{
+          {kCollideU1, 2002},
+          {kCollideU2, 1001},
+      });
+  UidGidMapper m(true, "test-salt", std::move(src));
+  m.Refresh();
+
+  // Sanity: outbound remains a pure function — both names route to the
+  // same hash regardless of who owns the reverse slot.
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 2002), kCollideUHash);
+  EXPECT_EQ(m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001), kCollideUHash);
+
+  // Reverse table is owned by the smaller local uid (1001 = kCollideU2).
+  EXPECT_EQ(m.HashedIdToLocalId(UidGidMapper::Kind::kUid, kCollideUHash), 1001u);
+}
+
+// ---- LocalPairToHashed: pair outbound translation ----
+
+TEST(UidGidMapperPair, OutboundDisabled_BothPassthrough) {
+  UidGidMapper m(/*enabled=*/false, "salt",
+                 std::make_unique<TableSource>());
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1001, 2002, ou, og);
+  EXPECT_EQ(ou, 1001u);
+  EXPECT_EQ(og, 2002u);
+}
+
+TEST(UidGidMapperPair, OutboundEqualInRange_UPG_OneFind) {
+  // user alice@1000 + group alice@1000 (UPG) — uid==gid AND uname==gname.
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1000}},
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1000}}));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1000, 1000, ou, og);
+  EXPECT_EQ(ou, m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1000));
+  EXPECT_EQ(og, m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1000));
+  EXPECT_EQ(ou, og);  // UPG: same name → same hash
+}
+
+TEST(UidGidMapperPair, OutboundEqualInRange_DifferentNames_TwoFields) {
+  // uid==gid==1000 but uname="alice" != gname="developers".
+  // Single find on numeric 1000 must return DIFFERENT hashes via two fields.
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1000}},
+                     std::vector<std::pair<std::string, uint32_t>>{{"developers", 1000}}));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1000, 1000, ou, og);
+  EXPECT_EQ(ou, m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1000));
+  EXPECT_EQ(og, m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1000));
+  EXPECT_NE(ou, og) << "different names must yield different hashes";
+}
+
+TEST(UidGidMapperPair, OutboundEqualInRange_OnlyUidKnown_GidPassthrough) {
+  // id 1000 is a uid but no group with gid 1000 exists.
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1000}}));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1000, 1000, ou, og);
+  EXPECT_GE(ou, UidGidMapper::kLocalUidMax);
+  EXPECT_EQ(og, 1000u);  // passthrough
+}
+
+TEST(UidGidMapperPair, OutboundUnequal_TwoFindPath) {
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}},
+                     std::vector<std::pair<std::string, uint32_t>>{{"dev", 500}}));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1001, 500, ou, og);
+  EXPECT_EQ(ou, m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001));
+  EXPECT_EQ(og, m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 500));
+}
+
+TEST(UidGidMapperPair, OutboundEqualButOutOfRange_BothPassthrough) {
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}}));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  // uid==gid==0 (root) → both 0
+  m.LocalPairToHashed(0, 0, ou, og);
+  EXPECT_EQ(ou, 0u);
+  EXPECT_EQ(og, 0u);
+  // uid==gid==12345 (>= kLocalUidMax) → passthrough
+  m.LocalPairToHashed(12345, 12345, ou, og);
+  EXPECT_EQ(ou, 12345u);
+  EXPECT_EQ(og, 12345u);
+}
+
+namespace {
+
+// PgidAwareSource lets tests inject a real paired_local_id cookie per user
+// so the fast-path cookie branch can be exercised.
+class PgidAwareSource : public PasswdSource {
+ public:
+  PgidAwareSource(std::vector<UserRecord> users,
+                  std::vector<std::pair<std::string, uint32_t>> groups)
+      : users_(std::move(users)), groups_(std::move(groups)) {}
+
+  std::vector<UserRecord> ListUsersWithPrimaryGid() override {
+    return users_;
+  }
+  std::vector<std::pair<std::string, uint32_t>> ListGroups() override {
+    return groups_;
+  }
+
+ private:
+  std::vector<UserRecord> users_;
+  std::vector<std::pair<std::string, uint32_t>> groups_;
+};
+
+}  // namespace
+
+TEST(UidGidMapperPair, OutboundUPG_NumericIdShared_FastPathOneFind) {
+  // alice user 1000 with primary gid 1000, AND group X with gid 1000 — UPG by
+  // number, different name. fast path: cookie matches, paired_hash != 0 →
+  // single find returns out_uid=H("alice"), out_gid=H("X").
+  PgidAwareSource src({{"alice", 1000, 1000}}, {{"X", 1000}});
+  UidGidMapper m(true, "salt",
+                 std::make_unique<PgidAwareSource>(std::move(src)));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1000, 1000, ou, og);
+  EXPECT_EQ(ou, m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1000));
+  EXPECT_EQ(og, m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1000));
+  EXPECT_GE(ou, UidGidMapper::kLocalUidMax);
+  EXPECT_GE(og, UidGidMapper::kLocalUidMax);
+  EXPECT_NE(ou, og) << "different names must produce different hashes";
+}
+
+TEST(UidGidMapperPair, OutboundUPG_PrimaryGidSwitched_CookieMismatchDegrades) {
+  // Models the staleness window: snapshot remembers alice with primary gid
+  // 1001 (alice_group); admin has just `usermod -g 1000 alice` and snapshot
+  // has not refreshed yet. FUSE arrives with (1000, 1000) since alice's
+  // effective gid is now 1000.
+  //   * /etc/group entries 1001 and 1000 are BOTH already in the snapshot
+  //     because group X (gid 1000) existed independently before the switch.
+  //   * cookie (1001) != fuse_gid (1000) → fast path bails.
+  //   * Per-element path then hits {1000, Gid} directly → H("X").
+  //   * Key assertion: out_gid is the H("X") hash, not the raw 1000 number.
+  PgidAwareSource src({{"alice", 1000, 1001}},
+                      {{"alice_group", 1001}, {"X", 1000}});
+  UidGidMapper m(true, "salt",
+                 std::make_unique<PgidAwareSource>(std::move(src)));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1000, 1000, ou, og);
+  EXPECT_EQ(ou, m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1000));
+  EXPECT_EQ(og, m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1000));
+  EXPECT_GE(og, UidGidMapper::kLocalUidMax);
+  EXPECT_NE(og, 1000u) << "must translate via {1000, Gid} entry, not passthrough";
+}
+
+TEST(UidGidMapperPair, OutboundUPG_PairedGroupMissingFromGroupFile) {
+  // alice has primary gid 1001 but /etc/group has no entry for 1001 (admin
+  // temporarily cleaned the group file). paired_hash falls to 0 → fast path
+  // path's paired_hash != 0 guard fails even though the cookie matches → fall
+  // through to the per-element path → {1001, Gid} miss → out_gid passthrough.
+  PgidAwareSource src({{"alice", 1000, 1001}}, {{"X", 500}});
+  UidGidMapper m(true, "salt",
+                 std::make_unique<PgidAwareSource>(std::move(src)));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1000, 1001, ou, og);
+  EXPECT_GE(ou, UidGidMapper::kLocalUidMax);
+  EXPECT_EQ(og, 1001u) << "no group with gid 1001 in snapshot → passthrough";
+}
+
+TEST(UidGidMapperPair, OutboundEqualAcrossGate_PerElement) {
+  // uid in range, gid out of range — must NOT take single-find branch.
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}}));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.LocalPairToHashed(1001, 70000, ou, og);
+  EXPECT_EQ(ou, m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001));
+  EXPECT_EQ(og, 70000u);
+}
+
+// ---- HashedPairToLocal: pair inbound translation ----
+
+TEST(UidGidMapperPair, InboundDisabled_BothPassthrough) {
+  UidGidMapper m(false, "salt", std::make_unique<TableSource>());
+  uint32_t ou = 0, og = 0;
+  m.HashedPairToLocal(123456u, 654321u, ou, og);
+  EXPECT_EQ(ou, 123456u);
+  EXPECT_EQ(og, 654321u);
+}
+
+TEST(UidGidMapperPair, InboundUPG_EqualHash_OneFind) {
+  // UPG: user alice + group alice → both Hash("alice") → equal hashes.
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  uint32_t h_uid = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  uint32_t h_gid = m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 1001);
+  ASSERT_EQ(h_uid, h_gid);
+
+  uint32_t ou = 0, og = 0;
+  m.HashedPairToLocal(h_uid, h_gid, ou, og);
+  EXPECT_EQ(ou, 1001u);
+  EXPECT_EQ(og, 1001u);
+}
+
+TEST(UidGidMapperPair, InboundUnequalHashes_TwoFindPath) {
+  // alice (uid 1001) + developers (gid 500) → different names → different hashes.
+  UidGidMapper m(true, "salt",
+                 std::make_unique<TableSource>(
+                     std::vector<std::pair<std::string, uint32_t>>{{"alice", 1001}},
+                     std::vector<std::pair<std::string, uint32_t>>{{"developers", 500}}));
+  m.Refresh();
+  uint32_t h_uid = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  uint32_t h_gid = m.LocalIdToHashedId(UidGidMapper::Kind::kGid, 500);
+  ASSERT_NE(h_uid, h_gid);
+
+  uint32_t ou = 0, og = 0;
+  m.HashedPairToLocal(h_uid, h_gid, ou, og);
+  EXPECT_EQ(ou, 1001u);
+  EXPECT_EQ(og, 500u);
+}
+
+TEST(UidGidMapperPair, InboundRoot_AlwaysZero) {
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  m.HashedPairToLocal(0, 0, ou, og);
+  EXPECT_EQ(ou, 0u);
+  EXPECT_EQ(og, 0u);
+}
+
+TEST(UidGidMapperPair, InboundEqualButBelowReserved_BothPassthrough) {
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  uint32_t ou = 0, og = 0;
+  // Equal but below reserved range — must NOT take fast path.
+  m.HashedPairToLocal(1001, 1001, ou, og);
+  EXPECT_EQ(ou, 1001u);
+  EXPECT_EQ(og, 1001u);
+}
+
+TEST(UidGidMapperPair, InboundAcrossGate_PerElement) {
+  // huid in reserved range (hit), hgid below (passthrough).
+  UidGidMapper m(true, "salt", MakeAliceSource(1001));
+  m.Refresh();
+  uint32_t h_uid = m.LocalIdToHashedId(UidGidMapper::Kind::kUid, 1001);
+  ASSERT_GE(h_uid, UidGidMapper::kLocalUidMax);
+
+  uint32_t ou = 0, og = 0;
+  m.HashedPairToLocal(h_uid, 500, ou, og);
+  EXPECT_EQ(ou, 1001u);
+  EXPECT_EQ(og, 500u);   // below reserved → passthrough
+}
+
+}  // namespace test
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/vfs/mock/mock_vfs_hub.h
+++ b/test/unit/client/vfs/mock/mock_vfs_hub.h
@@ -48,6 +48,7 @@ class MockVFSHub : public VFSHub {
   MOCK_METHOD(Compactor*, GetCompactor, (), (override));
   MOCK_METHOD(TraceManager*, GetTraceManager, (), (override));
   MOCK_METHOD(FsInfo, GetFsInfo, (), (override));
+  MOCK_METHOD(UidGidMapper*, GetUidGidMapper, (), (override));
   MOCK_METHOD(blockaccess::BlockAccessOptions, GetBlockAccesserOptions, (),
               (override));
 };

--- a/test/unit/client/vfs/test_base.h
+++ b/test/unit/client/vfs/test_base.h
@@ -121,6 +121,9 @@ class VFSTestBase : public ::testing::Test {
     ON_CALL(*mock_hub_, GetCBExecutor())
         .WillByDefault(Return(cb_executor_.get()));
     ON_CALL(*mock_hub_, GetFsInfo()).WillByDefault(Return(MakeTestFsInfo()));
+    // Null mapper => uid/gid translation passthrough. Tests that exercise the
+    // enabled-mapper path override this with their own real mapper.
+    ON_CALL(*mock_hub_, GetUidGidMapper()).WillByDefault(Return(nullptr));
 
     EXPECT_CALL(*mock_hub_, GetMetaSystem()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetHandleManager()).Times(AnyNumber());
@@ -134,6 +137,7 @@ class VFSTestBase : public ::testing::Test {
     EXPECT_CALL(*mock_hub_, GetBGExecutor()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetCBExecutor()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetFsInfo()).Times(AnyNumber());
+    EXPECT_CALL(*mock_hub_, GetUidGidMapper()).Times(AnyNumber());
 
     // --- 8. MockBlockStore: synchronous success by default ---
     // Callbacks invoked inline (no async) to eliminate timing non-determinism.

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -19,9 +19,12 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "client/vfs/components/uid_gid_mapper.h"
 #include "client/vfs/data/writer_table.h"
 #include "client/vfs/data_buffer.h"
 #include "client/vfs/vfs_impl.h"
@@ -46,6 +49,38 @@ using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::SetArgPointee;
+
+namespace {
+
+// Minimal in-memory PasswdSource for the uid/gid wiring tests. Mirrors the
+// TableSource used by uid_gid_mapper_test.cc, kept local since that helper is
+// not exported in a shared header. These tests don't exercise the fast-path
+// cookie, so primary_gid is always 0.
+class FakePasswdSource : public PasswdSource {
+ public:
+  explicit FakePasswdSource(
+      std::vector<std::pair<std::string, uint32_t>> users,
+      std::vector<std::pair<std::string, uint32_t>> groups)
+      : users_(std::move(users)), groups_(std::move(groups)) {}
+
+  std::vector<UserRecord> ListUsersWithPrimaryGid() override {
+    std::vector<UserRecord> out;
+    out.reserve(users_.size());
+    for (const auto& [name, uid] : users_) {
+      out.push_back({name, uid, 0});
+    }
+    return out;
+  }
+  std::vector<std::pair<std::string, uint32_t>> ListGroups() override {
+    return groups_;
+  }
+
+ private:
+  std::vector<std::pair<std::string, uint32_t>> users_;
+  std::vector<std::pair<std::string, uint32_t>> groups_;
+};
+
+}  // namespace
 
 class VFSImplTest : public test::VFSTestBase {
  protected:
@@ -497,6 +532,100 @@ TEST_F(VFSImplTest, Trash_Rename_IntoTrash_BlockedAtClient) {
                           /*new_parent=*/0x7FFFFFFF00000005ULL, "newname");
   EXPECT_FALSE(s.ok());
   EXPECT_TRUE(s.IsNoPermitted());
+}
+
+// ===========================================================================
+// uid/gid translation wiring (moved from the removed MDS-layer contract tests)
+//
+// The mapper now lives at the VFS layer: VFSImpl translates OUTBOUND (local ->
+// stored hash) before backend calls and INBOUND (stored -> local) on returned
+// attrs. These tests verify that wiring through the public VFSImpl surface.
+// ===========================================================================
+class VFSImplUidGidTest : public VFSImplTest {
+ protected:
+  // Build an enabled mapper preset with alice@kLocalUid and route the hub's
+  // GetUidGidMapper() to it. Stored as a member so it outlives the calls.
+  void EnableMapper() {
+    auto src = std::make_unique<FakePasswdSource>(
+        std::vector<std::pair<std::string, uint32_t>>{{"alice", kLocalUid}},
+        std::vector<std::pair<std::string, uint32_t>>{{"alice", kLocalUid}});
+    mapper_ = std::make_unique<UidGidMapper>(/*enabled=*/true, "salt-X",
+                                             std::move(src));
+    mapper_->Refresh();
+    EXPECT_CALL(*mock_hub_, GetUidGidMapper())
+        .WillRepeatedly(Return(mapper_.get()));
+  }
+
+  static constexpr uint32_t kLocalUid = 1001;
+  std::unique_ptr<UidGidMapper> mapper_;
+};
+
+// Outbound: MkNod with a local uid must reach the meta system as the hashed id.
+TEST_F(VFSImplUidGidTest, UidGid_OutboundTranslates_MkNod) {
+  EnableMapper();
+  const uint32_t hashed =
+      mapper_->LocalIdToHashedId(UidGidMapper::Kind::kUid, kLocalUid);
+  ASSERT_GE(hashed, UidGidMapper::kLocalUidMax);  // actually translated
+  ASSERT_NE(hashed, kLocalUid);
+
+  uint32_t seen_uid = 0;
+  EXPECT_CALL(*mock_meta_system_, MkNod(_, kRootIno, "f", _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<3>(&seen_uid), Return(Status::OK())));
+
+  Attr out;
+  Status s = vfs_->MkNod(ctx_, kRootIno, "f", /*uid=*/kLocalUid, /*gid=*/0,
+                         /*mode=*/0644, /*dev=*/0, &out);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(seen_uid, hashed);
+}
+
+// Inbound: a stored hashed uid returned by the backend must surface to the
+// caller as the local uid.
+TEST_F(VFSImplUidGidTest, UidGid_InboundTranslates_GetAttr) {
+  EnableMapper();
+  const uint32_t hashed =
+      mapper_->LocalIdToHashedId(UidGidMapper::Kind::kUid, kLocalUid);
+  ASSERT_GE(hashed, UidGidMapper::kLocalUidMax);
+
+  Attr attr;
+  attr.ino = 77;
+  attr.type = dingofs::kFile;
+  attr.uid = hashed;  // backend stores the hashed id
+
+  EXPECT_CALL(*mock_meta_system_, GetAttr(_, 77u, _))
+      .WillOnce(DoAll(SetArgPointee<2>(attr), Return(Status::OK())));
+
+  Attr out;
+  Status s = vfs_->GetAttr(ctx_, 77u, &out);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(out.uid, kLocalUid);
+}
+
+// Passthrough: with a null mapper (the fixture default), uid is unchanged in
+// both directions.
+TEST_F(VFSImplUidGidTest, UidGid_Passthrough_NullMapper) {
+  // GetUidGidMapper() returns nullptr by VFSTestBase default.
+
+  // Outbound: MkNod uid reaches the backend unchanged.
+  uint32_t seen_uid = 0;
+  EXPECT_CALL(*mock_meta_system_, MkNod(_, kRootIno, "f", _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<3>(&seen_uid), Return(Status::OK())));
+  Attr mk_out;
+  EXPECT_TRUE(vfs_->MkNod(ctx_, kRootIno, "f", /*uid=*/kLocalUid, /*gid=*/0,
+                          /*mode=*/0644, /*dev=*/0, &mk_out)
+                  .ok());
+  EXPECT_EQ(seen_uid, kLocalUid);
+
+  // Inbound: GetAttr uid surfaces unchanged.
+  Attr attr;
+  attr.ino = 88;
+  attr.type = dingofs::kFile;
+  attr.uid = kLocalUid;
+  EXPECT_CALL(*mock_meta_system_, GetAttr(_, 88u, _))
+      .WillOnce(DoAll(SetArgPointee<2>(attr), Return(Status::OK())));
+  Attr out;
+  EXPECT_TRUE(vfs_->GetAttr(ctx_, 88u, &out).ok());
+  EXPECT_EQ(out.uid, kLocalUid);
 }
 
 }  // namespace vfs

--- a/test/unit/mds/filesystem/test_filesystem.cc
+++ b/test/unit/mds/filesystem/test_filesystem.cc
@@ -990,6 +990,50 @@ TEST_F(FileSystemTest, RenameWithDiffDir) {
   }
 }
 
+TEST_F(FileSystemSetTest, CreateFs_PropagatesEnableUidGidMapTrue) {
+  auto fs_set = FsSet();
+
+  FileSystemSet::CreateFsParam param;
+  param.fs_name = "uidgid-on";
+  param.fs_id = 30001;  // explicit id to avoid auto-increment and id-reuse issues
+  param.block_size = 1 << 20;
+  param.chunk_size = 64 << 20;
+  param.fs_type = pb::mds::FsType::S3;
+  *param.fs_extra.mutable_s3_info() = CreateS3Info();
+  param.owner = "tester";
+  param.capacity = 1ULL << 30;
+  param.partition_type = pb::mds::PartitionType::MONOLITHIC_PARTITION;
+  param.candidate_mds_ids = {kMdsId};  // avoid random-select crash on empty mds_meta_map
+  param.enable_uid_gid_map = true;
+
+  pb::mds::FsInfo fs_info;
+  auto status = fs_set->CreateFs(param, fs_info);
+  ASSERT_TRUE(status.ok()) << "create fs fail: " << status.error_str();
+  EXPECT_TRUE(fs_info.enable_uid_gid_map());
+}
+
+TEST_F(FileSystemSetTest, CreateFs_PropagatesEnableUidGidMapDefaultFalse) {
+  auto fs_set = FsSet();
+
+  FileSystemSet::CreateFsParam param;
+  param.fs_name = "uidgid-off";
+  param.fs_id = 30002;  // explicit id to avoid auto-increment and id-reuse issues
+  param.block_size = 1 << 20;
+  param.chunk_size = 64 << 20;
+  param.fs_type = pb::mds::FsType::S3;
+  *param.fs_extra.mutable_s3_info() = CreateS3Info();
+  param.owner = "tester";
+  param.capacity = 1ULL << 30;
+  param.partition_type = pb::mds::PartitionType::MONOLITHIC_PARTITION;
+  param.candidate_mds_ids = {kMdsId};  // avoid random-select crash on empty mds_meta_map
+  // enable_uid_gid_map intentionally left default (false)
+
+  pb::mds::FsInfo fs_info;
+  auto status = fs_set->CreateFs(param, fs_info);
+  ASSERT_TRUE(status.ok()) << "create fs fail: " << status.error_str();
+  EXPECT_FALSE(fs_info.enable_uid_gid_map());
+}
+
 }  // namespace unit_test
 }  // namespace mds
 }  // namespace dingofs


### PR DESCRIPTION
Enable at fs-create time with `dingo-mds-client --enable_uid_gid_map=true`. When enabled, the client hashes the local user/group name into the reserved range [10000, 2^32) and stores it on the MDS, so the same file shows the *local* uid/gid on every mounting host even when local uids differ.

MDS:
- CreateFs propagates the enable_uid_gid_map flag.
- Dashboard FS list shows the EnableUidGidMap column.

Client:
- UidGidMapper: MD5-based name hashing, inbound/outbound translation, 60s refresh thread with Start/Stop lifecycle, deterministic hash-collision resolution (smaller local uid wins, logged at ERROR).
- LibcPasswdSource enumerates NSS via setpwent/setgrent (serialized).
- MDSMetaSystem owns the mapper lifecycle and wires refresh into crontab_manager_; runtime toggle supported.
- Inbound translation happens at Inode::ToAttr() read time (not at ctor), so snapshot changes are visible on cached inodes; all Attr out-params routed through ToAttr to avoid bypass.
- Mapper snapshot exposed via /ClientStatService/uidgidmap.

root (uid=0/gid=0) is never translated; local uids in [1, 10000) without a matching passwd entry pass through unchanged. Disabled fs behaves identically to prior releases.

Compatibility: every client mounting an enabled fs must be built with this feature; older clients silently ignore the proto3 flag and write raw local uids, which is unrecoverable. The MDS does not enforce version uniformity.

<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
