### PR TITLE
[fix] Write-page pool exhaustion: atomic reservation + short-write

### DIFF
--- a/src/client/vfs/data/slice/block_data.cc
+++ b/src/client/vfs/data/slice/block_data.cc
@@ -47,50 +47,83 @@ void BlockData::FreePageData() {
   }
 }
 
-char* BlockData::AllocPage() {
-  auto* page = write_buffer_manager_->Allocate();
-  VLOG(16) << fmt::format("{} Allocated page at: {} allocation", UUID(),
-                          Helper::Char2Addr(page));
-  return page;
-}
-
-PageData* BlockData::FindOrCreatePageData(uint32_t page_index,
-                                          int32_t page_offset) {
+PageData* BlockData::FindPageData(uint32_t page_index) {
   auto iter = pages_.find(page_index);
-  if (iter != pages_.end()) {
-    VLOG(6) << fmt::format("{} Found existing page data for page index: {}",
-                           UUID(), page_index);
-    return iter->second.get();
-  }
-
-  char* page = AllocPage();
-  if (page == nullptr) {
-    // Pool exhausted (bounded-acquire timed out). Don't create a PageData
-    // holding a null page -- return nullptr so BlockData::Write rolls back any
-    // pages it newly allocated this call and surfaces NoSpace.
-    return nullptr;
-  }
-
-  auto [new_iter, inserted] = pages_.emplace(
-      page_index,
-      std::make_unique<PageData>(vfs_hub_, page_index, context_.page_size, page,
-                                 page_offset));
-  CHECK(inserted);
-
-  VLOG(12) << fmt::format("{} Creating new page_data: {} for page index: {}",
-                          UUID(), new_iter->second->ToString(), page_index);
-
-  return new_iter->second.get();
+  return iter == pages_.end() ? nullptr : iter->second.get();
 }
 
-Status BlockData::Write(ContextSPtr ctx, const char* buf, int32_t size,
-                        int32_t block_offset) {
-  auto span = vfs_hub_->GetTraceManager()->StartChildSpan("BlockData::Write",
-                                                          ctx->GetTraceSpan());
+Status BlockData::ReservePages(int32_t size, int32_t block_offset,
+                               std::vector<uint32_t>* created_pages) {
+  CHECK_GT(size, 0);
+  CHECK_GE(block_offset, 0);
+  CHECK_LE(block_offset + size, context_.block_size);
 
-  VLOG(6) << fmt::format(
-      "{} Write Start data size: {}, block_offset: {}, block_data: {}", UUID(),
-      size, block_offset, ToString());
+  CHECK(block_offset == (block_offset_ + len_) ||
+        (block_offset + size) == block_offset_)
+      << fmt::format(
+             "{} Reserve Illegal block_offset: {}, size: {}, block_data: {}",
+             UUID(), block_offset, size, ToString());
+
+  int32_t page_size = context_.page_size;
+  uint32_t page_index = block_offset / page_size;
+  int32_t page_offset = block_offset % page_size;
+  int32_t remain_len = size;
+
+  // Allocate only the pages this write actually needs. Existing pages (e.g. a
+  // partially-filled straddle page) need no allocation and are NOT recorded, so
+  // a later RollbackPages won't free pages that predate this transaction. The
+  // first new page keeps its in-page offset; later pages start at 0 -- this
+  // matches the data_offset PageData::Write's contiguity CHECK expects.
+  while (remain_len > 0) {
+    int32_t write_size = std::min(remain_len, page_size - page_offset);
+    if (FindPageData(page_index) == nullptr) {
+      char* page = write_buffer_manager_->TryAllocate();
+      if (page == nullptr) {
+        return Status::NoSpace("write page pool exhausted");
+      }
+      auto [iter, inserted] = pages_.emplace(
+          page_index,
+          std::make_unique<PageData>(vfs_hub_, page_index, context_.page_size,
+                                     page, page_offset));
+      CHECK(inserted);
+      created_pages->push_back(page_index);
+      VLOG(12) << fmt::format(
+          "{} Reserved new page_data: {} for page index: {}", UUID(),
+          iter->second->ToString(), page_index);
+    }
+    remain_len -= write_size;
+    page_offset = 0;
+    ++page_index;
+  }
+  return Status::OK();
+}
+
+void BlockData::RollbackPages(const std::vector<uint32_t>& created_pages) {
+  for (uint32_t idx : created_pages) {
+    auto it = pages_.find(idx);
+    if (it != pages_.end()) {
+      if (it->second->page != nullptr) {
+        write_buffer_manager_->DeAllocate(it->second->page);
+      }
+      pages_.erase(it);
+    }
+  }
+  VLOG(6) << fmt::format("{} RollbackPages freed {} pages", UUID(),
+                         created_pages.size());
+}
+
+// INVARIANT: ApplyWrite must be infallible -- SliceWriter's two-phase
+// atomicity relies on it (all fallible work, i.e. allocation, lives in
+// ReservePages/phase 1; phase 2 only memcpys). It is infallible only because
+// writes are append-only (SliceWriter gates on CHECK_EQ(chunk_offset, End())):
+// PageData::Write then always sees a contiguous append/prepend and never its
+// "illegal range" CHECK. If a random-overwrite write path is ever added, that
+// CHECK can fire mid-apply -- after other blocks were already reserved/applied
+// -- and abort the process, breaking the transaction. Revisit this split then.
+void BlockData::ApplyWrite(ContextSPtr ctx, const char* buf, int32_t size,
+                           int32_t block_offset) {
+  auto span = vfs_hub_->GetTraceManager()->StartChildSpan(
+      "BlockData::ApplyWrite", ctx->GetTraceSpan());
 
   CHECK_GT(size, 0);
   CHECK_GE(block_offset, 0);
@@ -99,65 +132,20 @@ Status BlockData::Write(ContextSPtr ctx, const char* buf, int32_t size,
   CHECK(block_offset == (block_offset_ + len_) ||
         (block_offset + size) == block_offset_)
       << fmt::format(
-             "{} Write Illegal block_offset: {}, size: {}, block_data: {}",
+             "{} Apply Illegal block_offset: {}, size: {}, block_data: {}",
              UUID(), block_offset, size, ToString());
 
   int32_t page_size = context_.page_size;
   uint32_t page_index = block_offset / page_size;
   int32_t page_offset = block_offset % page_size;
-
-  // Pass 1: pre-allocate every page this write needs. AllocPage may fail (pool
-  // exhausted, bounded-acquire timed out) -- if so, roll back the pages created
-  // this call (DeAllocate + erase) and return NoSpace, leaving block state
-  // untouched (len_/block_offset_ unchanged, no half-written page) so a retry
-  // at the same offset is clean and won't trip PageData's contiguity CHECK.
-  {
-    std::vector<uint32_t> created_this_call;
-    int32_t pre_offset = page_offset;
-    uint32_t pre_index = page_index;
-    int32_t pre_remain = size;
-    bool alloc_failed = false;
-    while (pre_remain > 0) {
-      int32_t write_size = std::min(pre_remain, page_size - pre_offset);
-      bool existed = pages_.find(pre_index) != pages_.end();
-      PageData* page_data = FindOrCreatePageData(pre_index, pre_offset);
-      if (page_data == nullptr) {
-        alloc_failed = true;
-        break;
-      }
-      if (!existed) {
-        created_this_call.push_back(pre_index);
-      }
-      pre_remain -= write_size;
-      pre_offset = 0;
-      ++pre_index;
-    }
-
-    if (alloc_failed) {
-      for (uint32_t idx : created_this_call) {
-        auto it = pages_.find(idx);
-        if (it != pages_.end()) {
-          if (it->second->page != nullptr) {
-            write_buffer_manager_->DeAllocate(it->second->page);
-          }
-          pages_.erase(it);
-        }
-      }
-      VLOG(6) << fmt::format(
-          "{} Write rollback: pool exhausted, freed {} pages", UUID(),
-          created_this_call.size());
-      return Status::NoSpace("write page pool exhausted");
-    }
-  }
-
-  // Pass 2: every page is allocated -- memcpy into them (FindOrCreatePageData
-  // now always hits the existing entry).
   const char* buf_pos = buf;
   int32_t remain_len = size;
 
+  // Every page was reserved already -- FindPageData must hit. No allocation.
   while (remain_len > 0) {
     int32_t write_size = std::min(remain_len, page_size - page_offset);
-    PageData* page_data = FindOrCreatePageData(page_index, page_offset);
+    PageData* page_data = FindPageData(page_index);
+    CHECK_NOTNULL(page_data);
 
     page_data->Write(SpanScope::GetContext(span), buf_pos, write_size,
                      page_offset);
@@ -168,22 +156,14 @@ Status BlockData::Write(ContextSPtr ctx, const char* buf, int32_t size,
     ++page_index;
   }
 
-  {
-    int32_t old_len = len_;
-    int32_t old_block_offset = block_offset_;
+  int32_t old_len = len_;
+  int32_t old_block_offset = block_offset_;
+  block_offset_ = std::min(block_offset_, block_offset);
+  len_ += size;
 
-    block_offset_ = std::min(block_offset_, block_offset);
-    len_ += size;
-
-    VLOG(6) << fmt::format(
-        "{} Update block_data old_block_offset: {}, old_len: {}, "
-        "updated data_block: {}",
-        UUID(), old_block_offset, old_len, ToString());
-  }
-
-  VLOG(6) << fmt::format("{} Write End", UUID());
-
-  return Status::OK();
+  VLOG(6) << fmt::format(
+      "{} ApplyWrite old_block_offset: {}, old_len: {}, updated: {}", UUID(),
+      old_block_offset, old_len, ToString());
 }
 
 static void NoopDeleter(void* data) {}

--- a/src/client/vfs/data/slice/block_data.h
+++ b/src/client/vfs/data/slice/block_data.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "client/vfs/data/slice/common.h"
 #include "client/vfs/data/slice/page_data.h"
@@ -49,8 +50,25 @@ class BlockData {
 
   ~BlockData() { FreePageData(); }
 
-  Status Write(ContextSPtr ctx, const char* buf, int32_t size,
-               int32_t block_offset);
+  // Phase 1: ensure every page this write needs exists; allocate only, no
+  // memcpy, no len_ bump. New pages are appended to *created_pages (existing
+  // pages are skipped, not recorded). Allocates via TryAllocate (never blocks
+  // under the slice lock); on a miss returns NoSpace WITHOUT self-rollback so
+  // the caller can also undo pages it reserved in other blocks of the same
+  // SliceWriter transaction.
+  Status ReservePages(int32_t size, int32_t block_offset,
+                      std::vector<uint32_t>* created_pages);
+
+  // Free + erase the named pages. They MUST be this transaction's newly
+  // created pages (from ReservePages' created_pages) -- never pre-existing
+  // ones.
+  void RollbackPages(const std::vector<uint32_t>& created_pages);
+
+  // Phase 2: memcpy buf into already-reserved pages and bump
+  // block_offset_/len_. Precondition: ReservePages covering this range already
+  // succeeded -- this never allocates (CHECK-fails if a page is missing).
+  void ApplyWrite(ContextSPtr ctx, const char* buf, int32_t size,
+                  int32_t block_offset);
 
   IOBuffer ToIOBuffer() const;
 
@@ -77,11 +95,10 @@ class BlockData {
   }
 
  private:
-  char* AllocPage();
-
   void FreePageData();
 
-  PageData* FindOrCreatePageData(uint32_t page_index, int32_t page_offset);
+  // Lookup only -- never allocates. Returns nullptr if the page is absent.
+  PageData* FindPageData(uint32_t page_index);
 
   const SliceDataContext context_;
   VFSHub* vfs_hub_{nullptr};

--- a/src/client/vfs/data/slice/page_data.cc
+++ b/src/client/vfs/data/slice/page_data.cc
@@ -21,8 +21,6 @@
 
 #include <cstdint>
 
-#include "client/common/const.h"
-
 namespace dingofs {
 namespace client {
 namespace vfs {

--- a/src/client/vfs/data/slice/slice_writer.cc
+++ b/src/client/vfs/data/slice/slice_writer.cc
@@ -223,7 +223,10 @@ Status SliceWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
            ++it) {
         block_datas_.erase(*it);
       }
-      LOG(WARNING) << fmt::format(
+      // Page pool could not back this slice; record the rolled-back range so
+      // the locality is visible by default (the VFSImpl boundary log only knows
+      // the whole-write offset/size, not which slice failed).
+      LOG(INFO) << fmt::format(
           "{} Write reserve failed, rolled back chunk_range: [{}-{}], "
           "status: {}",
           UUID(), chunk_offset, end_in_chunk, fail_status.ToString());

--- a/src/client/vfs/data/slice/slice_writer.cc
+++ b/src/client/vfs/data/slice/slice_writer.cc
@@ -46,21 +46,26 @@ namespace vfs {
 
 #define METHOD_NAME() ("SliceWriter::" + std::string(__FUNCTION__))
 
-BlockData* SliceWriter::FindOrCreateBlockDataUnlocked(uint32_t block_index,
-                                                      int32_t block_offset) {
+BlockData* SliceWriter::FindBlockDataUnlocked(uint32_t block_index) {
   auto iter = block_datas_.find(block_index);
-  if (iter != block_datas_.end()) {
-    VLOG(4) << fmt::format(
-        "{} Found existing block data for block index: {}, block: {}", UUID(),
-        block_index, iter->second->ToString());
-    return iter->second.get();
+  if (iter == block_datas_.end()) {
+    return nullptr;
   }
+  VLOG(4) << fmt::format(
+      "{} Found existing block data for block index: {}, block: {}", UUID(),
+      block_index, iter->second->ToString());
+  return iter->second.get();
+}
 
+BlockData* SliceWriter::CreateBlockDataUnlocked(uint32_t block_index,
+                                                int32_t block_offset) {
   auto [new_iter, inserted] = block_datas_.emplace(
       block_index, std::make_unique<BlockData>(context_, vfs_hub_,
                                                vfs_hub_->GetWriteMemPool(),
                                                block_index, block_offset));
-  CHECK(inserted);
+  CHECK(inserted) << fmt::format(
+      "{} CreateBlockDataUnlocked on existing block index: {}", UUID(),
+      block_index);
 
   VLOG(4) << fmt::format(
       "{} Creating new block data for block index: {}, block: {}", UUID(),
@@ -151,40 +156,88 @@ Status SliceWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
   uint32_t block_index = slice_internal_offset / block_size;
   int32_t block_offset = slice_internal_offset % block_size;
 
-  const char* buf_pos = buf;
-
-  int32_t remain_len = size;
+  // One memcpy unit in phase 2: which block, where in it, from where in buf.
+  struct BlockApply {
+    BlockData* block;
+    const char* buf;
+    int32_t size;
+    int32_t block_offset;
+  };
+  // Pages this call newly reserved in a block -- the rollback unit.
+  struct Reserved {
+    BlockData* block;
+    std::vector<uint32_t> pages;
+  };
 
   {
     std::lock_guard<std::mutex> lg(write_flush_mutex_);
 
-    // ---- Write loop: only fills BlockData ----
-    while (remain_len > 0) {
-      int32_t write_size = std::min(remain_len, block_size - block_offset);
-      BlockData* block_data =
-          FindOrCreateBlockDataUnlocked(block_index, block_offset);
+    std::vector<BlockApply> applies;
+    std::vector<Reserved> reserved;        // every block's new pages this call
+    std::vector<uint32_t> created_blocks;  // BlockData newly created this call
 
-      Status s = block_data->Write(SpanScope::GetContext(span), buf_pos,
-                                   write_size, block_offset);
-      if (!s.ok()) {
-        // BlockData::Write already rolled back its own pages on pool
-        // exhaustion. Propagate up; blocks written earlier in this slice stay
-        // (POSIX short write), len_ is NOT bumped, caller surfaces ENOSPC.
-        LOG(WARNING) << fmt::format(
-            "{} BlockData::Write failed, block_index: {}, chunk_range: "
-            "[{}-{}], len: {}, status: {}",
-            UUID(), block_index, block_offset, (block_offset + write_size),
-            write_size, s.ToString());
-        return s;
+    // ---- Phase 1: reserve pages across ALL blocks (allocate only) ----
+    // Nothing is memcpy'd and len_ is untouched, so any pool miss can be fully
+    // rolled back, leaving zero visible state -- a same-offset retry stays
+    // clean (no contiguity CHECK trip) and flush can't pick up a half-write.
+    Status fail_status;
+    bool failed = false;
+    {
+      uint32_t bi = block_index;
+      int32_t bo = block_offset;
+      const char* p = buf;
+      int32_t remain_len = size;
+      while (remain_len > 0) {
+        int32_t write_size = std::min(remain_len, block_size - bo);
+
+        BlockData* block = FindBlockDataUnlocked(bi);
+        if (block == nullptr) {
+          block = CreateBlockDataUnlocked(bi, bo);
+          created_blocks.push_back(bi);
+        }
+
+        std::vector<uint32_t> pages;
+        Status s = block->ReservePages(write_size, bo, &pages);
+        reserved.push_back({block, std::move(pages)});
+        if (!s.ok()) {
+          fail_status = s;
+          failed = true;
+          break;
+        }
+        applies.push_back({block, p, write_size, bo});
+
+        remain_len -= write_size;
+        p += write_size;
+        bo = 0;
+        ++bi;
       }
-
-      remain_len -= write_size;
-      buf_pos += write_size;
-      block_offset = 0;
-      ++block_index;
     }
 
-    // ---- Update len_ ----
+    // ---- Rollback: free this call's new pages, drop this call's new blocks
+    // ----
+    if (failed) {
+      for (auto it = reserved.rbegin(); it != reserved.rend(); ++it) {
+        it->block->RollbackPages(it->pages);
+      }
+      for (auto it = created_blocks.rbegin(); it != created_blocks.rend();
+           ++it) {
+        block_datas_.erase(*it);
+      }
+      LOG(WARNING) << fmt::format(
+          "{} Write reserve failed, rolled back chunk_range: [{}-{}], "
+          "status: {}",
+          UUID(), chunk_offset, end_in_chunk, fail_status.ToString());
+      return fail_status;
+    }
+
+    // ---- Phase 2: every page exists -- memcpy + bump each BlockData::len_
+    // ----
+    for (const auto& a : applies) {
+      a.block->ApplyWrite(SpanScope::GetContext(span), a.buf, a.size,
+                          a.block_offset);
+    }
+
+    // ---- Publish slice len (only after full success) ----
     // chunk_offset_ is const (forward-append only); only len_ grows.
     int32_t old_len = len_;
     len_ += size;

--- a/src/client/vfs/data/slice/slice_writer.h
+++ b/src/client/vfs/data/slice/slice_writer.h
@@ -102,8 +102,13 @@ class SliceWriter {
         block_datas_.size());
   }
 
-  BlockData* FindOrCreateBlockDataUnlocked(uint32_t block_index,
-                                           int32_t block_offset);
+  // Lookup only -- never creates. Returns nullptr if the block is absent.
+  BlockData* FindBlockDataUnlocked(uint32_t block_index);
+
+  // Always creates a fresh BlockData (caller must have checked it is absent);
+  // the caller tracks the new index so the Write transaction can roll it back.
+  BlockData* CreateBlockDataUnlocked(uint32_t block_index,
+                                     int32_t block_offset);
 
   void PrepareSliceId();
   void FlushUpTo(int32_t written_len);  // caller holds write_flush_mutex_

--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -165,6 +165,11 @@ void FileWriter::ReleaseRef() {
 
 Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
                          uint64_t offset, uint64_t* out_wsize) {
+  // Define the out-param on every path: the early-return error paths below
+  // (sticky status / throttle timeout / closed) leave it 0 instead of relying
+  // on the caller to pre-zero.
+  *out_wsize = 0;
+
   // Sticky-broken fast-fail.
   DINGOFS_RETURN_NOT_OK(GetStatus());
 
@@ -207,10 +212,17 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
     s = chunk->Write(SpanScope::GetContext(span), pos, write_size,
                      chunk_offset);
     if (!s.ok()) {
-      LOG(WARNING) << "Fail write chunk, ino: " << ino_
-                   << ", chunk_index: " << chunk_index
-                   << ", chunk_offset: " << chunk_offset
-                   << ", write_size: " << write_size;
+      // Detail-only: this chunk stopped the write (surfaces as a short write if
+      // written_size > 0, else a hard error, decided after the loop). Don't
+      // WARN per chunk -- it floods under back-pressure and misreads a
+      // successful short write; the outcome is recorded uniformly in
+      // VFSWrapper's access log (status + out_wsize), the pool-pressure
+      // locality in SliceWriter, and the failure rate in the
+      // vfs_write_pool_alloc_fail_num metric.
+      VLOG(3) << "stop write at chunk, ino: " << ino_
+              << ", chunk_index: " << chunk_index
+              << ", chunk_offset: " << chunk_offset
+              << ", write_size: " << write_size << ", status: " << s.ToString();
       break;
     }
 
@@ -233,6 +245,15 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
   }
 
   *out_wsize = written_size;
+
+  // Partial progress is a POSIX short write, not a failure. SliceWriter::Write
+  // is atomic per chunk, so written_size is exactly the prefix of fully-written
+  // chunks; report OK + that prefix so the caller advances and re-issues the
+  // rest (which hits the throttle / backpressure). Only a zero-byte write
+  // surfaces the error (e.g. the very first chunk got ENOSPC).
+  if (written_size > 0) {
+    return Status::OK();
+  }
   return s;
 }
 

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -62,7 +62,7 @@ VFSImpl::VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id)
     : client_id_(client_id),
       mount_root_path_(
           vfs_conf.mount_root_path.empty() ? "/" : vfs_conf.mount_root_path),
-      vfs_hub_(std::make_unique<VFSHubImpl>(vfs_conf, client_id_)) {};
+      vfs_hub_(std::make_unique<VFSHubImpl>(vfs_conf, client_id_)){};
 
 VFSImpl::VFSImpl(std::unique_ptr<VFSHub> hub)
     : client_id_(), vfs_hub_(std::move(hub)) {
@@ -603,6 +603,10 @@ Status VFSImpl::Read(ContextSPtr ctx, Ino ino, DataBuffer* data_buffer,
 
 Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
                       uint64_t offset, uint64_t fh, uint64_t* out_wsize) {
+  // Define the out-param on every path: the read-only-fh early return below
+  // leaves it 0 instead of relying on the caller to pre-zero.
+  *out_wsize = 0;
+
   Status s;
   auto* handle = handle_manager_->FindHandler(fh);
   VFS_CHECK_HANDLE(handle, ino, fh);
@@ -619,15 +623,24 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
 
   s = handle->writer->Write(SpanScope::GetContext(span), buf, size, offset,
                             out_wsize);
-  if (s.ok()) {
-    s = meta_system_->Write(SpanScope::GetContext(span), ino, buf, offset, size,
-                            fh);
+  // Use *out_wsize, not size: writer->Write may short-write (OK with
+  // *out_wsize < size) when the page pool is exhausted mid-write. Metadata must
+  // reflect only what is durable -- MetaSystem::Write extends the inode length
+  // to offset + len, so passing the full size would claim bytes that were never
+  // written (reads past the durable prefix would see a phantom hole).
+  if (s.ok() && *out_wsize > 0) {
+    s = meta_system_->Write(SpanScope::GetContext(span), ino, buf, offset,
+                            *out_wsize, fh);
     // Invalidate read cache for all handles of this inode in the written range,
     // so that no other open file descriptor can serve stale cached data.
     handle_manager_->InvalidateByIno(ino, static_cast<int64_t>(offset),
-                                     static_cast<int64_t>(size));
+                                     static_cast<int64_t>(*out_wsize));
   }
 
+  // No status logging here: VFSImpl returns Status without logging per-op
+  // outcomes (like the other ops); the uniform status + out_wsize record lives
+  // in VFSWrapper's access log, the pool-pressure locality in SliceWriter, and
+  // the failure rate in the vfs_write_pool_alloc_fail_num metric.
   return s;
 }
 

--- a/src/common/writemempool/write_mem_pool.cc
+++ b/src/common/writemempool/write_mem_pool.cc
@@ -16,31 +16,9 @@
 
 #include "common/writemempool/write_mem_pool.h"
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
-#include <chrono>
-#include <thread>
-
 namespace dingofs {
-
-DEFINE_int64(vfs_write_pool_acquire_timeout_ms, 3000,
-             "Bounded-acquire deadline (ms) for one write-page Allocate(): "
-             "loop MemoryPool::Require() until this elapses before returning "
-             "nullptr. A single Require()==nullptr is transient contention, "
-             "not exhaustion; only a full window with no free buffer is.");
-
-namespace {
-// Bounded-acquire backoff: spin-yield this many times before each short sleep.
-constexpr uint32_t kAcquireSpinYields = 64;
-constexpr uint32_t kAcquireBackoffUs = 50;
-
-int64_t ElapsedUs(std::chrono::steady_clock::time_point start) {
-  return std::chrono::duration_cast<std::chrono::microseconds>(
-             std::chrono::steady_clock::now() - start)
-      .count();
-}
-}  // namespace
 
 WriteMemPool::WriteMemPool(int64_t total_bytes, int64_t page_size)
     : total_bytes_(total_bytes),
@@ -51,50 +29,24 @@ WriteMemPool::WriteMemPool(int64_t total_bytes, int64_t page_size)
                       page_size > 0 ? total_bytes / page_size : 0),
       used_pages_var_("vfs_write_pool_used_pages", UsedPages, this),
       used_bytes_var_("vfs_write_pool_used_bytes", UsedBytes, this),
-      acquire_fail_num_("vfs_write_pool_acquire_fail_num"),
-      transient_null_num_("vfs_write_pool_transient_null_num"),
-      acquire_wait_num_("vfs_write_pool_acquire_wait_num"),
-      acquire_wait_us_("vfs_write_pool_acquire_wait_us") {
+      alloc_fail_num_("vfs_write_pool_alloc_fail_num") {
   CHECK(pool_ != nullptr) << "WriteMemPool failed to create MemoryPool: page="
                           << page_size
                           << " count=" << (total_bytes / page_size);
 }
 
-char* WriteMemPool::Allocate() {
-  // A single Require() is try-semantics: nullptr means this attempt lost a
-  // cache/shard race OR the pool is exhausted -- it does NOT prove exhaustion.
-  // Bounded-retry until the deadline so transient contention under concurrency
-  // doesn't surface as a false failure; only a full window with no free buffer
-  // counts as genuine exhaustion (returns nullptr -> caller maps to ENOSPC).
+char* WriteMemPool::TryAllocate() {
+  // One Require(): try-semantics, never blocks, so it is safe under
+  // write_flush_mutex_ / slice_mutex_. Require() already sweeps all shards and
+  // steals from other caches internally, so a nullptr is a strong (near-)
+  // exhaustion signal; the caller (FileWriter throttle / short-write retry)
+  // owns any waiting, never this lock-holding layer.
   char* page = pool_->Require();
-  if (page == nullptr) {
-    // --- slow path: all metrics live here; the fast path above is untouched
-    // ---
-    transient_null_num_ << 1;  // first miss
-    acquire_wait_num_ << 1;    // this request entered bounded-acquire
-    const auto wait_start = std::chrono::steady_clock::now();
-    const auto deadline =
-        wait_start +
-        std::chrono::milliseconds(FLAGS_vfs_write_pool_acquire_timeout_ms);
-    uint32_t spins = 0;
-    while ((page = pool_->Require()) == nullptr) {
-      transient_null_num_ << 1;  // each retry miss
-      if (std::chrono::steady_clock::now() >= deadline) {
-        acquire_fail_num_ << 1;  // genuine exhaustion (bounded wait elapsed)
-        acquire_wait_us_ << ElapsedUs(wait_start);
-        return nullptr;
-      }
-      if (spins < kAcquireSpinYields) {
-        std::this_thread::yield();
-        ++spins;
-      } else {
-        std::this_thread::sleep_for(
-            std::chrono::microseconds(kAcquireBackoffUs));
-      }
-    }
-    acquire_wait_us_ << ElapsedUs(wait_start);
+  if (page != nullptr) {
+    used_pages_ << 1;
+  } else {
+    alloc_fail_num_ << 1;
   }
-  used_pages_ << 1;
   return page;
 }
 

--- a/src/common/writemempool/write_mem_pool.h
+++ b/src/common/writemempool/write_mem_pool.h
@@ -17,12 +17,10 @@
 #ifndef DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_MEM_POOL_H_
 #define DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_MEM_POOL_H_
 
-#include <gflags/gflags.h>
 #include <sys/types.h>
 
 #include <cstdint>
 
-#include "bvar/latency_recorder.h"
 #include "bvar/passive_status.h"
 #include "bvar/reducer.h"
 #include "bvar/status.h"
@@ -30,18 +28,19 @@
 
 namespace dingofs {
 
-// Bounded-acquire deadline (ms) for one write-page Allocate(). Defined in
-// write_mem_pool.cc; both DEFINE and DECLARE live in namespace dingofs (dingofs
-// keeps its gflags inside the namespace, see options/client.cc).
-DECLARE_int64(vfs_write_pool_acquire_timeout_ms);
-
 class WriteMemPool {
  public:
   explicit WriteMemPool(int64_t total_bytes, int64_t page_size);
 
   ~WriteMemPool() = default;
 
-  char* Allocate();
+  // Single try, never blocks -- the only allocation primitive. Safe under
+  // write_flush_mutex_ / slice_mutex_ (SliceWriter, BlockData hold them). The
+  // underlying MemoryPool::Require() already sweeps every shard and steals from
+  // other caches, so a nullptr is a strong (near-)exhaustion signal, not a
+  // casual shard-race miss. Any waiting/retry on a null is the caller's job
+  // (FileWriter's lock-free throttle / short-write retry), never this layer.
+  char* TryAllocate();
 
   void DeAllocate(char* page);
 
@@ -89,15 +88,10 @@ class WriteMemPool {
   bvar::PassiveStatus<int64_t> used_pages_var_;
   bvar::PassiveStatus<int64_t> used_bytes_var_;
 
-  // Slow-path counters (lock-free per-thread Adder). Bumped ONLY inside
-  // Allocate's bounded-acquire failure/retry branch -- the fast path (first
-  // Require() hit, ~99%) never touches these, so steady-state alloc cost is
-  // unchanged. The retry branch already yields/sleeps (us~ms), so the Adder's
-  // few ns are noise there.
-  bvar::Adder<int64_t> acquire_fail_num_;    // bounded-acquire timed out
-  bvar::Adder<int64_t> transient_null_num_;  // a TryRequire() returned null
-  bvar::Adder<int64_t> acquire_wait_num_;    // requests that entered retry
-  bvar::LatencyRecorder acquire_wait_us_;    // time spent in bounded-acquire
+  // Count of TryAllocate() failures (pool returned null -> caller surfaces
+  // ENOSPC / short write). Lock-free per-thread Adder, bumped only on the miss
+  // branch.
+  bvar::Adder<int64_t> alloc_fail_num_;
 };
 
 }  // namespace dingofs

--- a/test/unit/client/vfs/data/test_block_data.cc
+++ b/test/unit/client/vfs/data/test_block_data.cc
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2025 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "client/vfs/data/slice/block_data.h"
+#include "client/vfs/data/slice/common.h"
+#include "common/status.h"
+#include "common/trace/trace_manager.h"
+#include "common/writemempool/write_mem_pool.h"
+#include "test/unit/client/vfs/test_base.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+using ::testing::AnyNumber;
+using ::testing::Return;
+
+// Small geometry so tests stay cheap: 16 KiB block / 4 KiB page = 4 pages.
+static constexpr int64_t kPageSize = 4096;
+static constexpr int64_t kBlockSize = 4 * kPageSize;  // 4 pages
+static constexpr uint64_t kChunkSize = 64 * 1024 * 1024;
+static constexpr uint64_t kFsId = 1;
+static constexpr uint64_t kIno = 100;
+static constexpr uint64_t kChunkIndex = 0;
+
+class BlockDataTest : public test::VFSTestBase {
+ protected:
+  void SetUp() override {
+    trace_manager_ = std::make_unique<TraceManager>();
+    ON_CALL(*mock_hub_, GetTraceManager())
+        .WillByDefault(Return(trace_manager_.get()));
+    EXPECT_CALL(*mock_hub_, GetTraceManager()).Times(AnyNumber());
+
+    context_ = std::make_unique<SliceDataContext>(
+        kFsId, kIno, kChunkIndex, kChunkSize, kBlockSize, kPageSize);
+  }
+
+  // Build a pool with `slots` pages of kPageSize.
+  std::unique_ptr<WriteMemPool> MakePool(int slots) {
+    return std::make_unique<WriteMemPool>(
+        static_cast<int64_t>(slots) * kPageSize, kPageSize);
+  }
+
+  std::unique_ptr<BlockData> MakeBlock(WriteMemPool* pool,
+                                       int32_t block_offset = 0) {
+    return std::make_unique<BlockData>(*context_, mock_hub_, pool,
+                                       /*block_index=*/0, block_offset);
+  }
+
+  std::unique_ptr<TraceManager> trace_manager_;
+  std::unique_ptr<SliceDataContext> context_;
+};
+
+// ReservePages allocates the pages a write needs, records the new ones, and
+// leaves len_ untouched (reserve != apply).
+TEST_F(BlockDataTest, ReservePages_Success_RecordsNewPages_NoLenBump) {
+  auto pool = MakePool(4);
+  auto block = MakeBlock(pool.get());
+
+  std::vector<uint32_t> created;
+  Status s =
+      block->ReservePages(/*size=*/3 * kPageSize, /*block_offset=*/0, &created);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  EXPECT_EQ(created.size(), 3u);
+  EXPECT_EQ(block->Len(), 0);  // reserve does not bump len_
+  EXPECT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
+}
+
+// A reserve that outgrows the pool returns NoSpace; it does NOT self-rollback
+// (the SliceWriter transaction owns cross-block undo), so the pages it managed
+// to take stay recorded for the caller to roll back.
+TEST_F(BlockDataTest, ReservePages_Exhausted_ReturnsNoSpace_NoSelfRollback) {
+  auto pool = MakePool(2);
+  auto block = MakeBlock(pool.get());
+
+  std::vector<uint32_t> created;
+  Status s =
+      block->ReservePages(/*size=*/3 * kPageSize, /*block_offset=*/0, &created);
+  EXPECT_TRUE(s.IsNoSpace()) << s.ToString();
+  EXPECT_EQ(created.size(), 2u);  // took 2 before the 3rd missed
+  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);  // not self-rolled-back
+}
+
+// Pages already present (e.g. a partially-filled straddle page) are not
+// re-allocated and not recorded, so a later RollbackPages can't free them.
+TEST_F(BlockDataTest, ReservePages_SkipsExistingPages) {
+  auto pool = MakePool(4);
+  auto block = MakeBlock(pool.get());
+
+  std::vector<uint32_t> first;
+  ASSERT_TRUE(block->ReservePages(kPageSize, 0, &first).ok());
+  ASSERT_EQ(first.size(), 1u);
+
+  // Reserve [0, 2 pages): page0 already exists -> only page1 is new.
+  std::vector<uint32_t> second;
+  ASSERT_TRUE(block->ReservePages(2 * kPageSize, 0, &second).ok());
+  EXPECT_EQ(second.size(), 1u);
+  EXPECT_EQ(second[0], 1u);
+  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
+}
+
+// RollbackPages frees exactly the named pages and nothing else.
+TEST_F(BlockDataTest, RollbackPages_FreesOnlyNamedPages) {
+  auto pool = MakePool(4);
+  auto block = MakeBlock(pool.get());
+
+  std::vector<uint32_t> created;
+  ASSERT_TRUE(block->ReservePages(3 * kPageSize, 0, &created).ok());
+  ASSERT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
+
+  // Roll back only page index 2 -> 2 pages remain.
+  block->RollbackPages({created.back()});
+  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
+
+  // Roll back the rest -> back to empty.
+  block->RollbackPages({created[0], created[1]});
+  EXPECT_EQ(pool->GetUsedBytes(), 0);
+}
+
+// ApplyWrite memcpys into already-reserved pages and bumps len_, and must NOT
+// allocate -- the pool is drained dry before ApplyWrite and it still succeeds.
+TEST_F(BlockDataTest, ApplyWrite_NoAllocation_AfterReserve) {
+  auto pool = MakePool(2);
+  auto block = MakeBlock(pool.get());
+
+  const int32_t size = 2 * kPageSize;
+  std::vector<uint32_t> created;
+  ASSERT_TRUE(block->ReservePages(size, 0, &created).ok());
+  ASSERT_EQ(pool->GetUsedBytes(), size);  // pool now fully drained
+
+  std::vector<char> buf(size, 'Z');
+  block->ApplyWrite(ctx_, buf.data(), size, 0);
+
+  EXPECT_EQ(block->Len(), size);
+  EXPECT_EQ(pool->GetUsedBytes(), size);  // ApplyWrite did not allocate
+  // Data is durable in the pages.
+  EXPECT_EQ(block->ToIOBuffer().Size(), static_cast<size_t>(size));
+}
+
+// The reserve -> rollback -> reserve+apply sequence (what SliceWriter drives
+// per block) is atomic: a reserve larger than the pool leaves len_==0,
+// RollbackPages returns every page, and a same-offset reserve+apply afterwards
+// is clean (no contiguity CHECK trip).
+TEST_F(BlockDataTest, ReserveRollback_ThenReserveApply_SameOffsetClean) {
+  auto pool = MakePool(2);
+  auto block = MakeBlock(pool.get());
+
+  // Reserve more than the pool holds -> NoSpace, len untouched.
+  std::vector<uint32_t> created;
+  Status s = block->ReservePages(3 * kPageSize, 0, &created);
+  EXPECT_TRUE(s.IsNoSpace()) << s.ToString();
+  EXPECT_EQ(block->Len(), 0);
+
+  // Roll back the partial reservation -> pool fully returned.
+  block->RollbackPages(created);
+  EXPECT_EQ(pool->GetUsedBytes(), 0);
+  EXPECT_EQ(block->Len(), 0);
+
+  // Same offset now reserves + applies cleanly (2 pages fit).
+  std::vector<uint32_t> created2;
+  ASSERT_TRUE(block->ReservePages(2 * kPageSize, 0, &created2).ok());
+  std::vector<char> buf(2 * kPageSize, 'y');
+  block->ApplyWrite(ctx_, buf.data(), 2 * kPageSize, 0);
+  EXPECT_EQ(block->Len(), 2 * kPageSize);
+  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
+}
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/vfs/data/test_chunk_writer.cc
+++ b/test/unit/client/vfs/data/test_chunk_writer.cc
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <gflags/gflags.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -610,14 +609,13 @@ TEST_F(ChunkWriterTest, ConcurrentFlush_HoldsSliceMutexUntilQueuePush) {
 #endif  // NDEBUG
 }
 
-// --- P2 failure-path: pool exhaustion (WriteMemPool::Allocate -> nullptr) ---
+// --- P2 failure-path: pool exhaustion (WriteMemPool::TryAllocate -> nullptr)
+// ---
 
-// Tiny pool + zero acquire timeout makes exhaustion deterministic. A write
+// A tiny pool makes exhaustion deterministic (TryAllocate never waits). A write
 // needing more pages than the pool has must fail with NoSpace AND roll back
-// every page it briefly took (BlockData::Write pass-1 rollback) -- no leak.
+// every page it briefly took (BlockData reserve rollback) -- no leak.
 TEST_F(ChunkWriterTest, PoolExhaustion_WriteReturnsNoSpaceAndRollsBack) {
-  gflags::FlagSaver flag_saver;
-  FLAGS_vfs_write_pool_acquire_timeout_ms = 0;
   auto tiny_pool = std::make_unique<WriteMemPool>(4 * 4096, 4096);  // 4 slots
   ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny_pool.get()));
 
@@ -638,8 +636,6 @@ TEST_F(ChunkWriterTest, PoolExhaustion_WriteReturnsNoSpaceAndRollsBack) {
 // broken a waiter blocks forever and join() hangs (test times out). Reaching
 // the assertions proves no deadlock and no lost writer.
 TEST_F(ChunkWriterTest, PoolExhaustion_ConcurrentWritersAllWokenNoDeadlock) {
-  gflags::FlagSaver flag_saver;
-  FLAGS_vfs_write_pool_acquire_timeout_ms = 0;
   auto tiny_pool = std::make_unique<WriteMemPool>(4 * 4096, 4096);
   ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny_pool.get()));
 
@@ -679,8 +675,6 @@ TEST_F(ChunkWriterTest, PoolExhaustion_ConcurrentWritersAllWokenNoDeadlock) {
 // is flushed), the rest get NoSpace. The fix keeps okcnt > 0; the pre-fix bug
 // made it 0 for any batch that mixed success + failure.
 TEST_F(ChunkWriterTest, PoolExhaustion_PartialBatch_SuccessfulWritersReturnOK) {
-  gflags::FlagSaver flag_saver;
-  FLAGS_vfs_write_pool_acquire_timeout_ms = 0;
   auto tiny_pool = std::make_unique<WriteMemPool>(4 * 4096, 4096);  // 4 slots
   ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny_pool.get()));
 
@@ -716,6 +710,54 @@ TEST_F(ChunkWriterTest, PoolExhaustion_PartialBatch_SuccessfulWritersReturnOK) {
   EXPECT_EQ(tiny_pool->GetUsedBytes(),
             static_cast<int64_t>(okcnt.load()) * 4096)
       << "used should equal successful writers' pages with no leak";
+}
+
+// Cross-block atomicity regression. A single SliceWriter::Write that spans two
+// blocks where block0 reserves fully but block1 hits the exhausted pool must
+// roll back EVERYTHING (no half-write). Pre-fix, block0 was applied + len_ left
+// unbumped, so retrying the same offset re-entered an inconsistent BlockData
+// and tripped its contiguity CHECK (client abort). This asserts: NoSpace, zero
+// pool leak, AND that a retry at the same offset neither crashes nor wedges.
+TEST_F(ChunkWriterTest,
+       PoolExhaustion_CrossBlock_AtomicRollback_NoCrashOnRetry) {
+  // Derive geometry so the test follows the harness page size (and the fs block
+  // size) instead of hard-coding the pages-per-block count. context_.page_size
+  // == this pool's page (ChunkWriter takes it from GetWriteMemPool), so the
+  // page here is what BlockData actually allocates in.
+  constexpr int64_t kPage = 4096;
+  constexpr int64_t kBlockSize = 4 * 1024 * 1024;  // MakeTestFsInfo default
+  constexpr int64_t kBlockPages = kBlockSize / kPage;
+
+  // Pool holds exactly one block: block0 takes every page, block1's first page
+  // then fails.
+  auto pool = std::make_unique<WriteMemPool>(kBlockPages * kPage, kPage);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(pool.get()));
+
+  auto writer = MakeWriter();
+
+  // block_size + 1 page spans block0 (full) + block1 (1 page) -> one page more
+  // than the pool has.
+  const int32_t kWriteSize = static_cast<int32_t>(kBlockSize + kPage);
+  std::string buf(kWriteSize, 'x');
+
+  Status s1 = writer->Write(ctx_, buf.data(), kWriteSize, /*chunk_offset=*/0);
+  EXPECT_TRUE(s1.IsNoSpace()) << "expected NoSpace, got: " << s1.ToString();
+  EXPECT_EQ(pool->GetUsedBytes(), 0)
+      << "cross-block rollback must free block0's reserved pages";
+
+  // Retry SAME offset: must not abort (the pre-fix crash) and must fail
+  // cleanly.
+  Status s2 = writer->Write(ctx_, buf.data(), kWriteSize, /*chunk_offset=*/0);
+  EXPECT_TRUE(s2.IsNoSpace());
+  EXPECT_EQ(pool->GetUsedBytes(), 0);
+
+  // A write that fits (1 page) at the same offset now succeeds, proving slice
+  // state stayed consistent (End() == 0, no phantom len_).
+  std::string small(kPage, 'y');
+  Status s3 = writer->Write(ctx_, small.data(), static_cast<int32_t>(kPage),
+                            /*chunk_offset=*/0);
+  EXPECT_TRUE(s3.ok()) << s3.ToString();
+  EXPECT_EQ(pool->GetUsedBytes(), kPage);
 }
 
 }  // namespace vfs

--- a/test/unit/client/vfs/data/test_file_writer.cc
+++ b/test/unit/client/vfs/data/test_file_writer.cc
@@ -23,17 +23,18 @@
 
 #include "client/vfs/data/writer/file_writer.h"
 #include "common/trace/trace_manager.h"
+#include "common/writemempool/write_mem_pool.h"
 #include "test/unit/client/vfs/test_base.h"
 
 namespace dingofs {
 namespace client {
 namespace vfs {
 
+using dingofs::client::vfs::test::VFSTestBase;
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::Invoke;
 using ::testing::Return;
-using dingofs::client::vfs::test::VFSTestBase;
 
 class FileWriterTest : public VFSTestBase {
  protected:
@@ -89,6 +90,54 @@ TEST_F(FileWriterTest, Write_CrossingChunkBoundary) {
   Status s = w->Write(ctx_, buf.data(), kWriteSize, offset, &wsize);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(wsize, kWriteSize);
+
+  w->Close();
+  w->ReleaseRef();
+}
+
+// 2b. Cross-chunk pool exhaustion is a POSIX short write: chunk0 succeeds,
+//     chunk1 hits the exhausted pool. FileWriter must return OK with
+//     out_wsize == the chunk0 prefix (not an error that discards it), so the
+//     caller advances and re-issues the rest.
+TEST_F(FileWriterTest, Write_CrossChunk_PoolExhaustion_ShortWrite) {
+  // 1-page pool: chunk0's page fits, chunk1's page then fails.
+  auto tiny = std::make_unique<WriteMemPool>(4096, 4096);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny.get()));
+
+  auto* w = MakeOpenWriter();
+
+  const uint64_t chunk_size = mock_hub_->GetFsInfo().chunk_size;
+  // 8 bytes straddling the chunk 0/1 boundary: 4 bytes in each chunk.
+  constexpr uint64_t kWriteSize = 8;
+  uint64_t offset = chunk_size - 4;
+
+  std::vector<char> buf(kWriteSize, 'X');
+  uint64_t wsize = 0;
+  Status s = w->Write(ctx_, buf.data(), kWriteSize, offset, &wsize);
+
+  // Short write: OK, only the 4 bytes that landed in chunk 0.
+  EXPECT_TRUE(s.ok()) << s.ToString();
+  EXPECT_EQ(wsize, 4u);
+
+  w->Close();
+  w->ReleaseRef();
+}
+
+// 2c. First chunk itself exhausts the pool: zero bytes land, so the write is a
+//     hard failure -- NoSpace + out_wsize == 0 (not a short write).
+TEST_F(FileWriterTest, Write_FirstChunkNoSpace_ReturnsNoSpaceZeroWsize) {
+  // 1-page pool; a 2-page write to chunk 0 can't be reserved at all.
+  auto tiny = std::make_unique<WriteMemPool>(4096, 4096);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny.get()));
+
+  auto* w = MakeOpenWriter();
+
+  std::vector<char> buf(2 * 4096, 'X');  // 2 pages, pool holds 1
+  uint64_t wsize = 12345;                // poison: must end up 0
+  Status s = w->Write(ctx_, buf.data(), buf.size(), /*offset=*/0, &wsize);
+
+  EXPECT_TRUE(s.IsNoSpace()) << s.ToString();
+  EXPECT_EQ(wsize, 0u) << "zero bytes written -> hard failure, not short write";
 
   w->Close();
   w->ReleaseRef();
@@ -199,9 +248,10 @@ TEST_F(FileWriterTest, Write_AfterClose_ReturnsError) {
   w->Close();
 
   const char buf[] = "after close";
-  uint64_t wsize = 0;
+  uint64_t wsize = 12345;  // poison: the fast-fail path must reset it to 0
   Status s = w->Write(ctx_, buf, sizeof(buf), 0, &wsize);
   EXPECT_FALSE(s.ok());
+  EXPECT_EQ(wsize, 0u) << "fast-fail must define out_wsize = 0";
 
   // Release the ref (Close was already called above by test).
   w->ReleaseRef();
@@ -260,10 +310,10 @@ TEST_F(FileWriterTest, StickyStatus_BlocksSubsequentWrites) {
   ASSERT_FALSE(w->GetStatus().ok());
 
   const char buf[] = "blocked";
-  uint64_t wsize = 0;
+  uint64_t wsize = 12345;  // poison: the fast-fail path must reset it to 0
   Status s = w->Write(ctx_, buf, sizeof(buf), 0, &wsize);
-  EXPECT_FALSE(s.ok())
-      << "Write must fast-fail when sticky status is broken";
+  EXPECT_FALSE(s.ok()) << "Write must fast-fail when sticky status is broken";
+  EXPECT_EQ(wsize, 0u) << "fast-fail must define out_wsize = 0";
 
   w->Close();
   w->ReleaseRef();

--- a/test/unit/client/vfs/data/test_slice_writer.cc
+++ b/test/unit/client/vfs/data/test_slice_writer.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gflags/gflags.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -25,6 +26,7 @@
 #include "client/vfs/data/slice/slice_writer.h"
 #include "common/status.h"
 #include "common/trace/trace_manager.h"
+#include "common/writemempool/write_mem_pool.h"
 #include "test/unit/client/vfs/test_base.h"
 #include "test/unit/client/vfs/test_common.h"
 
@@ -118,6 +120,46 @@ TEST_F(SliceWriterTest, Write_MultiBlock_BoundaryAlignment) {
   EXPECT_EQ(sw_->Len(), write_size);
   // End should be chunk_offset + write_size
   EXPECT_EQ(sw_->End(), write_size);
+}
+
+// 2b. Cross-block pool exhaustion: SliceWriter::Write must be atomic. A write
+//     spanning two blocks where the pool only covers the first must roll back
+//     fully (Len() unchanged, zero leak), and a same-offset retry must not trip
+//     BlockData's contiguity CHECK (the pre-fix half-write crash).
+TEST_F(SliceWriterTest, Write_CrossBlock_PoolExhaustion_AtomicRollback) {
+  // Pool holds exactly one block's pages; block0 takes them all, block1 fails.
+  const int64_t block_pages = kBlockSize / kPageSize;
+  auto tiny =
+      std::make_unique<WriteMemPool>(block_pages * kPageSize, kPageSize);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny.get()));
+
+  // Use a LOCAL SliceWriter (not the fixture's sw_, which is torn down after
+  // `tiny`): the guard DecRefs it at scope exit, BEFORE `tiny` is destroyed, so
+  // pages from the final successful write are freed into a still-alive pool.
+  auto* sw = new SliceWriter(*context_, mock_hub_, /*chunk_offset=*/0);
+  sw->IncRef();
+  SliceWriterGuard guard(sw);
+
+  // block_size + 1 page spans block0 (full) + block1 (1 page) -> 1 page short.
+  const int32_t write_size = static_cast<int32_t>(kBlockSize + kPageSize);
+  auto buf = MakeBuf(write_size);
+
+  Status s1 = sw->Write(ctx_, buf.data(), write_size, 0);
+  EXPECT_TRUE(s1.IsNoSpace()) << s1.ToString();
+  EXPECT_EQ(sw->Len(), 0u) << "failed write must not bump slice len";
+  EXPECT_EQ(tiny->GetUsedBytes(), 0) << "block0's reserved pages must be freed";
+
+  // Retry same offset: clean, no abort.
+  Status s2 = sw->Write(ctx_, buf.data(), write_size, 0);
+  EXPECT_TRUE(s2.IsNoSpace());
+  EXPECT_EQ(sw->Len(), 0u);
+  EXPECT_EQ(tiny->GetUsedBytes(), 0);
+
+  // A fitting 1-page write at the same offset now succeeds (state consistent).
+  auto small = MakeBuf(kPageSize);
+  Status s3 = sw->Write(ctx_, small.data(), kPageSize, 0);
+  EXPECT_TRUE(s3.ok()) << s3.ToString();
+  EXPECT_EQ(sw->Len(), kPageSize);
 }
 
 // 3. Write data, mock NewSliceId returns id=42, mock PutAsync succeeds.

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
+#include <fcntl.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <memory>
 #include <string>
+#include <vector>
 
+#include "client/vfs/data/writer_table.h"
 #include "client/vfs/data_buffer.h"
 #include "client/vfs/vfs_impl.h"
 #include "common/blockaccess/accesser_common.h"
 #include "common/const.h"
 #include "common/status.h"
 #include "common/trace/trace_manager.h"
+#include "common/writemempool/write_mem_pool.h"
 #include "test/unit/client/vfs/mock/mock_meta_system.h"
 #include "test/unit/client/vfs/mock/mock_vfs_hub.h"
 #include "test/unit/client/vfs/test_base.h"
@@ -40,6 +44,7 @@ using ::testing::AnyNumber;
 using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::SaveArg;
 using ::testing::SetArgPointee;
 
 class VFSImplTest : public test::VFSTestBase {
@@ -112,6 +117,91 @@ TEST_F(VFSImplTest, GetAttr_DelegatesToMetaSystem) {
   Status s = vfs_->GetAttr(ctx_, 55u, &out);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(out.ino, 55u);
+}
+
+// --- 4b. Write short-write: metadata gets out_wsize, not the requested size.
+// On a cross-chunk write where the page pool is exhausted after chunk0, the
+// writer short-writes; VFSImpl must extend the inode length by only the durable
+// prefix (MetaSystem::Write sets length to offset+len), else reads past the
+// prefix would see a phantom hole. ---
+TEST_F(VFSImplTest, Write_ShortWrite_MetaGetsOutWsizeNotSize) {
+  // Locals ordered so writer_table (and the writer it owns) is destroyed before
+  // `tiny`: vfs_->Release below already tears the writer down synchronously,
+  // but this keeps the ordering safe regardless.
+  auto tiny = std::make_unique<WriteMemPool>(4096, 4096);  // 1 page
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny.get()));
+  EXPECT_CALL(*mock_hub_, GetWriteMemPool()).Times(AnyNumber());
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+
+  const uint64_t ino = 300;
+  ON_CALL(*mock_meta_system_, Open(_, ino, _, _))
+      .WillByDefault(Return(Status::OK()));
+  ON_CALL(*mock_meta_system_, Close(_, ino, _))
+      .WillByDefault(Return(Status::OK()));
+
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, ino, O_WRONLY, &fh).ok());
+
+  // Capture the size MetaSystem::Write receives (arg index 4).
+  uint64_t meta_size = 0;
+  EXPECT_CALL(*mock_meta_system_, Write(_, ino, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<4>(&meta_size), Return(Status::OK())));
+
+  const uint64_t chunk_size = mock_hub_->GetFsInfo().chunk_size;
+  const uint64_t offset = chunk_size - 4;  // 4 bytes chunk0, 4 bytes chunk1
+  std::vector<char> buf(8, 'X');
+  uint64_t wsize = 0;
+  Status s = vfs_->Write(ctx_, ino, buf.data(), buf.size(), offset, fh, &wsize);
+
+  EXPECT_TRUE(s.ok()) << s.ToString();
+  EXPECT_EQ(wsize, 4u);
+  EXPECT_EQ(meta_size, 4u)
+      << "metadata must extend by out_wsize (4), not the requested size (8)";
+
+  // Synchronously releases the handle -> writer -> frees pages into `tiny`.
+  vfs_->Release(ctx_, ino, fh);
+}
+
+// --- 4c. Metadata write fails after the data was already buffered. The writer
+// accepts the full write (out_wsize == size, data now dirty in its buffer), but
+// the inode metadata update fails, so VFSImpl::Write returns the error. The
+// buffered data may still be flushed later -- this is pre-existing behavior,
+// not introduced by the short-write change; the test pins the semantic. ---
+TEST_F(VFSImplTest, Write_MetaWriteFails_ReturnsErrorAfterDataBuffered) {
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+  // Uses the default (64 MiB) write pool from the fixture, so the writer
+  // accepts the whole write.
+
+  const uint64_t ino = 301;
+  ON_CALL(*mock_meta_system_, Open(_, ino, _, _))
+      .WillByDefault(Return(Status::OK()));
+  ON_CALL(*mock_meta_system_, Close(_, ino, _))
+      .WillByDefault(Return(Status::OK()));
+
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, ino, O_WRONLY, &fh).ok());
+
+  // Writer accepts the data; the metadata update then fails.
+  EXPECT_CALL(*mock_meta_system_, Write(_, ino, _, _, _, _))
+      .WillOnce(Return(Status::Internal("meta down")));
+
+  std::vector<char> buf(4096, 'X');
+  uint64_t wsize = 0;
+  Status s =
+      vfs_->Write(ctx_, ino, buf.data(), buf.size(), /*offset=*/0, fh, &wsize);
+
+  EXPECT_FALSE(s.ok()) << "metadata failure must surface as an error";
+  EXPECT_EQ(wsize, buf.size()) << "writer accepted the full write before "
+                                  "metadata failed (data buffered)";
+
+  vfs_->Release(ctx_, ino, fh);
 }
 
 // --- 5. GetAttr on .stats inode returns virtual attr ---

--- a/test/unit/common/writemempool/test_write_mem_pool.cc
+++ b/test/unit/common/writemempool/test_write_mem_pool.cc
@@ -28,22 +28,11 @@ namespace dingofs {
 
 // ─── WriteMemPool ──────────────────────────────────────────────────────
 
-TEST(WriteMemPoolTest, Allocate_ReturnsNonNull_IncreasesUsed) {
-  constexpr int64_t kPageSize = 4096;
-  WriteMemPool mgr(kPageSize * 4, kPageSize);
-
-  char* page = mgr.Allocate();
-  ASSERT_NE(page, nullptr);
-  EXPECT_EQ(mgr.GetUsedBytes(), kPageSize);
-
-  mgr.DeAllocate(page);
-}
-
 TEST(WriteMemPoolTest, DeAllocate_DecreasesUsed) {
   constexpr int64_t kPageSize = 4096;
   WriteMemPool mgr(kPageSize * 4, kPageSize);
 
-  char* page = mgr.Allocate();
+  char* page = mgr.TryAllocate();
   ASSERT_NE(page, nullptr);
   EXPECT_EQ(mgr.GetUsedBytes(), kPageSize);
 
@@ -65,8 +54,8 @@ TEST(WriteMemPoolTest, IsHighPressure_True_WhenAboveThreshold) {
   // 2 pages total; allocate 2 to hit 100% usage
   WriteMemPool mgr(kPageSize * 2, kPageSize);
 
-  char* p1 = mgr.Allocate();
-  char* p2 = mgr.Allocate();
+  char* p1 = mgr.TryAllocate();
+  char* p2 = mgr.TryAllocate();
   ASSERT_NE(p1, nullptr);
   ASSERT_NE(p2, nullptr);
 
@@ -89,7 +78,7 @@ TEST(WriteMemPoolTest, Concurrent_AllocAndDealloc_FinalZero) {
   for (int t = 0; t < kThreads; ++t) {
     threads.emplace_back([&mgr]() {
       for (int i = 0; i < kIters; ++i) {
-        char* page = mgr.Allocate();
+        char* page = mgr.TryAllocate();
         mgr.DeAllocate(page);
       }
     });
@@ -99,6 +88,39 @@ TEST(WriteMemPoolTest, Concurrent_AllocAndDealloc_FinalZero) {
   }
 
   EXPECT_EQ(mgr.GetUsedBytes(), 0);
+}
+
+// ─── TryAllocate ───────────────────────────────────────────────────────
+
+TEST(WriteMemPoolTest, TryAllocate_ReturnsNonNull_IncreasesUsed) {
+  constexpr int64_t kPageSize = 4096;
+  WriteMemPool mgr(kPageSize * 4, kPageSize);
+
+  char* page = mgr.TryAllocate();
+  ASSERT_NE(page, nullptr);
+  EXPECT_EQ(mgr.GetUsedBytes(), kPageSize);
+
+  mgr.DeAllocate(page);
+  EXPECT_EQ(mgr.GetUsedBytes(), 0);
+}
+
+TEST(WriteMemPoolTest, TryAllocate_ReturnsNull_WhenExhausted_NoBlock) {
+  constexpr int64_t kPageSize = 4096;
+  WriteMemPool mgr(kPageSize * 2, kPageSize);  // 2 slots
+
+  char* a = mgr.TryAllocate();
+  char* b = mgr.TryAllocate();
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+
+  // Pool drained -- TryAllocate returns immediately (no bounded wait) and used
+  // stays at capacity (a null result must not bump used_pages_).
+  char* c = mgr.TryAllocate();
+  EXPECT_EQ(c, nullptr);
+  EXPECT_EQ(mgr.GetUsedBytes(), 2 * kPageSize);
+
+  mgr.DeAllocate(a);
+  mgr.DeAllocate(b);
 }
 
 // ─── Perf: pooled Allocate/DeAllocate vs new char[] baseline ───────────
@@ -117,7 +139,7 @@ double RunPooledBench(WriteMemPool* wmp, int num_threads, int iters) {
     ts.emplace_back([&] {
       while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
       for (int i = 0; i < iters; ++i) {
-        char* p = wmp->Allocate();
+        char* p = wmp->TryAllocate();
         if (p != nullptr) wmp->DeAllocate(p);
       }
     });


### PR DESCRIPTION
> **WIP** — code + unit tests done; e2e (local + MDS) and vdbench soak pending.

Makes the FUSE write path correct under write-page pool exhaustion. Two
independent fixes (the pool can return no free page once flush falls behind a
slow backend):

## A. Cross-block atomicity (fixes a client crash)

`SliceWriter::Write` applied each block (memcpy + `BlockData::len_` bump) before
trying the next, so a later block hitting the exhausted pool left earlier blocks
written while `SliceWriter::len_` stayed unbumped. Because the append gate is
`CHECK_EQ(chunk_offset, End())` and `End()==chunk_offset_+len_`, a retry at the
same offset passed the gate, re-entered the already-filled block, and tripped
`BlockData`'s contiguity `CHECK` → **client abort**. Flush also uploaded the
orphaned block while the commit slice excluded it.

Fix — reserve-then-apply transaction:
- `WriteMemPool`: replace bounded-acquire `Allocate` with a single non-blocking
  `TryAllocate` (safe under the slice lock; `MemoryPool::Require` already sweeps
  all shards/caches, so a null is a strong exhaustion signal). Waiting is the
  caller's job, never the lock-holding layer.
- `BlockData`: split into `ReservePages` (allocate only) / `ApplyWrite` (memcpy +
  len, never allocates) / `RollbackPages` (free this call's new pages).
- `SliceWriter::Write`: reserve every block first; on any pool miss roll back this
  call's pages + drop blocks it created and return NoSpace (zero visible state →
  clean retry); only once all reserved does it apply each + bump len_ / FlushUpTo.

## B. Cross-chunk consistency (POSIX short write)

`FileWriter::Write` loops over chunks. With A, each chunk is atomic, but if
chunk0 succeeds and chunk1 hits the exhausted pool, chunk0's data is buffered
(will flush/commit) yet FileWriter returned the error → `VFSImpl` skipped the
metadata update and FUSE replied ENOSPC: the caller thinks nothing was written
while chunk0 persists, so inode length and durable data diverge.

Fix — report partial progress as a short write:
- `FileWriter::Write` returns OK + `out_wsize` = the fully-written prefix when
  `written_size > 0`; only a zero-byte write surfaces the error.
- `VFSImpl::Write` updates metadata + invalidates read cache with `*out_wsize`,
  not the requested size (`MetaSystem::Write` sets inode length to offset+len, so
  the full size would claim bytes never written).
- FUSE already replies `out_wsize` on OK, so the kernel/app re-issues the rest,
  which hits the throttle / backpressure.

## Test plan
- [x] WriteMemPool: TryAllocate hit/miss/no-block
- [x] BlockData: ReservePages / ApplyWrite (no-alloc) / RollbackPages + atomic retry
- [x] SliceWriter: cross-block exhaustion → atomic rollback, same-offset retry clean
- [x] ChunkWriter: per-writer batch status + cross-block exhaustion
- [x] FileWriter: cross-chunk exhaustion → short write (OK + chunk0 prefix)
- [x] VFSImpl: short write → metadata extends by out_wsize, not the requested size
- [x] e2e (local + MDS): local 32 passed, MDS precheck 5/5 + 32 passed (smoke)
- [ ] vdbench mixed-write soak

## Notes
- `ApplyWrite` carries an INVARIANT comment: it is infallible only because writes
  are append-only; a future random-overwrite path would break the two-phase
  transaction and must revisit the split.
