### PR TITLE
[fix][client] Compactor: don't crash the client when a compaction write fails

### DIFF
--- a/src/client/vfs/compaction/compactor_impl.cc
+++ b/src/client/vfs/compaction/compactor_impl.cc
@@ -142,8 +142,15 @@ Status CompactorImpl::DoCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
     Status ret =
         writer->Write(SpanScope::GetContext(span), to_write.data(),
                       static_cast<int32_t>(to_write.size()), offset_in_chunk);
-    CHECK(ret.ok()) << "Compaction write slice failed: " << ret.ToString()
-                    << ", ino: " << ino << ", chunk_index: " << chunk_index;
+    if (!ret.ok()) {
+      // Compaction is best-effort: a write failure (e.g. NoSpace when the write
+      // page pool is under back-pressure) must abort this compaction and be
+      // retried later, never crash the client. Propagate like the read/flush
+      // failures above; the caller (CompactChunkTask::Run) just logs it.
+      LOG(WARNING) << "Fail compaction because write failed: " << ret.ToString()
+                   << ", ino: " << ino << ", chunk_index: " << chunk_index;
+      return ret;
+    }
 
     Status s;
     BSynchronizer sync;


### PR DESCRIPTION
## Problem

Background chunk compaction writes the compacted slice through the **same write
page pool** as the foreground write path (`CompactorImpl::DoCompact` →
`SliceWriter::Write`). Under sustained back-pressure that pool can be exhausted,
and the write now returns `NoSpace` (write-page-pool exhaustion is surfaced as a
proper errno since the atomic-reservation work). But `DoCompact` `CHECK`-ed the
result, turning a transient, recoverable condition into a **FATAL client abort**:

```
F compactor_impl.cc:145] Check failed: ret.ok()
  Compaction write slice failed: NoSpace: write page pool exhausted,
  ino: 20000004476, chunk_index: 1
  @ CompactorImpl::DoCompact @ Compact @ CompactChunkTask::Run
```

Observed in an 8h vdbench consistency soak: the client died on this CHECK, the
FUSE mount went `ENOTCONN`, and vdbench reads then failed with `ECONNABORTED`
(no data miscompare — the data was fine; the client process had crashed).

## Fix

Compaction is best-effort. On a write failure, log and return — exactly like the
read-failure and flush-failure branches already do a few lines above in the same
function. The error propagates `DoCompact` → `Compact`
(`DINGOFS_RETURN_NOT_OK`) → `CompactChunkTask::Compact` (`if (!status.ok())
return`) → `CompactChunkTask::Run`, which only `LOG(ERROR)`s it. The chunk stays
uncompacted and is retried on a later compaction pass. No client crash.

The writer's `ScopedCleanup` already releases its ref on the early return, so
there is no leak.

## Test plan
- [x] `vfs_compaction` compiles on current main
- [ ] re-run the vdbench soak to confirm the client survives pool back-pressure
      during compaction (was the repro)