### PR TITLE
[fix][mds] Route trash restore to the MDS owning the original parent.

### DIFF
--- a/src/mds/client/mds.cc
+++ b/src/mds/client/mds.cc
@@ -321,6 +321,28 @@ GetFsInfoResponse MDSClient::GetFs(const std::string& fs_name) {
   return response;
 }
 
+GetFsInfoResponse MDSClient::GetFs(uint32_t fs_id) {
+  GetFsInfoRequest request;
+  GetFsInfoResponse response;
+
+  if (fs_id == 0) {
+    response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EILLEGAL_PARAMTETER);
+    response.mutable_error()->set_errmsg("fs_id is 0");
+    return response;
+  }
+
+  request.set_fs_id(fs_id);
+
+  auto status = interaction_->SendRequest("MDSService", "GetFsInfo", request, response);
+  if (!status.ok()) {
+    response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
+    response.mutable_error()->set_errmsg(status.error_str());
+    return response;
+  }
+
+  return response;
+}
+
 ListFsInfoResponse MDSClient::ListFs() {
   ListFsInfoRequest request;
   ListFsInfoResponse response;

--- a/src/mds/client/mds.h
+++ b/src/mds/client/mds.h
@@ -223,6 +223,7 @@ class MDSClient {
   DeleteFsResponse DeleteFs(const std::string& fs_name, bool is_force);
   UpdateFsInfoResponse UpdateFs(const std::string& fs_name, const pb::mds::FsInfo& fs_info);
   GetFsInfoResponse GetFs(const std::string& fs_name);
+  GetFsInfoResponse GetFs(uint32_t fs_id);
   ListFsInfoResponse ListFs();
 
   MkDirResponse MkDir(Ino parent, const std::string& name);

--- a/src/mds/client/trash_restore.cc
+++ b/src/mds/client/trash_restore.cc
@@ -73,7 +73,81 @@ bool TrashRestore::Init(const std::string& mds_addr, const Options& options) {
     std::cerr << "init mds client fail\n";
     return false;
   }
+  return InitRouting();
+}
+
+bool TrashRestore::InitRouting() {
+  auto fs_resp = client_->GetFs(options_.fs_id);
+  if (fs_resp.error().errcode() != pb::error::OK) {
+    std::cerr << fmt::format("get fs info fail: {} ({})\n", fs_resp.error().errmsg(),
+                             static_cast<int>(fs_resp.error().errcode()));
+    return false;
+  }
+  partition_policy_ = fs_resp.fs_info().partition_policy();
+
+  auto mds_resp = client_->GetMdsList();
+  if (mds_resp.error().errcode() != pb::error::OK) {
+    std::cerr << fmt::format("get mds list fail: {} ({})\n", mds_resp.error().errmsg(),
+                             static_cast<int>(mds_resp.error().errcode()));
+    return false;
+  }
+  std::unordered_map<uint64_t, std::string> mds_addrs;
+  for (const auto& mds : mds_resp.mdses()) {
+    mds_addrs[mds.id()] = fmt::format("{}:{}", mds.location().host(), mds.location().port());
+  }
+
+  std::unordered_set<uint64_t> owner_mds_ids;
+  if (partition_policy_.type() == pb::mds::PartitionType::MONOLITHIC_PARTITION) {
+    owner_mds_ids.insert(partition_policy_.mono().mds_id());
+
+  } else if (partition_policy_.type() == pb::mds::PartitionType::PARENT_ID_HASH_PARTITION) {
+    if (partition_policy_.parent_hash().bucket_num() == 0) {
+      std::cerr << "parent hash bucket_num is 0\n";
+      return false;
+    }
+    for (const auto& [mds_id, bucket_set] : partition_policy_.parent_hash().distributions()) {
+      owner_mds_ids.insert(mds_id);
+      for (const auto& bucket_id : bucket_set.bucket_ids()) bucket_to_mds_[bucket_id] = mds_id;
+    }
+
+  } else {
+    std::cerr << fmt::format("unknown partition type({})\n", pb::mds::PartitionType_Name(partition_policy_.type()));
+    return false;
+  }
+
+  for (uint64_t mds_id : owner_mds_ids) {
+    auto it = mds_addrs.find(mds_id);
+    if (it == mds_addrs.end()) {
+      LOG(WARNING) << fmt::format("mds({}) not in mds list, its restores fall back to seed mds", mds_id);
+      continue;
+    }
+    auto mds_client = std::make_unique<MDSClient>(options_.fs_id);
+    if (!mds_client->Init(it->second)) {
+      LOG(WARNING) << fmt::format("init client for mds({}) at {} fail, its restores fall back to seed mds", mds_id,
+                                  it->second);
+      continue;
+    }
+    mds_clients_[mds_id] = std::move(mds_client);
+  }
+
   return true;
+}
+
+MDSClient* TrashRestore::ClientForParent(Ino parent) {
+  uint64_t mds_id = 0;
+  if (partition_policy_.type() == pb::mds::PartitionType::MONOLITHIC_PARTITION) {
+    mds_id = partition_policy_.mono().mds_id();
+
+  } else {
+    auto it = bucket_to_mds_.find(static_cast<uint32_t>(parent % partition_policy_.parent_hash().bucket_num()));
+    if (it != bucket_to_mds_.end()) mds_id = it->second;
+  }
+
+  auto it = mds_clients_.find(mds_id);
+  if (it != mds_clients_.end()) return it->second.get();
+
+  LOG(WARNING) << fmt::format("no owner mds for parent({}), send restore to seed mds", parent);
+  return client_.get();
 }
 
 void TrashRestore::Run() {
@@ -223,7 +297,10 @@ void TrashRestore::RestoreOne(Ino bucket_ino, const pb::mds::Dentry& dentry) {
   }
 
   const bool allow_trash_parent = !options_.put_back;
-  auto resp = client_->RestoreFromTrash(bucket_ino, dentry.name(), kRootUid, allow_trash_parent);
+  // Route to the MDS owning orig_parent's partition so its inode/dentry
+  // caches are updated first-hand (the server can only heal misroutes
+  // asynchronously).
+  auto resp = ClientForParent(orig_parent)->RestoreFromTrash(bucket_ino, dentry.name(), kRootUid, allow_trash_parent);
   if (resp.error().errcode() == pb::error::OK) {
     restored_.fetch_add(1);
   } else {

--- a/src/mds/client/trash_restore.cc
+++ b/src/mds/client/trash_restore.cc
@@ -118,13 +118,13 @@ bool TrashRestore::InitRouting() {
   for (uint64_t mds_id : owner_mds_ids) {
     auto it = mds_addrs.find(mds_id);
     if (it == mds_addrs.end()) {
-      LOG(WARNING) << fmt::format("mds({}) not in mds list, its restores fall back to seed mds", mds_id);
+      LOG(ERROR) << fmt::format("mds({}) not in mds list, entries owned by it will fail to restore", mds_id);
       continue;
     }
     auto mds_client = std::make_unique<MDSClient>(options_.fs_id);
     if (!mds_client->Init(it->second)) {
-      LOG(WARNING) << fmt::format("init client for mds({}) at {} fail, its restores fall back to seed mds", mds_id,
-                                  it->second);
+      LOG(ERROR) << fmt::format("init client for mds({}) at {} fail, entries owned by it will fail to restore", mds_id,
+                                it->second);
       continue;
     }
     mds_clients_[mds_id] = std::move(mds_client);
@@ -146,8 +146,7 @@ MDSClient* TrashRestore::ClientForParent(Ino parent) {
   auto it = mds_clients_.find(mds_id);
   if (it != mds_clients_.end()) return it->second.get();
 
-  LOG(WARNING) << fmt::format("no owner mds for parent({}), send restore to seed mds", parent);
-  return client_.get();
+  return nullptr;
 }
 
 void TrashRestore::Run() {
@@ -298,9 +297,15 @@ void TrashRestore::RestoreOne(Ino bucket_ino, const pb::mds::Dentry& dentry) {
 
   const bool allow_trash_parent = !options_.put_back;
   // Route to the MDS owning orig_parent's partition so its inode/dentry
-  // caches are updated first-hand (the server can only heal misroutes
-  // asynchronously).
-  auto resp = ClientForParent(orig_parent)->RestoreFromTrash(bucket_ino, dentry.name(), kRootUid, allow_trash_parent);
+  // caches are updated first-hand. No route means no restore: sending the
+  // request to another MDS would leave the owner serving stale caches.
+  MDSClient* mds_client = ClientForParent(orig_parent);
+  if (mds_client == nullptr) {
+    LOG(ERROR) << fmt::format("no owner mds for parent({}), restore '{}' fail", orig_parent, dentry.name());
+    failed_.fetch_add(1);
+    return;
+  }
+  auto resp = mds_client->RestoreFromTrash(bucket_ino, dentry.name(), kRootUid, allow_trash_parent);
   if (resp.error().errcode() == pb::error::OK) {
     restored_.fetch_add(1);
   } else {

--- a/src/mds/client/trash_restore.h
+++ b/src/mds/client/trash_restore.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <queue>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -73,8 +74,26 @@ class TrashRestore {
   // (serial directory pre-pass).
   void RestoreOne(Ino bucket_ino, const pb::mds::Dentry& dentry);
 
+  // Fetch the fs partition policy and MDS list, then build one MDSClient per
+  // owner MDS. Returns false on failure.
+  bool InitRouting();
+  // Client connected to the MDS that owns parent's partition under the fs
+  // partition policy. Falls back to the seed client (with a warning) when no
+  // route is known.
+  MDSClient* ClientForParent(Ino parent);
+
   Options options_;
   std::unique_ptr<MDSClient> client_;
+
+  // Restore routing. RestoreFromTrash updates the dst parent's inode and
+  // dentry caches on the MDS that serves the request, so each request must go
+  // to the MDS owning the original parent's partition (same parent-hash
+  // scheme the FUSE client uses); otherwise the owner keeps serving stale
+  // caches and the restored entry stays invisible. Read-only after Init, so
+  // worker threads need no locking.
+  pb::mds::PartitionPolicy partition_policy_;
+  std::unordered_map<uint32_t, uint64_t> bucket_to_mds_;                  // parent-hash only
+  std::unordered_map<uint64_t, std::unique_ptr<MDSClient>> mds_clients_;  // mds_id -> client
 
   // Per-hour state. Reset at the top of each DoRestoreHour.
   std::mutex mu_;

--- a/src/mds/client/trash_restore.h
+++ b/src/mds/client/trash_restore.h
@@ -78,8 +78,9 @@ class TrashRestore {
   // owner MDS. Returns false on failure.
   bool InitRouting();
   // Client connected to the MDS that owns parent's partition under the fs
-  // partition policy. Falls back to the seed client (with a warning) when no
-  // route is known.
+  // partition policy. Returns nullptr when no route is known or the owner's
+  // client is unavailable; the caller fails the entry instead of misrouting
+  // it to another MDS.
   MDSClient* ClientForParent(Ino parent);
 
   Options options_;

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -3644,21 +3644,6 @@ Status FileSystem::RestoreFromTrash(Context& ctx, Ino trash_parent, const std::s
   // an empty parent_hash() and the notify helpers CHECK(mds_id != 0).
   if (IsParentHashPartition()) {
     NotifyBuddyRefreshInode(dst_parent_attr, cache_reason);
-    NotifyBuddyRefreshInode(file_attr, cache_reason);
-
-    // The restore RPC may have reached an MDS that doesn't own
-    // actual_dst_parent's partition (old CLI sending everything to one node,
-    // or a redistribution racing the restore run). The local cache updates
-    // above then landed on the wrong node, and the owner's caches can't heal
-    // by themselves: partition freshness is judged against the requester's
-    // parent version (see GetPartition), which the owner keeps serving stale.
-    // Push the new parent attr to the owner and drop its dentry cache so the
-    // next access rebuilds from KV and sees the restored entry.
-    const uint64_t dst_owner_mds_id = GetMdsIdByIno(actual_dst_parent);
-    if (dst_owner_mds_id != 0 && dst_owner_mds_id != self_mds_id_) {
-      NotifyBuddyRefreshInode({actual_dst_parent}, {.attr = dst_parent_attr}, cache_reason);
-      NotifyBuddyCleanPartitionCache(actual_dst_parent, cache_reason);
-    }
   }
 
   // Trash partitions don't participate in partition_cache_ (see

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -3639,6 +3639,28 @@ Status FileSystem::RestoreFromTrash(Context& ctx, Ino trash_parent, const std::s
   Dentry dentry(fs_id_, actual_dst_name, actual_dst_parent, result.file_ino, result.file_type, 0);
   AddDentryToPartition(actual_dst_parent, dentry, dst_parent_attr.version());
 
+  // Push the fresh dst-parent/file attrs to the other MDSes caching them,
+  // mirroring MkNod/Rename. Parent-hash only: under mono GetMdsIdByIno reads
+  // an empty parent_hash() and the notify helpers CHECK(mds_id != 0).
+  if (IsParentHashPartition()) {
+    NotifyBuddyRefreshInode(dst_parent_attr, cache_reason);
+    NotifyBuddyRefreshInode(file_attr, cache_reason);
+
+    // The restore RPC may have reached an MDS that doesn't own
+    // actual_dst_parent's partition (old CLI sending everything to one node,
+    // or a redistribution racing the restore run). The local cache updates
+    // above then landed on the wrong node, and the owner's caches can't heal
+    // by themselves: partition freshness is judged against the requester's
+    // parent version (see GetPartition), which the owner keeps serving stale.
+    // Push the new parent attr to the owner and drop its dentry cache so the
+    // next access rebuilds from KV and sees the restored entry.
+    const uint64_t dst_owner_mds_id = GetMdsIdByIno(actual_dst_parent);
+    if (dst_owner_mds_id != 0 && dst_owner_mds_id != self_mds_id_) {
+      NotifyBuddyRefreshInode({actual_dst_parent}, {.attr = dst_parent_attr}, cache_reason);
+      NotifyBuddyCleanPartitionCache(actual_dst_parent, cache_reason);
+    }
+  }
+
   // Trash partitions don't participate in partition_cache_ (see
   // GetPartitionFromStore), so there's nothing to evict here — the next
   // ls .trash/<bucket> reads dentries directly from KV.


### PR DESCRIPTION
The restoretrash CLI sent every RestoreFromTrash to the single MDS given by --mds_addr. Under PARENT_ID_HASH partitioning the serving MDS updates its own inode/partition caches, so when the request landed on a non-owner node, the MDS actually owning the original parent kept serving a stale parent attr and dentry cache. Since partition freshness is judged against the requester's parent version, the staleness never healed and the restored entry stayed invisible to clients routed to the owner.

Fix in two layers:
- CLI: fetch the fs partition policy and MDS list at init, build one client per owner MDS, and route each restore by orig_parent hash (mono: route to the mono owner). Trash bucket lookup/list stays on the seed MDS since trash bypasses the partition cache by design.
- Server: after a successful restore, notify buddies with the fresh dst-parent/file attrs (mirroring MkNod/Rename), and when the serving MDS is not the dst-parent owner (old CLI or a redistribution racing the run), push the new parent attr to the owner and drop its dentry cache so the next access rebuilds from KV.

<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
