### PR TITLE
feat(mds): directory usage statistics (dir-stats).

### DIFF
--- a/src/common/options/mds.h
+++ b/src/common/options/mds.h
@@ -41,6 +41,7 @@ DECLARE_uint32(mds_crontab_heartbeat_interval_s);
 DECLARE_uint32(mds_crontab_fsinfosync_interval_s);
 DECLARE_uint32(mds_crontab_mdsmonitor_interval_s);
 DECLARE_uint32(mds_crontab_quota_sync_interval_s);
+DECLARE_uint32(mds_crontab_dir_stats_sync_interval_s);
 DECLARE_uint32(mds_crontab_gc_interval_s);
 
 // server config

--- a/src/mds/background/dir_stats_sync.cc
+++ b/src/mds/background/dir_stats_sync.cc
@@ -12,33 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mds/background/quota_sync.h"
+#include "mds/background/dir_stats_sync.h"
 
 #include "mds/common/synchronization.h"
 
 namespace dingofs {
 namespace mds {
 
-void QuotaSynchronizer::Run() {
+void DirStatsSynchronizer::Run() {
   bool running = false;
   if (!is_running_.compare_exchange_strong(running, true)) {
     return;
   }
   DEFER(is_running_.store(false));
 
-  SyncFsQuota();
+  SyncDirStats();
 }
 
-void QuotaSynchronizer::SyncFsQuota() {
+void DirStatsSynchronizer::SyncDirStats() {
   auto fses = fs_set_->GetAllFileSystem();
   for (auto& fs : fses) {
-    auto& quota_manager = fs->GetQuotaManager();
-
-    // load fs and dir quota
-    quota_manager.LoadQuota();
-
-    // flush fs and dir usage
-    quota_manager.FlushUsage();
+    fs->GetDirStatManager().FlushDirStats();
   }
 }
 

--- a/src/mds/background/dir_stats_sync.h
+++ b/src/mds/background/dir_stats_sync.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DINGOFS_MDS_BACKGROUND_QUOTA_SYNC_H_
-#define DINGOFS_MDS_BACKGROUND_QUOTA_SYNC_H_
+#ifndef DINGOFS_MDS_BACKGROUND_DIR_STATS_SYNC_H_
+#define DINGOFS_MDS_BACKGROUND_DIR_STATS_SYNC_H_
 
 #include <atomic>
 #include <memory>
@@ -23,21 +23,24 @@
 namespace dingofs {
 namespace mds {
 
-class QuotaSynchronizer;
-using QuotaSynchronizerSPtr = std::shared_ptr<QuotaSynchronizer>;
+class DirStatsSynchronizer;
+using DirStatsSynchronizerSPtr = std::shared_ptr<DirStatsSynchronizer>;
 
-class QuotaSynchronizer {
+// Periodic per-filesystem dir-stats sync: flushes accumulated per-directory
+// dir-stat delta back to store. Flush-only (never loads). Driven by a
+// background crontab tick.
+class DirStatsSynchronizer {
  public:
-  QuotaSynchronizer(FileSystemSetSPtr fs_set) : fs_set_(fs_set) {};
-  ~QuotaSynchronizer() = default;
+  DirStatsSynchronizer(FileSystemSetSPtr fs_set) : fs_set_(fs_set) {};
+  ~DirStatsSynchronizer() = default;
 
-  static QuotaSynchronizerSPtr New(FileSystemSetSPtr fs_set) { return std::make_shared<QuotaSynchronizer>(fs_set); }
+  static DirStatsSynchronizerSPtr New(FileSystemSetSPtr fs_set) { return std::make_shared<DirStatsSynchronizer>(fs_set); }
 
   void Run();
 
  private:
-  // flush and load fs/dir quota
-  void SyncFsQuota();
+  // for each filesystem: flush dir-stats delta
+  void SyncDirStats();
 
   std::atomic<bool> is_running_{false};
 
@@ -47,4 +50,4 @@ class QuotaSynchronizer {
 }  // namespace mds
 }  // namespace dingofs
 
-#endif  // DINGOFS_MDS_BACKGROUND_QUOTA_SYNC_H_
+#endif  // DINGOFS_MDS_BACKGROUND_DIR_STATS_SYNC_H_

--- a/src/mds/common/codec.cc
+++ b/src/mds/common/codec.cc
@@ -82,6 +82,9 @@ static uint32_t kFileSessionKeySize = 1 + 4 + 1 + 8 + 36;
 // dir quota format: ${prefix} kTableFsMeta {fs_id} kMetaFsDirQuota {ino}
 static uint32_t kDirQuotaKeySize = 1 + 4 + 1 + 8;
 
+// dir stat format: ${prefix} kTableFsMeta {fs_id} kMetaFsDirStat {ino}
+static uint32_t kDirStatKeySize = 1 + 4 + 1 + 8;
+
 // inode delslice format: ${prefix} kTableFsMeta {fs_id} kMetaFsDelSlice {ino} {chunk_index} {time_ns}
 static uint32_t kDelSliceKeySize = 1 + 4 + 1 + 8 + 8 + 8;
 
@@ -139,6 +142,7 @@ enum MetaType : unsigned char {
   kMetaCacheMember = 25,
   kMetaFsTinyFileData = 27,
   kMetaFsSliceRef = 29,
+  kMetaFsDirStat = 31,
 };
 
 // inode meta type:
@@ -182,6 +186,7 @@ void MetaCodec::SetClusterID(uint32_t cluster_id) {
   kChunkKeySize += kPrefixSize;
   kFileSessionKeySize += kPrefixSize;
   kDirQuotaKeySize += kPrefixSize;
+  kDirStatKeySize += kPrefixSize;
   kDelSliceKeySize += kPrefixSize;
   kDelFileKeySize += kPrefixSize;
   kFsStatsKeySize += kPrefixSize;
@@ -509,6 +514,24 @@ Range MetaCodec::GetDirQuotaRange(uint32_t fs_id) {
   end.push_back(kTableFsMeta);
   SerialHelper::WriteInt(fs_id, end);
   end.push_back(kMetaFsDirQuota + 1);
+
+  return range;
+}
+
+Range MetaCodec::GetDirStatRange(uint32_t fs_id) {
+  Range range;
+
+  auto& start = range.start;
+  start = kPrefix;
+  start.push_back(kTableFsMeta);
+  SerialHelper::WriteInt(fs_id, start);
+  start.push_back(kMetaFsDirStat);
+
+  auto& end = range.end;
+  end = kPrefix;
+  end.push_back(kTableFsMeta);
+  SerialHelper::WriteInt(fs_id, end);
+  end.push_back(kMetaFsDirStat + 1);
 
   return range;
 }
@@ -1343,6 +1366,65 @@ QuotaEntry MetaCodec::DecodeDirQuotaValue(const std::string& value) {
   CHECK(dir_quota.ParseFromString(value)) << "parse dir quota fail.";
 
   return dir_quota;
+}
+
+// dir stat format: ${prefix} kTableFsMeta {fs_id} kMetaFsDirStat {ino}
+bool MetaCodec::IsDirStatKey(const std::string& key) {
+  if (key.size() != kDirStatKeySize) {
+    return false;
+  }
+  if (key.at(kPrefixSize) != kTableFsMeta || key.at(kPrefixSize + 1 + 4) != kMetaFsDirStat) {
+    return false;
+  }
+  return true;
+}
+
+std::string MetaCodec::EncodeDirStatKey(uint32_t fs_id, Ino ino) {
+  std::string key;
+  key.reserve(kDirStatKeySize);
+
+  key.append(kPrefix);
+  key.push_back(kTableFsMeta);
+  SerialHelper::WriteInt(fs_id, key);
+  key.push_back(kMetaFsDirStat);
+  SerialHelper::WriteULong(ino, key);
+
+  return key;
+}
+
+void MetaCodec::DecodeDirStatKey(const std::string& key, uint32_t& fs_id, Ino& ino) {
+  CHECK(IsDirStatKey(key)) << fmt::format("invalid dir stat key({}).", Helper::StringToHex(key));
+
+  fs_id = SerialHelper::ReadInt(key.substr(kPrefixSize + 1));
+  ino = SerialHelper::ReadULong(key.substr(kPrefixSize + 1 + 4 + 1));
+}
+
+std::string MetaCodec::EncodeDirStatValue(const DirStatEntry& dir_stat) {
+  std::string value = dir_stat.SerializeAsString();
+  // An all-zero DirStat (length/inodes/dirs all 0) serializes to empty bytes in
+  // proto3, but dingo-store rejects an empty value ("value is empty"). Emit an
+  // explicit inodes=0 field (tag 0x10 = field 2, varint; value 0x00) so the
+  // stored value is never empty yet still parses back to the same zero record --
+  // proto3 deserializes an explicit default-valued field identically to an
+  // absent one (see DecodeDirStatValue, which also still tolerates legacy empty
+  // values already in the store). Self-cleaning: any non-zero field makes
+  // SerializeAsString non-empty and the sentinel is not appended.
+  if (value.empty()) {
+    value.push_back('\x10');
+    value.push_back('\x00');
+  }
+  return value;
+}
+
+DirStatEntry MetaCodec::DecodeDirStatValue(const std::string& value) {
+  // An all-zero DirStat (a freshly-seeded or fully-emptied directory) serializes
+  // to empty bytes in proto3, so an empty value is valid here and parses to the
+  // zero record. Absence of the key is handled upstream via ENOT_FOUND, never by
+  // an empty value -- so don't reject empty here.
+  DirStatEntry dir_stat;
+  CHECK(dir_stat.ParseFromString(value)) << "parse dir stat fail.";
+
+  return dir_stat;
 }
 
 // inode delslice format: ${prefix} kTableFsMeta {fs_id} kMetaFsDelSlice {ino} {chunk_index} {time_ns}

--- a/src/mds/common/codec.h
+++ b/src/mds/common/codec.h
@@ -73,6 +73,9 @@ class MetaCodec {
   // format: ${prefix} kTableFsMeta {fs_id} kMetaDirQuota
   static Range GetDirQuotaRange(uint32_t fs_id);
 
+  // format: ${prefix} kTableFsMeta {fs_id} kMetaFsDirStat
+  static Range GetDirStatRange(uint32_t fs_id);
+
   // format: ${prefix} kTableFsMeta {fs_id} kMetaFsDelSlice
   static Range GetDelSliceRange(uint32_t fs_id);
   // format: ${prefix} kTableFsMeta {fs_id} kMetaFsDelSlice {ino}
@@ -193,6 +196,13 @@ class MetaCodec {
   static void DecodeDirQuotaKey(const std::string& key, uint32_t& fs_id, Ino& ino);
   static std::string EncodeDirQuotaValue(const QuotaEntry& dir_quota);
   static QuotaEntry DecodeDirQuotaValue(const std::string& value);
+
+  // dir stat format: ${prefix} kTableFsMeta {fs_id} kMetaFsDirStat {ino}
+  static bool IsDirStatKey(const std::string& key);
+  static std::string EncodeDirStatKey(uint32_t fs_id, Ino ino);
+  static void DecodeDirStatKey(const std::string& key, uint32_t& fs_id, Ino& ino);
+  static std::string EncodeDirStatValue(const DirStatEntry& dir_stat);
+  static DirStatEntry DecodeDirStatValue(const std::string& value);
 
   // inode delslice format: ${prefix} kTableFsMeta {fs_id} kMetaFsDelSlice {ino} {chunk_index} {time_ns}
   static bool IsDelSliceKey(const std::string& key);

--- a/src/mds/common/type.h
+++ b/src/mds/common/type.h
@@ -39,6 +39,25 @@ using TrashSliceEntry = pb::mds::TrashSlice;
 using TrashSliceList = pb::mds::TrashSliceList;
 using QuotaEntry = pb::mds::Quota;
 using UsageEntry = pb::mds::Usage;
+using DirStatEntry = pb::mds::DirStat;
+
+// in-memory single-level dir-stat delta (length/inodes/dirs)
+struct DirStatDelta {
+  int64_t length{0};
+  int64_t inodes{0};
+  int64_t dirs{0};
+};
+
+// a single buffered dir-stat delta tagged with a strictly-monotonic logical
+// timestamp. The timestamp lets the flush/recompute paths compact a time-bounded
+// prefix of the per-directory delta log (see DirStatManager) instead of dropping
+// the whole buffer -- mirrors quota's Usage{bytes,inodes,time_ns}.
+struct DirStatDeltaEntry {
+  int64_t length{0};
+  int64_t inodes{0};
+  int64_t dirs{0};
+  uint64_t time_ns{0};
+};
 using MdsEntry = pb::mds::MDS;
 using ClientEntry = pb::mds::Client;
 using FileSessionEntry = pb::mds::FileSession;

--- a/src/mds/filesystem/CMakeLists.txt
+++ b/src/mds/filesystem/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(mds_filesystem
     mds_service
     mds_background
     mds_quota
+    mds_statistics
 
     PROTO_OBJS
     protobuf::libprotobuf

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -3145,23 +3146,31 @@ Status FileSystem::CalcDirStat(Context& ctx, Ino ino, DirStatEntry& out) {
     // (bypassing the inode cache so a full-directory scan does not evict the hot
     // working set) instead of a serial per-child store round-trip. Sub-directory
     // children are counted into `dirs` so non-recursive summaries need no scan.
-    std::vector<uint64_t> file_inos;
-    file_inos.reserve(dentries.size());
+    //
+    // A same-directory hardlink (`ln f hl`) puts two dentries on one inode, so
+    // the inode number repeats within the page. BatchGet rejects duplicate keys,
+    // and length must still be charged once per dentry (matching `find`), so key
+    // the BatchGet by unique inode while remembering each inode's dentry count.
+    std::map<uint64_t, int64_t> file_ino_count;
     for (const auto& dentry : dentries) {
       if (dentry.Type() == pb::mds::FileType::FILE) {
-        file_inos.push_back(dentry.INo());
+        ++file_ino_count[dentry.INo()];
       } else if (dentry.Type() == pb::mds::FileType::DIRECTORY) {
         ++total_dirs;
       }
     }
 
-    if (file_inos.empty()) return Status::OK();
+    if (file_ino_count.empty()) return Status::OK();
+
+    std::vector<uint64_t> file_inos;
+    file_inos.reserve(file_ino_count.size());
+    for (const auto& [file_ino, count] : file_ino_count) file_inos.push_back(file_ino);
 
     std::vector<InodeSPtr> inodes;
     auto st = BatchGetInodeFromStore(ctx, file_inos, "CalcDirStat", /*is_cache=*/false, inodes);
     if (!st.ok()) return st;
     for (const auto& inode : inodes) {
-      total_length += static_cast<int64_t>(inode->Length());
+      total_length += static_cast<int64_t>(inode->Length()) * file_ino_count[inode->Ino()];
     }
     return Status::OK();
   });

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -48,6 +48,7 @@
 #include "mds/common/partition_helper.h"
 #include "mds/common/status.h"
 #include "mds/common/suffix_set.h"
+#include "mds/common/synchronization.h"
 #include "mds/common/tracing.h"
 #include "mds/common/trash.h"
 #include "mds/common/type.h"
@@ -163,7 +164,8 @@ static bool IsInodeInTrash(const InodeSPtr& inode) {
 FileSystem::FileSystem(uint64_t self_mds_id, FsInfoSPtr fs_info, IdGeneratorUPtr ino_id_generator,
                        IdGeneratorSPtr slice_id_generator, KVStorageSPtr kv_storage,
                        OperationProcessorSPtr operation_processor, MDSMetaMapSPtr mds_meta_map,
-                       WorkerSetSPtr quota_worker_set, notify::NotifyBuddySPtr notify_buddy)
+                       WorkerSetSPtr quota_worker_set, WorkerSetSPtr dir_stat_worker_set,
+                       notify::NotifyBuddySPtr notify_buddy)
     : self_mds_id_(self_mds_id),
       fs_info_(fs_info),
       fs_id_(fs_info_->GetFsId()),
@@ -177,8 +179,13 @@ FileSystem::FileSystem(uint64_t self_mds_id, FsInfoSPtr fs_info, IdGeneratorUPtr
       parent_memo_(fs_id_),
       chunk_cache_(fs_id_),
       quota_manager_(fs_info, parent_memo_, operation_processor, quota_worker_set, notify_buddy),
+      dir_stat_manager_(fs_info, operation_processor, dir_stat_worker_set),
       notify_buddy_(notify_buddy),
       file_session_manager_(fs_id_, operation_processor) {
+  // Inject the live-tree recompute: DirStatManager's seed/repair paths need it
+  // but the scan relies on FileSystem's dentry/inode traversal primitives.
+  dir_stat_manager_.SetRecomputeFn(
+      [this](Context& ctx, Ino ino, DirStatEntry& out) { return CalcDirStat(ctx, ino, out); });
   can_serve_ = CanServe(self_mds_id);
 };
 
@@ -828,6 +835,7 @@ Status FileSystem::BatchCreate(Context& ctx, Ino parent, const std::vector<MkNod
   // update quota
   quota_manager_.UpdateFsUsage(0, params.size(), reason);
   quota_manager_.AsyncUpdateDirUsage(parent, 0, params.size(), reason);
+  UpdateDirStat(parent, 0, static_cast<int64_t>(params.size()), 0, reason);
 
   // update parent memo
   for (auto& dentry : dentries) parent_memo_.Remeber(dentry.INo(), parent);
@@ -930,6 +938,7 @@ Status FileSystem::MkNod(Context& ctx, const MkNodParam& param, EntryOut& entry_
   // update quota
   quota_manager_.UpdateFsUsage(0, 1, reason);
   quota_manager_.AsyncUpdateDirUsage(param.parent, 0, 1, reason);
+  UpdateDirStat(param.parent, 0, 1, 0, reason);
 
   // update parent memo
   parent_memo_.Remeber(attr.ino(), param.parent);
@@ -1043,6 +1052,7 @@ Status FileSystem::BatchMkNod(Context& ctx, const std::vector<MkNodParam>& param
   // update quota
   quota_manager_.UpdateFsUsage(0, params.size(), reason);
   quota_manager_.AsyncUpdateDirUsage(parent, 0, params.size(), reason);
+  UpdateDirStat(parent, 0, static_cast<int64_t>(params.size()), 0, reason);
 
   // update parent memo
   for (const auto& dentry : dentries) parent_memo_.Remeber(dentry.INo(), parent);
@@ -1194,6 +1204,7 @@ Status FileSystem::Open(Context& ctx, Ino ino, const OpenParam& param, EntryOut&
     quota_manager_.UpdateFsUsage(delta_bytes, 0, reason);
     for (auto parent : attr.parents()) {
       quota_manager_.AsyncUpdateDirUsage(parent, delta_bytes, 0, reason);
+      UpdateDirStat(parent, delta_bytes, 0, 0, reason);
     }
   }
 
@@ -1298,6 +1309,7 @@ Status FileSystem::FlushFile(Context& ctx, Ino ino, const FlushFileParam& param,
 
     for (const auto& parent : attr.parents()) {
       quota_manager_.AsyncUpdateDirUsage(parent, delta_bytes, 0, reason);
+      UpdateDirStat(parent, delta_bytes, 0, 0, reason);
     }
   }
 
@@ -1442,6 +1454,7 @@ Status FileSystem::MkDir(Context& ctx, const MkDirParam& param, EntryOut& entry_
   // update quota
   quota_manager_.UpdateFsUsage(0, 1, reason);
   quota_manager_.AsyncUpdateDirUsage(param.parent, 0, 1, reason);
+  UpdateDirStat(param.parent, 0, 1, /*dir_delta=*/1, reason);
 
   // update parent memo
   parent_memo_.Remeber(attr.ino(), param.parent);
@@ -1554,6 +1567,8 @@ Status FileSystem::BatchMkDir(Context& ctx, const std::vector<MkDirParam>& param
   // update quota
   quota_manager_.UpdateFsUsage(0, params.size(), reason);
   quota_manager_.AsyncUpdateDirUsage(parent, 0, params.size(), reason);
+  UpdateDirStat(parent, 0, static_cast<int64_t>(params.size()),
+                /*dir_delta=*/static_cast<int64_t>(params.size()), reason);
 
   // update parent memo
   for (const auto& dentry : dentries) parent_memo_.Remeber(dentry.INo(), dentry.ParentIno());
@@ -1669,6 +1684,8 @@ Status FileSystem::RmDir(Context& ctx, Ino parent, const std::string& name, Ino&
       quota_manager_.AsyncUpdateDirUsage(parent, 0, -1, reason);
       quota_manager_.AsyncDeleteDirQuota(dentry.ino());
     }
+
+    UpdateDirStat(parent, 0, -1, /*dir_delta=*/-1, reason);
   }
 
   // update parent memo
@@ -1786,6 +1803,8 @@ Status FileSystem::Link(Context& ctx, Ino ino, Ino new_parent, const std::string
   // update quota
   std::string reason = fmt::format("link.{}.{}.{}.{}", request_id, ino, new_parent, new_name);
   quota_manager_.AsyncUpdateDirUsage(new_parent, attr.length(), 1, reason);
+  UpdateDirStat(new_parent, attr.type() == pb::mds::FileType::FILE ? static_cast<int64_t>(attr.length()) : 0, 1, 0,
+                reason);
 
   // update cache
   UpsertInodeCache(attr, reason);
@@ -1894,6 +1913,9 @@ Status FileSystem::UnLink(Context& ctx, Ino parent, const std::string& name, Ent
       if (attr.nlink() == 0) quota_manager_.UpdateFsUsage(-delta_bytes, -1, reason);
       quota_manager_.AsyncUpdateDirUsage(parent, -delta_bytes, -1, reason);
     }
+
+    // dir-stat: debit `parent` at dentry-move time (see UpdateDirStat docs).
+    UpdateDirStat(parent, -delta_bytes, -1, 0, reason);
   }
 
   if (attr.nlink() == 0) chunk_cache_.Delete(attr.ino());
@@ -1989,6 +2011,9 @@ Status FileSystem::BatchUnLink(Context& ctx, Ino parent, const std::vector<std::
   // Quota: same matrix as UnLink, applied per-child. Manual-cleanup parses
   // the per-entry origin parent from names[i] (trash entry name encoding).
   std::string reason = fmt::format("unlink.{}.{}.{}", request_id, parent, join_name);
+  // dir-stat: accumulate all removed children's deltas and apply once (one lock
+  // acquisition) after the loop. See UpdateDirStat docs for trash policy.
+  DirStatDelta dir_stat_delta;
   for (size_t i = 0; i < child_attrs.size(); ++i) {
     const auto& attr = child_attrs[i];
     const int64_t delta_bytes = attr.type() == pb::mds::FILE ? static_cast<int64_t>(attr.length()) : 0;
@@ -2011,9 +2036,15 @@ Status FileSystem::BatchUnLink(Context& ctx, Ino parent, const std::vector<std::
         if (attr.nlink() == 0) quota_manager_.UpdateFsUsage(-delta_bytes, -1, reason);
         quota_manager_.AsyncUpdateDirUsage(parent, -delta_bytes, -1, reason);
       }
+
+      dir_stat_delta.length -= delta_bytes;
+      dir_stat_delta.inodes -= 1;
     }
 
     if (attr.nlink() == 0) chunk_cache_.Delete(attr.ino());
+  }
+  if (dir_stat_delta.inodes != 0) {
+    UpdateDirStat(parent, dir_stat_delta.length, dir_stat_delta.inodes, 0, reason);
   }
 
   // update cache
@@ -2119,6 +2150,9 @@ Status FileSystem::Symlink(Context& ctx, const std::string& symlink, Ino new_par
 
   quota_manager_.UpdateFsUsage(0, 1, reason);
   quota_manager_.AsyncUpdateDirUsage(new_parent, 0, 1, reason);
+  // symlink contributes 0 length (consistent with
+  // CalcDirStat treating non-FILE as length 0).
+  UpdateDirStat(new_parent, 0, 1, 0, reason);
 
   // set output
   entry_out.parent_attr = last_parent_attr;
@@ -2217,6 +2251,7 @@ Status FileSystem::SetAttr(Context& ctx, Ino ino, const SetAttrParam& param, Ent
 
     for (const auto& parent : attr.parents()) {
       quota_manager_.AsyncUpdateDirUsage(parent, delta_bytes, 0, reason);
+      UpdateDirStat(parent, delta_bytes, 0, 0, reason);
     }
   }
 
@@ -2646,6 +2681,25 @@ Status FileSystem::Rename(Context& ctx, const RenameParam& param, uint64_t& old_
     }
   }
 
+  // update dir-stat. Independent of trash: the dentry physically moves between
+  // parents at rename time, and the overwritten target leaves new_parent now.
+  // (src = renamed entry, tgt = overwritten existing entry.)
+  {
+    const bool src_is_file = (dentry.Type() == pb::mds::FileType::FILE);
+    const bool src_is_dir = (dentry.Type() == pb::mds::FileType::DIRECTORY);
+    const int64_t src_len = src_is_file ? static_cast<int64_t>(old_attr.length()) : 0;
+    if (!is_same_parent) {
+      UpdateDirStat(old_parent, -src_len, -1, /*dir_delta=*/src_is_dir ? -1 : 0, reason);
+      UpdateDirStat(new_parent, +src_len, +1, /*dir_delta=*/src_is_dir ? +1 : 0, reason);
+    }
+    if (is_exist_new_dentry) {
+      const bool tgt_is_file = (prev_new_attr.type() == pb::mds::FileType::FILE);
+      const bool tgt_is_dir = (prev_new_attr.type() == pb::mds::FileType::DIRECTORY);
+      const int64_t tgt_len = tgt_is_file ? static_cast<int64_t>(prev_new_attr.length()) : 0;
+      UpdateDirStat(new_parent, -tgt_len, -1, /*dir_delta=*/tgt_is_dir ? -1 : 0, reason);
+    }
+  }
+
   // If an hour bucket was renamed out of .trash, the cached <bucket_name,
   // bucket_ino> may now point at an inode that no longer lives under .trash.
   // Drop the cache so subsequent trash-move requests re-resolve cleanly.
@@ -2833,6 +2887,13 @@ Status FileSystem::CopyFileRange(Context& ctx, const CopyFileRangeParam& param, 
   if (length_delta > 0) {
     quota_manager_.UpdateFsUsage(length_delta, 0, reason);
     quota_manager_.AsyncUpdateDirUsage(param.dst_ino, length_delta, 0, reason);
+
+    // dir-stat must target the dst file's parent directory(ies) (CalcDirStat
+    // sums over a directory's children), not the file inode. dst_attr carries
+    // the parent list.
+    for (const auto& parent : dst_attr.parents()) {
+      UpdateDirStat(parent, length_delta, 0, 0, reason);
+    }
   }
 
   entry_out.attr = dst_attr;
@@ -2937,6 +2998,20 @@ Status FileSystem::Fallocate(Context& ctx, Ino ino, int32_t mode, uint64_t offse
   std::string reason = fmt::format("fallocate.{}.{}", request_id, ino);
   UpsertInodeCache(attr, reason);
 
+  // Preallocate / ZERO_RANGE-without-KEEP_SIZE may have extended the file; charge
+  // the growth to quota and the parent directories' dir-stat, mirroring the other
+  // length-mutating paths (Open/O_TRUNC, FlushFile, SetAttr, CopyFileRange). Use
+  // the delta computed inside the operation's txn from the authoritative
+  // pre-image: re-reading inode->Length() here is wrong because UpsertInodeCache
+  // above mutates the cached inode in-place, which would zero the delta.
+  if (delta_bytes > 0) {
+    quota_manager_.UpdateFsUsage(delta_bytes, 0, reason);
+    quota_manager_.AsyncUpdateDirUsage(ino, delta_bytes, 0, reason);
+    for (const auto& parent : attr.parents()) {
+      UpdateDirStat(parent, delta_bytes, 0, 0, reason);
+    }
+  }
+
   // update chunk cache
   for (auto& chunk : effected_chunks) chunk_cache_.PutIf(ino, chunk);
 
@@ -3013,6 +3088,91 @@ Status FileSystem::GetDentry(Context& ctx, Ino parent, const std::string& name, 
   }
 
   return GetDentryFromStore(parent, name, dentry);
+}
+
+void FileSystem::UpdateDirStat(Ino parent, int64_t length_delta, int64_t inode_delta, int64_t dir_delta,
+                               const std::string& reason) {
+  if (!EnableDirStats()) return;
+  // Trash buckets (kTrashInodeId and the hour-bucket inodes) are never tracked.
+  // Gate here so every caller is covered in one place -- e.g. a Rename rescuing
+  // a child out of an hour bucket, or a flush/setattr on a hardlinked file whose
+  // parents still include a bucket -- instead of each site needing its own guard
+  // (a missed one silently materializes a never-reclaimed bucket record).
+  if (IsTrashInode(parent)) return;
+  dir_stat_manager_.AsyncUpdateDirStat(parent, length_delta, inode_delta, dir_delta, reason);
+}
+
+template <typename Fn>
+Status FileSystem::ForEachDentryPage(Context& ctx, Ino ino, bool is_only_dir, Fn fn) {
+  constexpr uint32_t kDirStatScanPageSize = 1000;
+  std::string last_name;
+  for (;;) {
+    std::vector<Dentry> dentries;
+    auto status = ListDentry(ctx, ino, last_name, kDirStatScanPageSize, is_only_dir, dentries);
+    if (!status.ok()) return status;
+    if (dentries.empty()) break;
+
+    const bool full_page = dentries.size() >= kDirStatScanPageSize;
+    // The store-backed ListDentry scans inclusive of last_name while the cache
+    // path is exclusive; drop the duplicated boundary entry so it is never
+    // processed twice across pages (names are unique within a directory).
+    const bool dup_front = (!last_name.empty() && dentries.front().Name() == last_name);
+    last_name = dentries.back().Name();
+    if (dup_front) dentries.erase(dentries.begin());
+
+    if (!dentries.empty()) {
+      status = fn(dentries);
+      if (!status.ok()) return status;
+    }
+
+    if (!full_page) break;
+  }
+  return Status::OK();
+}
+
+Status FileSystem::CalcDirStat(Context& ctx, Ino ino, DirStatEntry& out) {
+  out.Clear();
+
+  int64_t total_inodes = 0;
+  int64_t total_dirs = 0;
+  int64_t total_length = 0;
+
+  auto status = ForEachDentryPage(ctx, ino, /*is_only_dir=*/false, [&](const std::vector<Dentry>& dentries) -> Status {
+    total_inodes += static_cast<int64_t>(dentries.size());
+
+    // Only files carry a non-zero length; dirs/symlinks contribute none. Collect
+    // the file children of this page and read their inodes in one BatchGetInode
+    // (bypassing the inode cache so a full-directory scan does not evict the hot
+    // working set) instead of a serial per-child store round-trip. Sub-directory
+    // children are counted into `dirs` so non-recursive summaries need no scan.
+    std::vector<uint64_t> file_inos;
+    file_inos.reserve(dentries.size());
+    for (const auto& dentry : dentries) {
+      if (dentry.Type() == pb::mds::FileType::FILE) {
+        file_inos.push_back(dentry.INo());
+      } else if (dentry.Type() == pb::mds::FileType::DIRECTORY) {
+        ++total_dirs;
+      }
+    }
+
+    if (file_inos.empty()) return Status::OK();
+
+    std::vector<InodeSPtr> inodes;
+    auto st = BatchGetInodeFromStore(ctx, file_inos, "CalcDirStat", /*is_cache=*/false, inodes);
+    if (!st.ok()) return st;
+    for (const auto& inode : inodes) {
+      total_length += static_cast<int64_t>(inode->Length());
+    }
+    return Status::OK();
+  });
+
+  if (!status.ok()) return status;
+
+  out.set_inodes(total_inodes);
+  out.set_dirs(total_dirs);
+  out.set_length(total_length);
+
+  return Status::OK();
 }
 
 Status FileSystem::ListDentry(Context& ctx, Ino parent, const std::string& last_name, uint32_t limit, bool is_only_dir,
@@ -3715,6 +3875,22 @@ Status FileSystem::RestoreFromTrash(Context& ctx, Ino trash_parent, const std::s
     quota_manager_.AsyncUpdateDirUsage(actual_dst_parent, delta_bytes, 1, reason);
   }
 
+  // dir-stat: any restore re-adds the dentry to actual_dst_parent, so credit
+  // that directory -- mirroring the trash-move debit symmetrically (debit at
+  // dentry-move time, credit at dentry-restore time), independent of
+  // immediate_trash_quota. This must be gated on "dst is a real user directory"
+  // rather than allow_trash_parent: a tree-rebuild graft (allow_trash_parent)
+  // still moves the dentry into a real (merely trashed) user dir, and that dir
+  // may later be put_back carrying the dentry along -- if we skip the credit
+  // here, the restored dir's stat permanently under-counts the grafted child.
+  // The only dst we must NOT credit is the trash bucket itself (which is never
+  // tracked); a bucket-range dst means the entry stays loose in trash.
+  if (!IsTrashInode(actual_dst_parent)) {
+    UpdateDirStat(actual_dst_parent,
+                  file_attr.type() == pb::mds::FileType::FILE ? static_cast<int64_t>(file_attr.length()) : 0, 1,
+                  /*dir_delta=*/file_attr.type() == pb::mds::FileType::DIRECTORY ? 1 : 0, cache_reason);
+  }
+
   return status;
 }
 
@@ -3746,7 +3922,8 @@ void FileSystem::RecordTrashMoveOutcome(Ino bucket_ino) {
 FileSystemSet::FileSystemSet(CoordinatorClientSPtr coordinator_client, IdGeneratorUPtr fs_id_generator,
                              IdGeneratorSPtr slice_id_generator, KVStorageSPtr kv_storage, MDSMeta self_mds_meta,
                              MDSMetaMapSPtr mds_meta_map, OperationProcessorSPtr operation_processor,
-                             WorkerSetSPtr quota_worker_set, notify::NotifyBuddySPtr notify_buddy)
+                             WorkerSetSPtr quota_worker_set, WorkerSetSPtr dir_stat_worker_set,
+                             notify::NotifyBuddySPtr notify_buddy)
     : coordinator_client_(coordinator_client),
       fs_id_generator_(std::move(fs_id_generator)),
       slice_id_generator_(slice_id_generator),
@@ -3755,6 +3932,7 @@ FileSystemSet::FileSystemSet(CoordinatorClientSPtr coordinator_client, IdGenerat
       mds_meta_map_(mds_meta_map),
       operation_processor_(operation_processor),
       quota_worker_set_(quota_worker_set),
+      dir_stat_worker_set_(dir_stat_worker_set),
       notify_buddy_(notify_buddy) {}
 
 FileSystemSet::~FileSystemSet() {}  // NOLINT
@@ -4023,7 +4201,8 @@ Status FileSystemSet::CreateFs(const CreateFsParam& param, FsInfoEntry& fs_info)
   CHECK(ino_id_generator != nullptr) << "new id generator fail.";
 
   auto fs = FileSystem::New(self_mds_meta_.ID(), FsInfo::New(fs_info), std::move(ino_id_generator), slice_id_generator_,
-                            kv_storage_, operation_processor_, mds_meta_map_, quota_worker_set_, notify_buddy_);
+                            kv_storage_, operation_processor_, mds_meta_map_, quota_worker_set_, dir_stat_worker_set_,
+                            notify_buddy_);
   if (!fs->Init()) {
     cleanup(fs_id, table_id, fs_key, "");
     return Status(pb::error::EINTERNAL, "init FileSystem fail");
@@ -4425,7 +4604,8 @@ bool FileSystemSet::LoadFileSystems() {
     CHECK(ino_id_generator != nullptr) << "new id generator fail.";
 
     fs = FileSystem::New(self_mds_meta_.ID(), FsInfo::New(fs_info), std::move(ino_id_generator), slice_id_generator_,
-                         kv_storage_, operation_processor_, mds_meta_map_, quota_worker_set_, notify_buddy_);
+                         kv_storage_, operation_processor_, mds_meta_map_, quota_worker_set_, dir_stat_worker_set_,
+                         notify_buddy_);
     if (!fs->Init()) {
       LOG(ERROR) << fmt::format("[fsset.{}.{}] init filesystem fail.", fs_info.fs_name(), fs_info.fs_id());
       continue;

--- a/src/mds/filesystem/filesystem.h
+++ b/src/mds/filesystem/filesystem.h
@@ -30,6 +30,7 @@
 #include "mds/common/status.h"
 #include "mds/common/trash.h"
 #include "mds/common/type.h"
+#include "mds/statistics/dir_stat_manager.h"
 #include "mds/filesystem/chunk_cache.h"
 #include "mds/filesystem/dentry.h"
 #include "mds/filesystem/file_session.h"
@@ -90,7 +91,8 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
  public:
   FileSystem(uint64_t self_mds_id, FsInfoSPtr fs_info, IdGeneratorUPtr ino_id_generator,
              IdGeneratorSPtr slice_id_generator, KVStorageSPtr kv_storage, OperationProcessorSPtr operation_processor,
-             MDSMetaMapSPtr mds_meta_map, WorkerSetSPtr quota_worker_set, notify::NotifyBuddySPtr notify_buddy);
+             MDSMetaMapSPtr mds_meta_map, WorkerSetSPtr quota_worker_set, WorkerSetSPtr dir_stat_worker_set,
+             notify::NotifyBuddySPtr notify_buddy);
   ~FileSystem();
 
   FileSystem(const FileSystem&) = delete;
@@ -101,9 +103,11 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
   static FileSystemSPtr New(uint64_t self_mds_id, FsInfoSPtr fs_info, IdGeneratorUPtr ino_id_generator,
                             IdGeneratorSPtr slice_id_generator, KVStorageSPtr kv_storage,
                             OperationProcessorSPtr operation_processor, MDSMetaMapSPtr mds_meta_map,
-                            WorkerSetSPtr quota_worker_set, notify::NotifyBuddySPtr notify_buddy) {
+                            WorkerSetSPtr quota_worker_set, WorkerSetSPtr dir_stat_worker_set,
+                            notify::NotifyBuddySPtr notify_buddy) {
     return std::make_shared<FileSystem>(self_mds_id, fs_info, std::move(ino_id_generator), slice_id_generator,
-                                        kv_storage, operation_processor, mds_meta_map, quota_worker_set, notify_buddy);
+                                        kv_storage, operation_processor, mds_meta_map, quota_worker_set,
+                                        dir_stat_worker_set, notify_buddy);
   }
 
   FileSystemSPtr GetSelfPtr();
@@ -273,6 +277,12 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
   };
   Status CompactChunk(Context& ctx, Ino ino, uint32_t index, const CompactChunkParam& param, ChunkEntry& chunk_out);
 
+  // Recompute a directory's single-level stat by scanning the live tree. Stays
+  // in FileSystem because it relies on the dentry/inode traversal primitives
+  // (ForEachDentryPage + BatchGetInodeFromStore); DirStatManager invokes it via
+  // an injected recompute callback for its seed/repair paths.
+  Status CalcDirStat(Context& ctx, Ino ino, DirStatEntry& out);
+
   // dentry/inode
   Status GetDentry(Context& ctx, Ino parent, const std::string& name, Dentry& dentry);
   Status ListDentry(Context& ctx, Ino parent, const std::string& last_name, uint32_t limit, bool is_only_dir,
@@ -299,6 +309,11 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
   InodeCache& GetInodeCache() { return inode_cache_; }
 
   quota::QuotaManager& GetQuotaManager() { return quota_manager_; }
+
+  dir_stat::DirStatManager& GetDirStatManager() { return dir_stat_manager_; }
+  // Read live from fs_info_ so a runtime toggle (propagated via RefreshFsInfo)
+  // takes effect without recreating the FileSystem.
+  bool EnableDirStats() const { return fs_info_->EnableDirStats(); }
 
   FileSessionManager& GetFileSessionManager() { return file_session_manager_; }
 
@@ -340,6 +355,11 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
   Status ListDentryFromStore(Ino parent, const std::string& last_name, uint32_t limit, bool is_only_dir,
                              std::vector<Dentry>& dentries);
 
+  // paged iteration handing each page (vector<Dentry>) to fn, so callers can
+  // batch per-page work (e.g. one BatchGetInode instead of one read per child).
+  template <typename Fn>
+  Status ForEachDentryPage(Context& ctx, Ino ino, bool is_only_dir, Fn fn);
+
   // get inode
   Status GetInode(Context& ctx, Ino ino, InodeSPtr& out_inode);
   Status GetInode(Context& ctx, uint64_t version, Ino ino, InodeSPtr& out_inode);
@@ -374,6 +394,13 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
   void NotifyBuddyRefreshInode(const std::vector<Ino>& parents, const AttrOrMutation& attr_or_mutation,
                                const std::string& reason);
   void NotifyBuddyCleanPartitionCache(Ino ino, const std::string& reason);
+
+  // Accumulate a single-level dir-stat delta on `parent`: logical-length and
+  // child-count deltas (both signed). Debits (unlink/rmdir/trash-move) pass
+  // negative deltas; a cleaned trash-bucket entry is never a tracked dir so it
+  // contributes nothing. No-op unless EnableDirStats().
+  void UpdateDirStat(Ino parent, int64_t length_delta, int64_t inode_delta, int64_t dir_delta,
+                     const std::string& reason);
 
   TrashMove BuildTrashMove(Ino parent);
 
@@ -419,6 +446,9 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
   // quota
   quota::QuotaManager quota_manager_;
 
+  // dir stats
+  dir_stat::DirStatManager dir_stat_manager_;
+
   // renamer
   Renamer renamer_;
 
@@ -437,7 +467,7 @@ class FileSystemSet {
   FileSystemSet(CoordinatorClientSPtr coordinator_client, IdGeneratorUPtr fs_id_generator,
                 IdGeneratorSPtr slice_id_generator, KVStorageSPtr kv_storage, MDSMeta self_mds_meta,
                 MDSMetaMapSPtr mds_meta_map, OperationProcessorSPtr operation_processor, WorkerSetSPtr quota_worker_set,
-                notify::NotifyBuddySPtr notify_buddy);
+                WorkerSetSPtr dir_stat_worker_set, notify::NotifyBuddySPtr notify_buddy);
   ~FileSystemSet();
 
   FileSystemSet(const FileSystemSet&) = delete;
@@ -448,10 +478,11 @@ class FileSystemSet {
   static FileSystemSetSPtr New(CoordinatorClientSPtr coordinator_client, IdGeneratorUPtr fs_id_generator,
                                IdGeneratorSPtr slice_id_generator, KVStorageSPtr kv_storage, MDSMeta self_mds_meta,
                                MDSMetaMapSPtr mds_meta_map, OperationProcessorSPtr operation_processor,
-                               WorkerSetSPtr quota_worker_set, notify::NotifyBuddySPtr notify_buddy) {
+                               WorkerSetSPtr quota_worker_set, WorkerSetSPtr dir_stat_worker_set,
+                               notify::NotifyBuddySPtr notify_buddy) {
     return std::make_shared<FileSystemSet>(coordinator_client, std::move(fs_id_generator),
                                            std::move(slice_id_generator), kv_storage, self_mds_meta, mds_meta_map,
-                                           operation_processor, quota_worker_set, notify_buddy);
+                                           operation_processor, quota_worker_set, dir_stat_worker_set, notify_buddy);
   }
 
   bool Init();
@@ -561,6 +592,8 @@ class FileSystemSet {
   OperationProcessorSPtr operation_processor_;
 
   WorkerSetSPtr quota_worker_set_;
+
+  WorkerSetSPtr dir_stat_worker_set_;
 
   // notify buddy
   notify::NotifyBuddySPtr notify_buddy_;

--- a/src/mds/filesystem/fs_info.h
+++ b/src/mds/filesystem/fs_info.h
@@ -107,6 +107,12 @@ class FsInfo {
     return fs_info_.trash_days() != 0;
   }
 
+  bool EnableDirStats() {
+    utils::ReadLockGuard lock(lock_);
+
+    return fs_info_.enable_dir_stats();
+  }
+
   pb::mds::PartitionType GetPartitionType() {
     utils::ReadLockGuard lock(lock_);
 

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -21,6 +21,7 @@
 #include <cstdlib>
 #include <functional>
 #include <map>
+#include <set>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -385,6 +386,9 @@ const char* Operation::OpName() const {
     case OpType::kScanDelFile:
       return "ScanDelFile";
 
+    case OpType::kScanDirStat:
+      return "ScanDirStat";
+
     case OpType::kScanDelSlice:
       return "ScanDelSlice";
 
@@ -429,6 +433,18 @@ const char* Operation::OpName() const {
 
     case OpType::kGetCacheMember:
       return "GetCacheMember";
+
+    case OpType::kDeleteDirStat:
+      return "DeleteDirStat";
+
+    case OpType::kBatchSetDirStat:
+      return "BatchSetDirStat";
+
+    case OpType::kGetDirStat:
+      return "GetDirStat";
+
+    case OpType::kFlushDirStats:
+      return "FlushDirStats";
 
     default:
       return "UnknownOperation";
@@ -609,6 +625,9 @@ Status UpdateFsOperation::Run(TxnUPtr& txn) {
   // GetFsInfo, flip the flag, and UpdateFsInfo with the full record (the
   // same read-modify-write convention used for trash_days above).
   new_fs_info.set_enable_uid_gid_map(fs_info_.enable_uid_gid_map());
+  // enable_dir_stats is likewise a runtime-mutable toggle (hot-switchable):
+  // same GetFsInfo -> flip -> UpdateFsInfo read-modify-write convention.
+  new_fs_info.set_enable_dir_stats(fs_info_.enable_dir_stats());
   if (fs_info_.has_extra() && fs_info_.extra().has_s3_info()) {
     const auto& s3_info = fs_info_.extra().s3_info();
     auto* mut_s3_info = new_fs_info.mutable_extra()->mutable_s3_info();
@@ -738,6 +757,11 @@ Status MkDirOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_param) 
   // create inode
   txn->Put(MetaCodec::EncodeInodeKey(fs_id, dentry_.INo()), MetaCodec::EncodeInodeValue(attr_));
 
+  // seed an empty dir-stat record so the dir is tracked from birth (no first-flush
+  // recompute); the lazy missing_inos->CalcDirStat path still covers pre-existing dirs.
+  DirStatEntry dir_stat;
+  txn->Put(MetaCodec::EncodeDirStatKey(fs_id, dentry_.INo()), MetaCodec::EncodeDirStatValue(dir_stat));
+
   // update parent attr
   parent_attr.set_nlink(parent_attr.nlink() + 1);
   parent_attr.set_mtime(std::max(parent_attr.mtime(), GetTime()));
@@ -762,9 +786,12 @@ Status BatchMkDirOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_pa
     txn->Put(MetaCodec::EncodeDentryKey(fs_id, parent, dentry.Name()), MetaCodec::EncodeDentryValue(dentry.Copy()));
   }
 
-  // create
+  // create inode + seed empty dir-stat in the same txn so each dir is tracked from birth
   for (const auto& attr : attrs_) {
     txn->Put(MetaCodec::EncodeInodeKey(fs_id, attr.ino()), MetaCodec::EncodeInodeValue(attr));
+
+    DirStatEntry dir_stat;
+    txn->Put(MetaCodec::EncodeDirStatKey(fs_id, attr.ino()), MetaCodec::EncodeDirStatValue(dir_stat));
   }
 
   // update parent attr
@@ -1464,6 +1491,8 @@ Status FallocateOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_par
   const uint64_t offset = param_.offset;
   const uint64_t len = param_.len;
 
+  // Pre-image length, before PreAlloc/SetZero mutate attr. The growth is charged
+  // to quota and dir-stat by the caller via result_.delta_bytes.
   const uint64_t file_length = attr.length();
 
   if (mode_ == 0) {
@@ -1746,11 +1775,14 @@ Status RmDirOperation::Run(TxnUPtr& txn) {
 
   if (!enable_trash) {
     child_attr_key = MetaCodec::EncodeInodeKey(fs_id, dentry.ino());
-    // 6a. Plain rmdir: drop the child inode and its mutation slots.
+    // 6a. Plain rmdir: drop the child inode, its mutation slots and its dir-stat
+    // record. This also covers trash GC permanent deletion, which reuses
+    // RmDirOperation with trash disabled, so the dir-stat record is not leaked.
     txn->Delete(child_attr_key);
     for (uint32_t i = 0; i < kDirAttrMutationNum; ++i) {
       txn->Delete(MetaCodec::EncodeDirInodeMutationKey(fs_id, dentry.ino(), i));
     }
+    txn->Delete(MetaCodec::EncodeDirStatKey(fs_id, dentry.ino()));
   } else {
     CHECK(trash_.bucket_ino != 0) << "invalid trash bucket ino(0)";
 
@@ -3072,6 +3104,124 @@ Status FlushDirUsagesOperation::Run(TxnUPtr& txn) {
   return Status::OK();
 }
 
+Status DeleteDirStatOperation::Run(TxnUPtr& txn) {
+  txn->Delete(MetaCodec::EncodeDirStatKey(fs_id_, ino_));
+  return Status::OK();
+}
+
+Status BatchSetDirStatOperation::Run(TxnUPtr& txn) {
+  for (const auto& [ino, dir_stat] : dir_stats_) {
+    txn->Put(MetaCodec::EncodeDirStatKey(fs_id_, ino), MetaCodec::EncodeDirStatValue(dir_stat));
+  }
+  return Status::OK();
+}
+
+Status GetDirStatOperation::Run(TxnUPtr& txn) {
+  std::string key = MetaCodec::EncodeDirStatKey(fs_id_, ino_);
+  std::string value;
+  auto status = txn->Get(key, value);
+  if (status.error_code() == pb::error::ENOT_FOUND) {
+    result_.found = false;
+    return Status::OK();
+  }
+  if (!status.ok()) return status;
+  result_.found = true;
+  result_.dir_stat = MetaCodec::DecodeDirStatValue(value);
+  return Status::OK();
+}
+
+Status FlushDirStatsOperation::Run(TxnUPtr& txn) {
+  // Clear result state at entry: RunAlone re-invokes Run on the same operation
+  // object on commit-conflict retry, so without this a missing/negative ino
+  // recorded by a failed attempt would survive into a successful retry and get
+  // needlessly recomputed (regressing its version / clobbering its deltas).
+  result_.missing_inos.clear();
+
+  std::vector<std::string> keys;
+  keys.reserve(delta_map_.size());
+  for (const auto& [ino, _] : delta_map_) {
+    keys.push_back(MetaCodec::EncodeDirStatKey(fs_id_, ino));
+  }
+
+  std::vector<KeyValue> kvs;
+  auto status = txn->BatchGet(keys, kvs);
+  if (!status.ok()) return status;
+
+  std::set<uint64_t> found;
+  for (auto& kv : kvs) {
+    uint32_t fs_id;
+    uint64_t ino;
+    MetaCodec::DecodeDirStatKey(kv.key, fs_id, ino);
+    found.insert(ino);
+
+    auto stat = MetaCodec::DecodeDirStatValue(kv.value);
+    const auto& d = delta_map_.at(ino);
+    int64_t length = stat.length() + d.length;
+    int64_t inodes = stat.inodes() + d.inodes;
+    int64_t dirs = stat.dirs() + d.dirs;
+
+    if (length < 0 || inodes < 0 || dirs < 0) {
+      result_.missing_inos.push_back(ino);
+      continue;
+    }
+
+    stat.set_length(length);
+    stat.set_inodes(inodes);
+    stat.set_dirs(dirs);
+    txn->Put(kv.key, MetaCodec::EncodeDirStatValue(stat));
+  }
+
+  for (const auto& [ino, _] : delta_map_) {
+    if (found.find(ino) == found.end()) {
+      result_.missing_inos.push_back(ino);
+    }
+  }
+
+  return Status::OK();
+}
+
+Status SeedDirStatOperation::Run(TxnUPtr& txn) {
+  result_.seeded = false;
+
+  std::string key = MetaCodec::EncodeDirStatKey(fs_id_, ino_);
+  std::string value;
+  auto status = txn->Get(key, value);
+  if (status.ok()) {
+    // Record already exists (created by a concurrent flush/seed). Do not clobber.
+    return Status::OK();
+  }
+  if (status.error_code() != pb::error::ENOT_FOUND) return status;
+
+  txn->Put(key, MetaCodec::EncodeDirStatValue(dir_stat_));
+  result_.seeded = true;
+  return Status::OK();
+}
+
+Status RepairDirStatOperation::Run(TxnUPtr& txn) {
+  result_ = Result{};
+
+  std::string key = MetaCodec::EncodeDirStatKey(fs_id_, ino_);
+  std::string value;
+  auto status = txn->Get(key, value);
+  if (status.ok()) {
+    result_.found = true;
+    result_.stored = MetaCodec::DecodeDirStatValue(value);
+  } else if (status.error_code() != pb::error::ENOT_FOUND) {
+    return status;
+  }
+
+  // Same mismatch criteria as the pre-existing SyncDirStat check (dirs excluded).
+  result_.mismatch = !result_.found || result_.stored.length() != calc_.length() ||
+                     result_.stored.inodes() != calc_.inodes();
+
+  if (repair_ && result_.mismatch) {
+    txn->Put(key, MetaCodec::EncodeDirStatValue(calc_));
+    result_.wrote = true;
+  }
+
+  return Status::OK();
+}
+
 Status UpsertMdsOperation::Run(TxnUPtr& txn) {
   CHECK(mds_meta_.id() > 0) << "mds id is 0";
 
@@ -3378,6 +3528,13 @@ Status ScanDelFileOperation::Run(TxnUPtr& txn) {
   return txn->Scan(range, scan_handler_);
 }
 
+Status ScanDirStatOperation::Run(TxnUPtr& txn) {
+  CHECK(fs_id_ > 0) << "fs_id is 0";
+  Range range = MetaCodec::GetDirStatRange(fs_id_);
+
+  return txn->Scan(range, scan_handler_);
+}
+
 Status ScanMetaTableOperation::Run(TxnUPtr& txn) {
   Range range = MetaCodec::GetMetaTableRange();
 
@@ -3472,9 +3629,11 @@ Status GetInodeAttrOperation::Run(TxnUPtr& txn) {
     range.start = MetaCodec::EncodeInodeKey(fs_id_, ino_);
     range.end = MetaCodec::GetDirInodeUpdateOpRange(fs_id_, ino_).end;
 
-    return txn->Scan(range, [&](const std::string& key, const std::string& value) -> bool {
+    bool found = false;
+    auto status = txn->Scan(range, [&](const std::string& key, const std::string& value) -> bool {
       if (MetaCodec::IsInodeKey(key)) {
         result_.attr_with_mutation.attr = MetaCodec::DecodeInodeValue(value);
+        found = true;
 
       } else if (MetaCodec::IsDirInodeMutationKey(key)) {
         result_.attr_with_mutation.mutations.push_back(MetaCodec::DecodeDirInodeMutationValue(value));
@@ -3485,6 +3644,17 @@ Status GetInodeAttrOperation::Run(TxnUPtr& txn) {
 
       return true;
     });
+    if (!status.ok()) return status;
+
+    // The scan can come back without the base inode key (only mutation keys, or
+    // nothing) when the directory inode was deleted while a client still holds a
+    // stale reference and issues GetAttr. Surface that as ENOT_FOUND instead of
+    // returning a default zero-ino attr, which UpsertInodeCache rejects with
+    // LOG(FATAL) -- crashing the MDS on a GetAttr of any missing directory.
+    if (!found) {
+      return Status(pb::error::ENOT_FOUND, fmt::format("not found inode({})", ino_));
+    }
+    return Status::OK();
 
   } else {
     std::string value;

--- a/src/mds/filesystem/store_operation.h
+++ b/src/mds/filesystem/store_operation.h
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -161,6 +162,12 @@ class Operation {
     kDeleteCacheMember = 181,
     kScanCacheMember = 182,
     kGetCacheMember = 183,
+
+    kDeleteDirStat = 190,
+    kGetDirStat = 191,
+    kFlushDirStats = 192,
+    kBatchSetDirStat = 193,
+    kScanDirStat = 194,
   };
 
   const char* OpName() const;
@@ -1074,6 +1081,10 @@ class FallocateOperation : public Operation {
   struct Result {
     AttrEntry attr;
     std::vector<ChunkEntry> effected_chunks;
+    // File-size growth (signed) computed in the txn from the authoritative
+    // pre-image so callers need not re-read the inode (a cached inode is mutated
+    // in-place on upsert, which would zero a re-read delta). Drives the
+    // shrink/expand flags and the quota + parent dir-stat charge.
     int64_t delta_bytes{0};
   };
 
@@ -1801,6 +1812,150 @@ class FlushDirUsagesOperation : public Operation {
   Result result_;
 };
 
+// Write a single dir stat entry (overwrite).
+// Delete a directory's dir-stat record (used when a directory is hard-deleted).
+class DeleteDirStatOperation : public Operation {
+ public:
+  DeleteDirStatOperation(Trace& trace, uint32_t fs_id, Ino ino) : Operation(trace), fs_id_(fs_id), ino_(ino) {}
+  ~DeleteDirStatOperation() override = default;
+
+  OpType GetOpType() const override { return OpType::kDeleteDirStat; }
+  uint32_t GetFsId() const override { return fs_id_; }
+  Ino GetIno() const override { return ino_; }
+  Status Run(TxnUPtr& txn) override;
+
+ private:
+  uint32_t fs_id_;
+  Ino ino_;
+};
+
+// Write multiple dir stat entries (overwrite) in a single transaction.
+class BatchSetDirStatOperation : public Operation {
+ public:
+  BatchSetDirStatOperation(Trace& trace, uint32_t fs_id, std::map<uint64_t, DirStatEntry> dir_stats)
+      : Operation(trace), fs_id_(fs_id), dir_stats_(std::move(dir_stats)) {}
+  ~BatchSetDirStatOperation() override = default;
+
+  OpType GetOpType() const override { return OpType::kBatchSetDirStat; }
+  uint32_t GetFsId() const override { return fs_id_; }
+  Ino GetIno() const override { return 0; }
+  Status Run(TxnUPtr& txn) override;
+
+ private:
+  uint32_t fs_id_;
+  std::map<uint64_t, DirStatEntry> dir_stats_;
+};
+
+// Read a single dir stat entry.
+class GetDirStatOperation : public Operation {
+ public:
+  GetDirStatOperation(Trace& trace, uint32_t fs_id, Ino ino)
+      : Operation(trace), fs_id_(fs_id), ino_(ino) {}
+  ~GetDirStatOperation() override = default;
+
+  struct Result {
+    bool found{false};
+    DirStatEntry dir_stat;
+  };
+
+  OpType GetOpType() const override { return OpType::kGetDirStat; }
+  uint32_t GetFsId() const override { return fs_id_; }
+  Ino GetIno() const override { return ino_; }
+  Status Run(TxnUPtr& txn) override;
+  Result& GetResult() { return result_; }
+
+ private:
+  uint32_t fs_id_;
+  Ino ino_;
+  Result result_;
+};
+
+// Batch read-add-write dir stat deltas; missing keys are reported, not created.
+class FlushDirStatsOperation : public Operation {
+ public:
+  FlushDirStatsOperation(Trace& trace, uint32_t fs_id, const std::map<uint64_t, DirStatDelta>& delta_map)
+      : Operation(trace), fs_id_(fs_id), delta_map_(delta_map) {}
+  ~FlushDirStatsOperation() override = default;
+
+  struct Result {
+    std::vector<uint64_t> missing_inos;
+  };
+
+  OpType GetOpType() const override { return OpType::kFlushDirStats; }
+  uint32_t GetFsId() const override { return fs_id_; }
+  Ino GetIno() const override { return 0; }
+  Status Run(TxnUPtr& txn) override;
+  Result& GetResult() { return result_; }
+
+ private:
+  uint32_t fs_id_;
+  std::map<uint64_t, DirStatDelta> delta_map_;
+  Result result_;
+};
+
+// Create a dir-stat record only if it does not already exist, seeding it with
+// version 1. Implemented as Get-then-conditional-Put in one SI txn (not the
+// store's PutIfAbsent, whose "already exists" only surfaces at commit on the
+// real backend): if the snapshot shows the key present we skip the write; if a
+// concurrent writer creates it between our read and commit, SI write-conflict
+// forces a retry that re-reads and then skips. Used by the GetDirStat read path
+// when a record is missing so a stale just-scanned value never clobbers a newer
+// one written by a concurrent flush/recompute.
+class SeedDirStatOperation : public Operation {
+ public:
+  SeedDirStatOperation(Trace& trace, uint32_t fs_id, Ino ino, DirStatEntry dir_stat)
+      : Operation(trace), fs_id_(fs_id), ino_(ino), dir_stat_(std::move(dir_stat)) {}
+  ~SeedDirStatOperation() override = default;
+
+  struct Result {
+    bool seeded{false};  // true if this op created the record; false if it already existed
+  };
+
+  OpType GetOpType() const override { return OpType::kBatchSetDirStat; }
+  uint32_t GetFsId() const override { return fs_id_; }
+  Ino GetIno() const override { return ino_; }
+  Status Run(TxnUPtr& txn) override;
+  Result& GetResult() { return result_; }
+
+ private:
+  uint32_t fs_id_;
+  Ino ino_;
+  DirStatEntry dir_stat_;
+  Result result_;
+};
+
+// Read a dir-stat record, compare against a freshly recomputed absolute value,
+// and (when repair) overwrite a mismatch in the same transaction. Single SI txn
+// under RunAlone: a flush committing between the read and the write forces a
+// retry that re-reads, so the recomputed absolute is never lost-updated against
+// a concurrent flush. A check (repair=false) issues only the read.
+class RepairDirStatOperation : public Operation {
+ public:
+  RepairDirStatOperation(Trace& trace, uint32_t fs_id, Ino ino, DirStatEntry calc, bool repair)
+      : Operation(trace), fs_id_(fs_id), ino_(ino), calc_(std::move(calc)), repair_(repair) {}
+  ~RepairDirStatOperation() override = default;
+
+  struct Result {
+    bool found{false};        // whether a stored record existed
+    DirStatEntry stored;      // the stored record (valid when found)
+    bool mismatch{false};     // whether stored differs from calc (or was absent)
+    bool wrote{false};        // whether this op wrote a new absolute value
+  };
+
+  OpType GetOpType() const override { return OpType::kBatchSetDirStat; }
+  uint32_t GetFsId() const override { return fs_id_; }
+  Ino GetIno() const override { return ino_; }
+  Status Run(TxnUPtr& txn) override;
+  Result& GetResult() { return result_; }
+
+ private:
+  uint32_t fs_id_;
+  Ino ino_;
+  DirStatEntry calc_;
+  bool repair_;
+  Result result_;
+};
+
 class UpsertMdsOperation : public Operation {
  public:
   UpsertMdsOperation(Trace& trace, const MdsEntry& mds_meta) : Operation(trace), mds_meta_(mds_meta) {};
@@ -2193,6 +2348,23 @@ class ScanDelFileOperation : public Operation {
   ~ScanDelFileOperation() override = default;
 
   OpType GetOpType() const override { return OpType::kScanDelFile; }
+
+  uint32_t GetFsId() const override { return fs_id_; }
+
+  Status Run(TxnUPtr& txn) override;
+
+ private:
+  const uint32_t fs_id_{0};
+  Txn::ScanHandlerType scan_handler_;
+};
+
+class ScanDirStatOperation : public Operation {
+ public:
+  ScanDirStatOperation(Trace& trace, uint32_t fs_id, Txn::ScanHandlerType scan_handler)
+      : Operation(trace), fs_id_(fs_id), scan_handler_(scan_handler) {};
+  ~ScanDirStatOperation() override = default;
+
+  OpType GetOpType() const override { return OpType::kScanDirStat; }
 
   uint32_t GetFsId() const override { return fs_id_; }
 

--- a/src/mds/main.cc
+++ b/src/mds/main.cc
@@ -339,6 +339,7 @@ int main(int argc, char* argv[]) {
   CHECK(server.InitMonitor()) << "init mds monitor error.";
   CHECK(server.InitGcProcessor()) << "init gc error.";
   CHECK(server.InitQuotaSynchronizer()) << "init quota synchronizer error.";
+  CHECK(server.InitDirStatsSynchronizer()) << "init dir-stats synchronizer error.";
   CHECK(server.InitCrontab()) << "init crontab error.";
   CHECK(server.InitService()) << "init service error.";
 

--- a/src/mds/server.cc
+++ b/src/mds/server.cc
@@ -61,11 +61,16 @@ const std::string kQuotaWorkerSetName = "QUOTA_WORKER_SET";
 DEFINE_uint32(mds_quota_worker_num, 24, "quota worker number");
 DEFINE_uint32(mds_quota_worker_max_pending_num, 4096, "quota worker max pending number");
 
+const std::string kDirStatWorkerSetName = "DIR_STAT_WORKER_SET";
+DEFINE_uint32(mds_dir_stat_worker_num, 24, "dir stat worker number");
+DEFINE_uint32(mds_dir_stat_worker_max_pending_num, 4096, "dir stat worker max pending number");
+
 // crontab config
 DEFINE_uint32(mds_crontab_heartbeat_interval_s, 5, "heartbeat interval seconds");
 DEFINE_uint32(mds_crontab_fsinfosync_interval_s, 10, "fs info sync interval seconds");
 DEFINE_uint32(mds_crontab_mdsmonitor_interval_s, 5, "mds monitor interval seconds");
-DEFINE_uint32(mds_crontab_quota_sync_interval_s, 3, "quota sync interval seconds");
+DEFINE_uint32(mds_crontab_quota_sync_interval_s, 3, "quota (load + flush usage) sync interval seconds");
+DEFINE_uint32(mds_crontab_dir_stats_sync_interval_s, 3, "dir-stats flush interval seconds");
 DEFINE_uint32(mds_crontab_gc_interval_s, 60, "gc interval seconds");
 DEFINE_uint32(mds_crontab_gc_trash_interval_s, 3600,
               "gc trash scan interval seconds (aligned with hour-bucket granularity)");
@@ -272,11 +277,16 @@ bool Server::InitFileSystem() {
   quota_worker_set_ = ExecqWorkerSet::NewUnique(kQuotaWorkerSetName, FLAGS_mds_quota_worker_num,
                                                 FLAGS_mds_quota_worker_max_pending_num);
   CHECK(quota_worker_set_ != nullptr) << "new quota worker set fail.";
-  CHECK(quota_worker_set_->Init()) << "init service read worker set fail.";
+  CHECK(quota_worker_set_->Init()) << "init quota worker set fail.";
 
-  file_system_set_ =
-      FileSystemSet::New(coordinator_client_, std::move(fs_id_generator), slice_id_generator, kv_storage_,
-                         self_mds_meta_, mds_meta_map_, operation_processor_, quota_worker_set_, notify_buddy_);
+  dir_stat_worker_set_ = ExecqWorkerSet::NewUnique(kDirStatWorkerSetName, FLAGS_mds_dir_stat_worker_num,
+                                                   FLAGS_mds_dir_stat_worker_max_pending_num);
+  CHECK(dir_stat_worker_set_ != nullptr) << "new dir stat worker set fail.";
+  CHECK(dir_stat_worker_set_->Init()) << "init dir stat worker set fail.";
+
+  file_system_set_ = FileSystemSet::New(coordinator_client_, std::move(fs_id_generator), slice_id_generator, kv_storage_,
+                                        self_mds_meta_, mds_meta_map_, operation_processor_, quota_worker_set_,
+                                        dir_stat_worker_set_, notify_buddy_);
   CHECK(file_system_set_ != nullptr) << "new FileSystem fail.";
 
   return file_system_set_->Init();
@@ -343,6 +353,15 @@ bool Server::InitQuotaSynchronizer() {
   return true;
 }
 
+bool Server::InitDirStatsSynchronizer() {
+  CHECK(file_system_set_ != nullptr) << "file_system_set is nullptr.";
+
+  dir_stats_synchronizer_ = DirStatsSynchronizer::New(file_system_set_);
+  CHECK(dir_stats_synchronizer_ != nullptr) << "new DirStatsSynchronizer fail.";
+
+  return true;
+}
+
 bool Server::InitGcProcessor() {
   CHECK(operation_processor_ != nullptr) << "operation_processor is nullptr.";
   CHECK(file_system_set_ != nullptr) << "file system set is nullptr.";
@@ -390,6 +409,14 @@ bool Server::InitCrontab() {
       FLAGS_mds_crontab_quota_sync_interval_s * 1000,
       true,
       [](void*) { Server::GetInstance().GetQuotaSynchronizer()->Run(); },
+  });
+
+  // Add dir-stats sync crontab
+  crontab_configs_.push_back({
+      "DIR_STATS_SYNC",
+      FLAGS_mds_crontab_dir_stats_sync_interval_s * 1000,
+      true,
+      [](void*) { Server::GetInstance().GetDirStatsSynchronizer()->Run(); },
   });
 
   // Add fs info sync crontab
@@ -519,6 +546,12 @@ QuotaSynchronizerSPtr Server::GetQuotaSynchronizer() {
   CHECK(quota_synchronizer_ != nullptr) << "quota_synchronizer is nullptr.";
 
   return quota_synchronizer_;
+}
+
+DirStatsSynchronizerSPtr Server::GetDirStatsSynchronizer() {
+  CHECK(dir_stats_synchronizer_ != nullptr) << "dir_stats_synchronizer is nullptr.";
+
+  return dir_stats_synchronizer_;
 }
 
 GcProcessorSPtr Server::GetGcProcessor() {

--- a/src/mds/server.h
+++ b/src/mds/server.h
@@ -26,6 +26,7 @@
 #include "mds/background/gc.h"
 #include "mds/background/heartbeat.h"
 #include "mds/background/monitor.h"
+#include "mds/background/dir_stats_sync.h"
 #include "mds/background/quota_sync.h"
 #include "mds/cachegroup/member_manager.h"
 #include "mds/common/crontab.h"
@@ -76,6 +77,8 @@ class Server {
 
   bool InitQuotaSynchronizer();
 
+  bool InitDirStatsSynchronizer();
+
   bool InitGcProcessor();
 
   bool InitCrontab();
@@ -96,6 +99,7 @@ class Server {
   MonitorSPtr GetMonitor();
   OperationProcessorSPtr GetOperationProcessor();
   QuotaSynchronizerSPtr GetQuotaSynchronizer();
+  DirStatsSynchronizerSPtr GetDirStatsSynchronizer();
   GcProcessorSPtr GetGcProcessor();
   CacheGroupMemberManagerSPtr GetCacheGroupMemberManager();
   CacheMemberSynchronizerSPtr& GetCacheMemberSynchronizer();
@@ -141,6 +145,9 @@ class Server {
   // worker set for quota
   WorkerSetSPtr quota_worker_set_;
 
+  // worker set for dir stats
+  WorkerSetSPtr dir_stat_worker_set_;
+
   // filesystem
   FileSystemSetSPtr file_system_set_;
 
@@ -162,8 +169,11 @@ class Server {
   // mds monitor
   MonitorSPtr monitor_;
 
-  // quota synchronizer
+  // quota synchronizer (load quota + flush usage)
   QuotaSynchronizerSPtr quota_synchronizer_;
+
+  // dir-stats synchronizer (flush dir-stats)
+  DirStatsSynchronizerSPtr dir_stats_synchronizer_;
 
   // gc
   GcProcessorSPtr gc_processor_;

--- a/src/mds/service/fsstat_service.cc
+++ b/src/mds/service/fsstat_service.cc
@@ -222,6 +222,8 @@ static void RenderFsInfo(const std::vector<pb::mds::FsInfo>& fs_infoes, butil::I
     result += "<br>";
     result += fmt::format(R"(<a href="FsStatService/quota/{}" target="_blank">quota</a>)", fs_info.fs_id());
     result += "<br>";
+    result += fmt::format(R"(<a href="FsStatService/dirstat/{}" target="_blank">dir-stats</a>)", fs_info.fs_id());
+    result += "<br>";
     result += fmt::format(R"(<a href="FsStatService/delfiles/{}" target="_blank">delfiles</a>)", fs_info.fs_id());
     result += "<br>";
     result += fmt::format(R"(<a href="FsStatService/delslices/{}" target="_blank">delslices</a>)", fs_info.fs_id());
@@ -248,6 +250,7 @@ static void RenderFsInfo(const std::vector<pb::mds::FsInfo>& fs_infoes, butil::I
   os << "<th>Navigation</th>";
   os << "<th>Time</th>";
   os << "<th>EnableUidGidMap</th>";
+  os << "<th>EnableDirStats</th>";
   os << "<th>Trash</th>";
   os << "<th>RecycleTime</th>";
   os << "<th>MountPoint</th>";
@@ -274,6 +277,7 @@ static void RenderFsInfo(const std::vector<pb::mds::FsInfo>& fs_infoes, butil::I
     os << "<td>" << render_navigation_func(fs_info) << "</td>";
     os << "<td>" << render_time_func(fs_info) << "</td>";
     os << "<td>" << (fs_info.enable_uid_gid_map() ? "On" : "Off") << "</td>";
+    os << "<td>" << (fs_info.enable_dir_stats() ? "On" : "Off") << "</td>";
     os << "<td>"
        << fmt::format("trash_days: {}<br>immediate_trash_quota: {}", fs_info.trash_days(),
                       fs_info.immediate_trash_quota() ? "true" : "false")
@@ -991,6 +995,60 @@ static void RenderQuotaPage(FileSystemSPtr fs, butil::IOBufBuilder& os) {
     os << "</table>";
   } else {
     os << fmt::format(R"(<span class="red-text">Load dir quota fail, status({}).</span>)", status.error_str());
+  }
+  os << "</div>";
+
+  os << "</body>";
+  os << "</html>";
+}
+
+static void RenderDirStatsPage(FileSystemSPtr fs, butil::IOBufBuilder& os) {
+  os << "<!DOCTYPE html><html>\n";
+
+  os << "<head>";
+  os << RenderHead("dingofs dir stats");
+  os << "</head>";
+
+  os << "<body>";
+  os << R"(<h1 style="text-align:center;">Dir Stats</h1>)";
+
+  std::map<Ino, DirStatEntry> dir_stat_map;
+  auto status = fs->GetDirStatManager().GetAllDirStats(dir_stat_map);
+
+  // Drop empty records (all-zero), e.g. trash hour-bucket dirs and freshly
+  // seeded directories, so the dashboard only lists directories with usage.
+  for (auto it = dir_stat_map.begin(); it != dir_stat_map.end();) {
+    const auto& ds = it->second;
+    if (ds.length() == 0 && ds.inodes() == 0 && ds.dirs() == 0) {
+      it = dir_stat_map.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  os << R"(<div style="margin:12px;margin-top:32px;font-size:smaller;">)";
+  os << fmt::format(R"(<h3>Dir Stat [{}]</h3>)", dir_stat_map.size());
+  if (status.ok()) {
+    os << R"(<table class="gridtable sortable" border=1 style="max-width:100%;white-space:nowrap;">)";
+    os << "<tr>";
+    os << "<th>Ino</th>";
+    os << "<th>Length(byte)</th>";
+    os << "<th>Inodes</th>";
+    os << "<th>Dirs</th>";
+    os << "</tr>";
+
+    for (const auto& [ino, dir_stat] : dir_stat_map) {
+      os << "<tr>";
+      os << fmt::format(R"(<td>{}</td>)", ino);
+      os << fmt::format(R"(<td>{}</td>)", dir_stat.length());
+      os << fmt::format(R"(<td>{}</td>)", dir_stat.inodes());
+      os << fmt::format(R"(<td>{}</td>)", dir_stat.dirs());
+      os << "</tr>";
+    }
+
+    os << "</table>";
+  } else {
+    os << fmt::format(R"(<span class="red-text">Get dir stats fail, status({}).</span>)", status.error_str());
   }
   os << "</div>";
 
@@ -1896,6 +1954,19 @@ void FsStatServiceImpl::default_method(::google::protobuf::RpcController* contro
     auto file_system = file_system_set->GetFileSystem(fs_id);
     if (file_system != nullptr) {
       RenderQuotaPage(file_system, os);
+
+    } else {
+      os << fmt::format("Not found file system {}.", fs_id);
+    }
+
+  } else if (params.size() == 2 && params[0] == "dirstat") {
+    // /FsStatService/dirstat/{fs_id}
+
+    uint32_t fs_id = Helper::StringToInt32(params[1]);
+    auto file_system_set = Server::GetInstance().GetFileSystemSet();
+    auto file_system = file_system_set->GetFileSystem(fs_id);
+    if (file_system != nullptr) {
+      RenderDirStatsPage(file_system, os);
 
     } else {
       os << fmt::format("Not found file system {}.", fs_id);

--- a/src/mds/service/mds_service.cc
+++ b/src/mds/service/mds_service.cc
@@ -3536,5 +3536,123 @@ void MDSServiceImpl::RestoreFromTrash(google::protobuf::RpcController* controlle
   }
 }
 
+void MDSServiceImpl::DoGetDirStat(google::protobuf::RpcController*, const pb::mds::GetDirStatRequest* request,
+                                  pb::mds::GetDirStatResponse* response, TraceClosure* done) {
+  brpc::ClosureGuard done_guard(done);
+  done->SetQueueWaitTime();
+
+  auto span = StartSpan("MDSServiceImpl::DoGetDirStat", request->info());
+
+  auto file_system = GetFileSystem(request->fs_id());
+  auto status = SimpleValidateRequest(file_system, request, done->GetQueueWaitTimeUs());
+  if (BAIDU_UNLIKELY(!status.ok())) {
+    SpanScope::SetStatus(span, status);
+    return ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());
+  }
+
+  Context ctx(request->context(), request->info().request_id(), __func__);
+
+  DirStatEntry dir_stat;
+  status = file_system->GetDirStatManager().GetDirStat(ctx, request->ino(), dir_stat, /*with_pending=*/true);
+  ServiceHelper::SetResponseInfo(ctx.GetTrace(), response->mutable_info());
+  if (BAIDU_UNLIKELY(!status.ok())) {
+    SpanScope::SetStatus(span, status);
+    return ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());
+  }
+
+  response->mutable_dir_stat()->Swap(&dir_stat);
+}
+
+void MDSServiceImpl::GetDirStat(google::protobuf::RpcController* controller,
+                                const pb::mds::GetDirStatRequest* request, pb::mds::GetDirStatResponse* response,
+                                google::protobuf::Closure* done) {
+  auto* svr_done = new ServiceClosure(__func__, done, request, response);
+
+  auto validate_fn = [&]() -> Status {
+    if (request->fs_id() == 0) {
+      return Status(pb::error::EILLEGAL_PARAMTETER, "fs_id is 0");
+    }
+    if (request->ino() == 0) {
+      return Status(pb::error::EILLEGAL_PARAMTETER, "ino is 0");
+    }
+    return Status::OK();
+  };
+
+  auto status = validate_fn();
+  if (BAIDU_UNLIKELY(!status.ok())) {
+    brpc::ClosureGuard done_guard(svr_done);
+    return ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());
+  }
+
+  RunInPlace(GetDirStat, controller, request, response, svr_done);
+  RunInQueue(GetDirStat, controller, request, response, svr_done, read_worker_set_);
+}
+
+void MDSServiceImpl::DoSyncDirStat(google::protobuf::RpcController*, const pb::mds::SyncDirStatRequest* request,
+                                   pb::mds::SyncDirStatResponse* response, TraceClosure* done) {
+  brpc::ClosureGuard done_guard(done);
+  done->SetQueueWaitTime();
+
+  auto span = StartSpan("MDSServiceImpl::DoSyncDirStat", request->info());
+
+  auto file_system = GetFileSystem(request->fs_id());
+  auto status = SimpleValidateRequest(file_system, request, done->GetQueueWaitTimeUs());
+  if (BAIDU_UNLIKELY(!status.ok())) {
+    SpanScope::SetStatus(span, status);
+    return ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());
+  }
+
+  // Single-level check/repair for one directory. Force an authoritative-store
+  // read (critical for repair=true: repairing off a stale cache would overwrite a
+  // correct record). Tree-wide recursion is driven by the client (mds-cli), which
+  // calls this per directory routed to the owning MDS.
+  auto context_entry = request->context();
+  context_entry.set_is_bypass_cache(true);
+  Context ctx(context_entry, request->info().request_id(), __func__);
+
+  std::vector<dir_stat::DirStatManager::DirStatMismatch> mismatches;
+  status = file_system->GetDirStatManager().SyncDirStat(ctx, request->ino(), request->repair(), mismatches);
+  ServiceHelper::SetResponseInfo(ctx.GetTrace(), response->mutable_info());
+  if (BAIDU_UNLIKELY(!status.ok())) {
+    SpanScope::SetStatus(span, status);
+    return ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());
+  }
+
+  for (const auto& brk : mismatches) {
+    auto* out = response->add_mismatches();
+    out->set_ino(brk.ino);
+    out->set_found(brk.found);
+    out->set_want_inodes(brk.want.inodes());
+    out->set_want_length(brk.want.length());
+    out->set_got_inodes(brk.got.inodes());
+    out->set_got_length(brk.got.length());
+  }
+}
+
+void MDSServiceImpl::SyncDirStat(google::protobuf::RpcController* controller,
+                                 const pb::mds::SyncDirStatRequest* request, pb::mds::SyncDirStatResponse* response,
+                                 google::protobuf::Closure* done) {
+  auto* svr_done = new ServiceClosure(__func__, done, request, response);
+
+  auto validate_fn = [&]() -> Status {
+    if (request->fs_id() == 0) {
+      return Status(pb::error::EILLEGAL_PARAMTETER, "fs_id is 0");
+    }
+    if (request->ino() == 0) {
+      return Status(pb::error::EILLEGAL_PARAMTETER, "ino is 0");
+    }
+    return Status::OK();
+  };
+
+  auto status = validate_fn();
+  if (BAIDU_UNLIKELY(!status.ok())) {
+    brpc::ClosureGuard done_guard(svr_done);
+    return ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());
+  }
+
+  RunInPlace(SyncDirStat, controller, request, response, svr_done);
+  RunInQueue(SyncDirStat, controller, request, response, svr_done, write_worker_set_);
+}
+
 }  // namespace mds
 }  // namespace dingofs

--- a/src/mds/service/mds_service.cc
+++ b/src/mds/service/mds_service.cc
@@ -786,6 +786,10 @@ void MDSServiceImpl::DoGetInode(google::protobuf::RpcController*, const pb::mds:
     return ServiceHelper::SetError(response->mutable_error(), status.error_code(), status.error_str());
   }
 
+  if (BAIDU_UNLIKELY(request->ino() == 0)) {
+    return ServiceHelper::SetError(response->mutable_error(), pb::error::EILLEGAL_PARAMTETER, "ino is zero");
+  }
+
   Context ctx(request->context(), request->info().request_id(), __func__);
 
   EntryOut entry_out;
@@ -3563,9 +3567,8 @@ void MDSServiceImpl::DoGetDirStat(google::protobuf::RpcController*, const pb::md
   response->mutable_dir_stat()->Swap(&dir_stat);
 }
 
-void MDSServiceImpl::GetDirStat(google::protobuf::RpcController* controller,
-                                const pb::mds::GetDirStatRequest* request, pb::mds::GetDirStatResponse* response,
-                                google::protobuf::Closure* done) {
+void MDSServiceImpl::GetDirStat(google::protobuf::RpcController* controller, const pb::mds::GetDirStatRequest* request,
+                                pb::mds::GetDirStatResponse* response, google::protobuf::Closure* done) {
   auto* svr_done = new ServiceClosure(__func__, done, request, response);
 
   auto validate_fn = [&]() -> Status {

--- a/src/mds/service/mds_service.h
+++ b/src/mds/service/mds_service.h
@@ -190,6 +190,12 @@ class MDSServiceImpl : public pb::mds::MDSService {
   void DeleteDirQuota(google::protobuf::RpcController* controller, const pb::mds::DeleteDirQuotaRequest* request,
                       pb::mds::DeleteDirQuotaResponse* response, google::protobuf::Closure* done) override;
 
+  // dir-stat interface
+  void GetDirStat(google::protobuf::RpcController* controller, const pb::mds::GetDirStatRequest* request,
+                  pb::mds::GetDirStatResponse* response, google::protobuf::Closure* done) override;
+  void SyncDirStat(google::protobuf::RpcController* controller, const pb::mds::SyncDirStatRequest* request,
+                   pb::mds::SyncDirStatResponse* response, google::protobuf::Closure* done) override;
+
   void LoadDirQuotas(google::protobuf::RpcController* controller, const pb::mds::LoadDirQuotasRequest* request,
                      pb::mds::LoadDirQuotasResponse* response, google::protobuf::Closure* done) override;
 
@@ -385,6 +391,12 @@ class MDSServiceImpl : public pb::mds::MDSService {
                         pb::mds::DeleteDirQuotaResponse* response, TraceClosure* done);
   void DoLoadDirQuotas(google::protobuf::RpcController* controller, const pb::mds::LoadDirQuotasRequest* request,
                        pb::mds::LoadDirQuotasResponse* response, TraceClosure* done);
+
+  // dir-stat interface
+  void DoGetDirStat(google::protobuf::RpcController* controller, const pb::mds::GetDirStatRequest* request,
+                    pb::mds::GetDirStatResponse* response, TraceClosure* done);
+  void DoSyncDirStat(google::protobuf::RpcController* controller, const pb::mds::SyncDirStatRequest* request,
+                     pb::mds::SyncDirStatResponse* response, TraceClosure* done);
 
   // fs statistics
   void DoSetFsStats(google::protobuf::RpcController* controller, const pb::mds::SetFsStatsRequest* request,

--- a/src/mds/statistics/dir_stat_manager.cc
+++ b/src/mds/statistics/dir_stat_manager.cc
@@ -1,0 +1,312 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mds/statistics/dir_stat_manager.h"
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "fmt/format.h"
+#include "glog/logging.h"
+#include "mds/common/codec.h"
+#include "mds/common/synchronization.h"
+#include "mds/common/tracing.h"
+#include "mds/common/trash.h"
+#include "utils/time.h"
+
+namespace dingofs {
+namespace mds {
+namespace dir_stat {
+
+void DirStatManager::AsyncUpdateDirStat(Ino parent, int64_t length_delta, int64_t inode_delta, int64_t dir_delta,
+                                        const std::string& reason) {
+  auto task = UpdateDirStatTask::New(*this, parent, length_delta, inode_delta, dir_delta, reason);
+
+  if (!worker_set_->ExecuteHash(parent, task)) {
+    LOG(ERROR) << fmt::format(
+        "[dirstat.{}.{}] async update dir stat fail, length_delta({}) inode_delta({}) dir_delta({}) reason({}).",
+        fs_id_, parent, length_delta, inode_delta, dir_delta, reason);
+  }
+}
+
+void DirStatManager::UpdateDirStat(Ino parent, int64_t length_delta, int64_t inode_delta, int64_t dir_delta,
+                                   const std::string& reason) {
+  LOG(INFO) << fmt::format(
+      "[dirstat.{}.{}] update dir stat, length_delta({}) inode_delta({}) dir_delta({}) reason({}).", fs_id_, parent,
+      length_delta, inode_delta, dir_delta, reason);
+
+  shard_map_.withWLock(
+      [parent, length_delta, inode_delta, dir_delta](Map& map) {
+        auto& log = map[parent];
+        uint64_t now = utils::TimestampNs();
+        uint64_t time_ns = std::max(now, log.last_time_ns) + 1;
+        log.last_time_ns = time_ns;
+
+        DirStatDeltaEntry entry;
+        entry.length = length_delta;
+        entry.inodes = inode_delta;
+        entry.dirs = dir_delta;
+        entry.time_ns = time_ns;
+        log.deltas.push_back(entry);
+      },
+      parent);
+}
+
+void UpdateDirStatTask::Run() {
+  dir_stat_manager_.UpdateDirStat(parent_, length_delta_, inode_delta_, dir_delta_, reason_);
+}
+
+std::map<uint64_t, DirStatFlushEntry> DirStatManager::GetFlushSnapshot() {
+  std::map<uint64_t, DirStatFlushEntry> out;
+  shard_map_.iterate([&out](Map& map) {
+    for (const auto& [ino, log] : map) {
+      if (log.deltas.empty()) continue;
+      DirStatFlushEntry fe;
+      for (const auto& e : log.deltas) {
+        fe.delta.length += e.length;
+        fe.delta.inodes += e.inodes;
+        fe.delta.dirs += e.dirs;
+        fe.timepoint = e.time_ns;  // deque is time-ordered, so the last is the max
+      }
+      out.emplace(ino, fe);
+    }
+  });
+  return out;
+}
+
+void DirStatManager::Compact(Ino ino, uint64_t timepoint) {
+  shard_map_.withWLock(
+      [ino, timepoint](Map& map) {
+        auto it = map.find(ino);
+        if (it == map.end()) return;
+        auto& deque = it->second.deltas;
+        while (!deque.empty() && deque.front().time_ns <= timepoint) {
+          deque.pop_front();
+        }
+        // Drop the whole entry (and its retained clock) once empty: with a
+        // monotonic physical clock the next append still gets a fresh, larger
+        // timestamp, and timestamps are only ever compared within a live deque.
+        if (deque.empty()) map.erase(it);
+      },
+      ino);
+}
+
+DirStatDelta DirStatManager::GetPending(Ino ino) {
+  DirStatDelta out;
+  shard_map_.withRLock(
+      [ino, &out](Map& map) {
+        auto it = map.find(ino);
+        if (it == map.end()) return;
+        for (const auto& e : it->second.deltas) {
+          out.length += e.length;
+          out.inodes += e.inodes;
+          out.dirs += e.dirs;
+        }
+      },
+      ino);
+  return out;
+}
+
+uint64_t DirStatManager::PeekMaxTimeNs(Ino ino) {
+  uint64_t out = 0;
+  shard_map_.withRLock(
+      [ino, &out](Map& map) {
+        auto it = map.find(ino);
+        if (it == map.end() || it->second.deltas.empty()) return;
+        out = it->second.deltas.back().time_ns;  // time-ordered
+      },
+      ino);
+  return out;
+}
+
+size_t DirStatManager::Size() {
+  size_t n = 0;
+  shard_map_.iterate([&n](Map& map) {
+    for (const auto& [ino, log] : map) {
+      if (!log.deltas.empty()) ++n;
+    }
+  });
+  return n;
+}
+
+Status DirStatManager::GetDirStat(Context& ctx, Ino ino, DirStatEntry& out, bool with_pending) {
+  GetDirStatOperation operation(ctx.GetTrace(), fs_id_, ino);
+  auto status = operation_processor_->RunAlone(&operation);
+  if (!status.ok()) return status;
+
+  if (operation.GetResult().found) {
+    out = operation.GetResult().dir_stat;
+
+    if (with_pending) {
+      DirStatDelta pending = GetPending(ino);
+      out.set_length(out.length() + pending.length);
+      out.set_inodes(out.inodes() + pending.inodes);
+      out.set_dirs(out.dirs() + pending.dirs);
+    }
+    return Status::OK();
+  }
+
+  // No stored record (a directory created before the feature was enabled). The
+  // read must not corrupt the store-vs-buffer reconciliation, so: capture the
+  // buffer's high-water timestamp BEFORE the scan, recompute the absolute from
+  // the live tree, then seed it with a single-txn no-clobber op (a concurrent
+  // flush/seed that already created the record wins). On a successful seed,
+  // compact the delta prefix that pre-dates the scan; deltas that raced in after
+  // the scan (time_ns > cut) survive and flush on top. The returned value is the
+  // scan absolute itself, which already reflects every committed mutation -- we
+  // do NOT fold pending here (that would double-count what the scan saw). The
+  // residual (a mutation committed-and-scanned whose async delta predates `cut`)
+  // is bounded by async dispatch latency and converges via SyncDirStat; there is
+  // no store commit clock to make this exact.
+  uint64_t cut = EnableDirStats() ? PeekMaxTimeNs(ino) : 0;
+
+  status = recompute_(ctx, ino, out);
+  if (!status.ok()) return status;
+
+  if (EnableDirStats() && !IsTrashInode(ino)) {
+    SeedDirStatOperation seed_op(ctx.GetTrace(), fs_id_, ino, out);
+    auto st = operation_processor_->RunAlone(&seed_op);
+    if (st.ok()) {
+      if (seed_op.GetResult().seeded) Compact(ino, cut);
+    } else {
+      LOG(WARNING) << fmt::format("[dirstat.{}] seed recomputed dir stat fail, ino({}), status({}).", fs_id_, ino,
+                                  st.error_str());
+    }
+  }
+
+  return Status::OK();
+}
+
+Status DirStatManager::GetAllDirStats(std::map<Ino, DirStatEntry>& dir_stats) {
+  Trace trace;
+  ScanDirStatOperation operation(trace, fs_id_, [&](const std::string& key, const std::string& value) -> bool {
+    uint32_t fs_id = 0;
+    Ino ino = 0;
+    MetaCodec::DecodeDirStatKey(key, fs_id, ino);
+    dir_stats[ino] = MetaCodec::DecodeDirStatValue(value);
+    return true;
+  });
+  operation.SetIsolationLevel(Txn::kReadCommitted);
+
+  return operation_processor_->RunAlone(&operation);
+}
+
+// Single-level dir-stat check/repair for one directory: recompute its stat from
+// the live tree and compare against the stored record, recording (and optionally
+// repairing) a mismatch. Tree-wide recursion now lives in the client (mds-cli),
+// which calls this per directory routed to the owning MDS.
+Status DirStatManager::SyncDirStat(Context& ctx, Ino ino, bool repair, std::vector<DirStatMismatch>& mismatches) {
+  // Capture the buffer high-water BEFORE the scan so a delta that races in after
+  // the scan snapshot is kept (compacted only after a successful repair write).
+  uint64_t cut = (repair && EnableDirStats()) ? PeekMaxTimeNs(ino) : 0;
+
+  DirStatEntry calc;
+  auto status = recompute_(ctx, ino, calc);
+  if (!status.ok()) return status;
+
+  // Read + (on repair) overwrite in a single SI txn: a flush committing between
+  // the read and the write triggers a retry that re-reads, so the recomputed
+  // absolute is never lost-updated against it. repair=false issues only the read.
+  RepairDirStatOperation op(ctx.GetTrace(), fs_id_, ino, calc, repair);
+  status = operation_processor_->RunAlone(&op);
+  if (!status.ok()) return status;
+
+  const auto& r = op.GetResult();
+  if (r.mismatch) {
+    DirStatMismatch brk;
+    brk.ino = ino;
+    brk.found = r.found;
+    brk.want = calc;
+    if (r.found) brk.got = r.stored;
+    mismatches.push_back(std::move(brk));
+  }
+
+  // Drop the pre-scan delta prefix only when we actually wrote the recomputed
+  // absolute (it already reflects those deltas); deltas with time_ns > cut survive.
+  if (r.wrote) Compact(ino, cut);
+
+  return Status::OK();
+}
+
+Status DirStatManager::FlushDirStats() {
+  if (!EnableDirStats()) return Status::OK();
+
+  // Serialize flushes: a flush snapshots the delta log then applies the sums to
+  // the store. Two concurrent flushes would both read and apply the same deltas
+  // (double count). The atomic gate makes overlap (cron vs Destroy/manual) safe.
+  bool expected = false;
+  if (!flushing_.compare_exchange_strong(expected, true)) return Status::OK();
+  ON_SCOPE_EXIT([this]() { flushing_.store(false); });
+
+  auto snapshot = GetFlushSnapshot();
+  if (snapshot.empty()) return Status::OK();
+
+  std::map<uint64_t, DirStatDelta> deltas;
+  for (const auto& [ino, fe] : snapshot) deltas.emplace(ino, fe.delta);
+
+  Trace trace;
+  FlushDirStatsOperation operation(trace, fs_id_, deltas);
+  auto status = operation_processor_->RunAlone(&operation);
+  if (!status.ok()) {
+    // The flush transaction applied nothing; leave the delta log untouched (we
+    // never removed anything) so the next flush simply retries.
+    LOG(ERROR) << fmt::format("[dirstat.{}] flush dir stats fail, status({}).", fs_id_, status.error_str());
+    return status;
+  }
+
+  // Drop the persisted prefix per ino. A delta appended during the flush has a
+  // larger logical timestamp than the snapshot timepoint and survives for the
+  // next cycle. Skip inos the op could not apply (missing/negative) -- handled
+  // by the recompute below.
+  const auto& missing_inos = operation.GetResult().missing_inos;
+  std::set<uint64_t> missing(missing_inos.begin(), missing_inos.end());
+  for (const auto& [ino, fe] : snapshot) {
+    if (missing.count(ino)) continue;
+    Compact(ino, fe.timepoint);
+  }
+
+  // Records that were absent or whose merged value went negative: recompute the
+  // absolute from the live tree and overwrite it (version-guarded), then compact
+  // the pre-scan delta prefix -- same reconciliation as the GetDirStat miss path.
+  for (Ino ino : missing_inos) {
+    if (IsTrashInode(ino)) continue;
+    Context ctx;
+    uint64_t cut = PeekMaxTimeNs(ino);
+
+    DirStatEntry calc;
+    auto st = recompute_(ctx, ino, calc);
+    if (!st.ok()) {
+      LOG(WARNING) << fmt::format("[dirstat.{}] recalc dir stat fail, ino({}), status({}).", fs_id_, ino,
+                                  st.error_str());
+      continue;
+    }
+
+    RepairDirStatOperation rep(ctx.GetTrace(), fs_id_, ino, calc, /*repair=*/true);
+    st = operation_processor_->RunAlone(&rep);
+    if (!st.ok()) {
+      LOG(WARNING) << fmt::format("[dirstat.{}] repair recomputed dir stat fail, ino({}), status({}).", fs_id_, ino,
+                                  st.error_str());
+      continue;
+    }
+    Compact(ino, cut);
+  }
+
+  return Status::OK();
+}
+
+}  // namespace dir_stat
+}  // namespace mds
+}  // namespace dingofs

--- a/src/mds/statistics/dir_stat_manager.h
+++ b/src/mds/statistics/dir_stat_manager.h
@@ -1,0 +1,226 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DINGOFS_MDS_DIR_STAT_DIR_STAT_MANAGER_H_
+#define DINGOFS_MDS_DIR_STAT_DIR_STAT_MANAGER_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "mds/common/context.h"
+#include "mds/common/runnable.h"
+#include "mds/common/status.h"
+#include "mds/common/type.h"
+#include "mds/filesystem/fs_info.h"
+#include "mds/filesystem/store_operation.h"
+#include "utils/shards.h"
+
+namespace dingofs {
+namespace mds {
+namespace dir_stat {
+
+// One directory's buffered deltas, summed, plus the timepoint (max logical
+// timestamp) of the deltas included -- the unit GetFlushSnapshot hands to the
+// flusher. After the flush commits, Compact(ino, timepoint) drops exactly this
+// prefix while any delta that arrived during the flush (a strictly larger
+// timestamp) survives. Mirrors quota's GetUsage()/CompactDeltaUsage(timepoint).
+struct DirStatFlushEntry {
+  DirStatDelta delta;
+  uint64_t timepoint{0};
+};
+
+// Thread-safe in-memory per-directory delta log. Modeled on quota's
+// Quota{used,delta_usages_}: each mutation appends a single-level delta tagged
+// with a strictly-monotonic logical timestamp; reads fold the un-flushed deltas
+// on top of the stored absolute; the flusher snapshots, persists, then compacts
+// only the persisted prefix. This time-bounded compaction (rather than a
+// blanket buffer drop) is what lets the recompute/repair paths keep deltas that
+// post-date their tree scan.
+class DirStatManager {
+ public:
+  DirStatManager(FsInfoSPtr fs_info, OperationProcessorSPtr operation_processor, WorkerSetSPtr worker_set)
+      : fs_id_(fs_info->GetFsId()),
+        fs_info_(std::move(fs_info)),
+        operation_processor_(std::move(operation_processor)),
+        worker_set_(std::move(worker_set)) {}
+  ~DirStatManager() = default;
+
+  DirStatManager(const DirStatManager&) = delete;
+  DirStatManager& operator=(const DirStatManager&) = delete;
+
+  // recompute one directory's single-level stat from the live tree -- supplied
+  // by FileSystem (CalcDirStat) since the scan needs the dentry/inode traversal
+  // primitives. Used by the seed/repair paths of GetDirStat/SyncDirStat/Flush.
+  using RecomputeFn = std::function<Status(Context&, Ino, DirStatEntry&)>;
+
+  // Inject the recompute callback. Set once right after construction (the
+  // callback captures the owning FileSystem, which is not yet usable in the
+  // member initializer list).
+  void SetRecomputeFn(RecomputeFn fn) { recompute_ = std::move(fn); }
+
+  // A directory whose stored dir-stat disagreed with a fresh recompute.
+  // `want` is the recomputed (authoritative) value; `got` is the stored record
+  // (default-constructed, i.e. all-zero, when `found` is false).
+  struct DirStatMismatch {
+    Ino ino;
+    bool found;
+    DirStatEntry want;
+    DirStatEntry got;
+  };
+
+  // with_pending: fold the owner-local unflushed dir-stat delta onto the stored
+  // record so the returned value is real-time. Only the RPC handler (single-
+  // directory read) opts in; the internal recursive-summary caller must leave it
+  // false because it folds the delta itself (else the delta is double-counted).
+  Status GetDirStat(Context& ctx, Ino ino, DirStatEntry& out, bool with_pending = false);
+
+  // Enumerate all dir-stat records stored in the KV store for this fs. Reads the
+  // store only (does not fold the in-memory unflushed delta), so a freshly
+  // mutated directory shows up after the next background flush. Used by the
+  // dashboard dir-stats page.
+  Status GetAllDirStats(std::map<Ino, DirStatEntry>& dir_stats);
+
+  // Single-level check/repair for one directory; tree-wide recursion now lives
+  // in the client (mds-cli), which calls this per directory routed to the owner.
+  Status SyncDirStat(Context& ctx, Ino ino, bool repair, std::vector<DirStatMismatch>& mismatches);
+
+  // Snapshot the in-memory delta log and apply the sums to the store, then drop
+  // the persisted prefix. Serialized against itself by `flushing_`.
+  Status FlushDirStats();
+
+  // dispatch the accumulation to a worker hashed by `parent` so the request
+  // thread never touches the shard lock. Same-parent updates land on the same
+  // worker, preserving per-directory ordering. The actual append is UpdateDirStat.
+  void AsyncUpdateDirStat(Ino parent, int64_t length_delta, int64_t inode_delta, int64_t dir_delta,
+                          const std::string& reason);
+
+  // append one delta (tagged with a fresh logical timestamp) to `parent`'s log.
+  void UpdateDirStat(Ino parent, int64_t length_delta, int64_t inode_delta, int64_t dir_delta,
+                     const std::string& reason);
+
+  // snapshot every directory's currently-buffered deltas (summed) plus the
+  // timepoint of the newest included delta. Does NOT remove anything -- removal
+  // happens only via Compact after the flush commits, so a failed flush leaves
+  // the log intact and a delta arriving mid-flush is never lost.
+  std::map<uint64_t, DirStatFlushEntry> GetFlushSnapshot();
+
+  // drop the prefix of `ino`'s log with time_ns <= timepoint (the entries a just-
+  // committed flush/recompute already persisted). Entries with a larger timestamp
+  // remain. Erases the ino when its log becomes empty.
+  void Compact(Ino ino, uint64_t timepoint);
+
+  // sum of `ino`'s currently-buffered deltas (zero if none). Lets a single-level
+  // read fold the un-flushed delta on top of the stored record.
+  DirStatDelta GetPending(Ino ino);
+
+  // the largest logical timestamp currently buffered for `ino` (0 if none).
+  // Captured before a tree scan so the post-scan Compact keeps deltas that
+  // raced in after the scan snapshot.
+  uint64_t PeekMaxTimeNs(Ino ino);
+
+  // number of directories currently holding buffered deltas (test-only hook).
+  size_t Size();
+
+ private:
+  // Read live from fs_info_ so a runtime toggle takes effect without recreating
+  // the manager. Mirrors FileSystem::EnableDirStats().
+  bool EnableDirStats() const { return fs_info_->EnableDirStats(); }
+
+  const uint32_t fs_id_;
+
+  FsInfoSPtr fs_info_;
+
+  // run dir-stat store operations (read/seed/repair/scan/flush) directly via
+  // RunAlone -- all dir-stat ops are non-batch. Mirrors QuotaManager.
+  OperationProcessorSPtr operation_processor_;
+
+  // serialize FlushDirStats: it snapshots the in-memory delta log then applies
+  // the sums to the store, so two concurrent flushes would both read and apply
+  // the same deltas (double count). The cron is single-timer but Destroy/manual
+  // paths could overlap it.
+  std::atomic<bool> flushing_{false};
+
+  // injected live-tree recompute (FileSystem::CalcDirStat).
+  RecomputeFn recompute_;
+
+  // AsyncUpdateDirStat offloads every append onto this worker set (hashed by
+  // parent), keeping the shard lock off the request thread entirely.
+  WorkerSetSPtr worker_set_;
+
+  // One directory's buffered deltas plus its own logical clock -- the per-
+  // directory analogue of quota's Quota{delta_usages_, last_time_ns_}. The
+  // timestamp is allocated under the shard lock as max(now, last_time_ns)+1, so
+  // the log stays append-ordered == time-ordered (Compact pops a sorted prefix)
+  // with no cross-directory atomic clock to contend on.
+  struct DirStatLog {
+    std::deque<DirStatDeltaEntry> deltas;
+    uint64_t last_time_ns{0};
+  };
+
+  // Per-directory delta log, sharded (lock striping) so the worker pool applies
+  // many parents in parallel without convoying on one lock.
+  using Map = absl::flat_hash_map<uint64_t, DirStatLog>;
+  constexpr static size_t kShardNum = 128;
+  utils::Shards<Map, kShardNum> shard_map_;
+};
+
+class UpdateDirStatTask;
+using UpdateDirStatTaskSPtr = std::shared_ptr<UpdateDirStatTask>;
+
+class UpdateDirStatTask : public TaskRunnable {
+ public:
+  UpdateDirStatTask(DirStatManager& dir_stat_manager, Ino parent, int64_t length_delta, int64_t inode_delta,
+                    int64_t dir_delta, const std::string& reason)
+      : dir_stat_manager_(dir_stat_manager),
+        parent_(parent),
+        length_delta_(length_delta),
+        inode_delta_(inode_delta),
+        dir_delta_(dir_delta),
+        reason_(reason) {}
+
+  ~UpdateDirStatTask() override = default;
+
+  static UpdateDirStatTaskSPtr New(DirStatManager& dir_stat_manager, Ino parent, int64_t length_delta,
+                                   int64_t inode_delta, int64_t dir_delta, const std::string& reason) {
+    return std::make_shared<UpdateDirStatTask>(dir_stat_manager, parent, length_delta, inode_delta, dir_delta, reason);
+  }
+
+  std::string Type() override { return "UpdateDirStatTask"; }
+
+  void Run() override;
+
+ private:
+  DirStatManager& dir_stat_manager_;
+
+  Ino parent_;
+  int64_t length_delta_;
+  int64_t inode_delta_;
+  int64_t dir_delta_;
+
+  const std::string reason_;
+};
+
+}  // namespace dir_stat
+}  // namespace mds
+}  // namespace dingofs
+
+#endif  // DINGOFS_MDS_DIR_STAT_DIR_STAT_MANAGER_H_

--- a/src/tools/mds-cli/CMakeLists.txt
+++ b/src/tools/mds-cli/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(mds_client
   interaction.cc
   br.cc
   trash_restore.cc
+  owner_router.cc
+  dir_tree_walker.cc
 )
 
 target_link_libraries(mds_client

--- a/src/tools/mds-cli/br.cc
+++ b/src/tools/mds-cli/br.cc
@@ -444,8 +444,8 @@ Status Backup::BackupFsMetaTable(uint32_t fs_id, OutputUPtr output) {
   CHECK(output != nullptr) << "output is nullptr.";
 
   uint64_t total_count = 0, inode_count = 0, dentry_count = 0, chunk_count = 0;
-  uint64_t dir_quota_count = 0, file_session_count = 0, del_slice_count = 0,
-           del_file_count = 0;
+  uint64_t dir_quota_count = 0, dir_stat_count = 0, file_session_count = 0,
+           del_slice_count = 0, del_file_count = 0;
 
   Trace trace;
   ScanFsMetaTableOperation operation(
@@ -455,6 +455,8 @@ Status Backup::BackupFsMetaTable(uint32_t fs_id, OutputUPtr output) {
 
         if (MetaCodec::IsDirQuotaKey(key)) {
           ++dir_quota_count;
+        } else if (MetaCodec::IsDirStatKey(key)) {
+          ++dir_stat_count;
         } else if (MetaCodec::IsInodeKey(key)) {
           ++inode_count;
         } else if (MetaCodec::IsDentryKey(key)) {
@@ -485,10 +487,10 @@ Status Backup::BackupFsMetaTable(uint32_t fs_id, OutputUPtr output) {
   std::cout << fmt::format(
       "backup fsmeta table done.\n summary total_count({}) inode_count({}) "
       "dentry_count({}) chunk_count({}) "
-      "dir_quota_count({}) "
+      "dir_quota_count({}) dir_stat_count({}) "
       "file_session_count({}) del_slice_count({}) del_file_count({}).\n",
       total_count, inode_count, dentry_count, chunk_count, dir_quota_count,
-      file_session_count, del_slice_count, del_file_count);
+      dir_stat_count, file_session_count, del_slice_count, del_file_count);
 
   return status;
 }
@@ -741,8 +743,8 @@ Status Restore::RestoreFsMetaTable(uint32_t fs_id, InputUPtr input,
 
   // import fs meta to table
 
-  uint64_t total_count = 0, dir_quota_count = 0, inode_count = 0,
-           dentry_count = 0;
+  uint64_t total_count = 0, dir_quota_count = 0, dir_stat_count = 0,
+           inode_count = 0, dentry_count = 0;
   uint64_t chunk_count = 0, file_session_count = 0, del_slice_count = 0,
            del_file_count = 0;
 
@@ -756,6 +758,8 @@ Status Restore::RestoreFsMetaTable(uint32_t fs_id, InputUPtr input,
 
     if (MetaCodec::IsDirQuotaKey(kv.key)) {
       ++dir_quota_count;
+    } else if (MetaCodec::IsDirStatKey(kv.key)) {
+      ++dir_stat_count;
     } else if (MetaCodec::IsInodeKey(kv.key)) {
       ++inode_count;
     } else if (MetaCodec::IsDentryKey(kv.key)) {
@@ -794,10 +798,11 @@ Status Restore::RestoreFsMetaTable(uint32_t fs_id, InputUPtr input,
   std::cout << fmt::format(
       "restore fsmeta table done.\n summary total_count({}) inode_count({}) "
       "dentry_count({}) chunk_count({}) "
-      "dir_quota_count({}) file_session_count({}) del_slice_count({}) "
-      "del_file_count({}) status({}).\n",
+      "dir_quota_count({}) dir_stat_count({}) file_session_count({}) "
+      "del_slice_count({}) del_file_count({}) status({}).\n",
       total_count, inode_count, dentry_count, chunk_count, dir_quota_count,
-      file_session_count, del_slice_count, del_file_count, status.error_str());
+      dir_stat_count, file_session_count, del_slice_count, del_file_count,
+      status.error_str());
 
   return Status::OK();
 }

--- a/src/tools/mds-cli/dir_tree_walker.cc
+++ b/src/tools/mds-cli/dir_tree_walker.cc
@@ -1,0 +1,449 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/mds-cli/dir_tree_walker.h"
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "dingofs/error.pb.h"
+#include "dingofs/mds.pb.h"
+
+namespace dingofs {
+namespace mds {
+namespace client {
+
+namespace {
+
+using pb::mds::FileType;
+
+// ReadDir is served one page at a time; this value is passed as the request
+// limit, so a page with fewer entries is the last one.
+constexpr int kReadDirPage = 100;
+// ListDentry page size for sub-directory enumeration.
+constexpr uint32_t kListDentryPage = 1000;
+
+bool IsOk(const pb::error::Error& e) {
+  return e.errcode() == pb::error::Errno::OK;
+}
+bool IsNotFound(const pb::error::Error& e) {
+  return e.errcode() == pb::error::Errno::ENOT_FOUND;
+}
+
+// One directory's single-level contribution plus its sub-directories.
+struct LevelResult {
+  bool ok{false};        // read succeeded; files/length/subdirs are valid
+  bool vanished{false};  // ENOT_FOUND (concurrent rmdir) -> skip, not an error
+  int64_t files{0};      // direct non-directory children (symlinks included)
+  int64_t length{0};     // sum of direct FILE child lengths
+  std::vector<std::pair<Ino, std::string>> subdirs;  // {ino, name}
+};
+
+// Page through ListDentry(is_only_dir=true) on `owner`, collecting
+// sub-directory {ino, name}. Returns false on failure; `vanished` distinguishes
+// ENOT_FOUND.
+bool ListSubdirs(MDSClient* owner, Ino ino,
+                 std::vector<std::pair<Ino, std::string>>& out,
+                 bool& vanished) {
+  vanished = false;
+  std::string last;
+  for (;;) {
+    auto resp = owner->ListDentryPaged(ino, last, kListDentryPage,
+                                       /*is_only_dir=*/true);
+    if (!IsOk(resp.error())) {
+      vanished = IsNotFound(resp.error());
+      return false;
+    }
+    const int n = resp.dentries_size();
+    for (const auto& d : resp.dentries()) {
+      // The store-backed ListDentry scans inclusive of `last`; drop the
+      // repeated boundary entry so it is not counted twice (names are unique in
+      // a dir).
+      if (!last.empty() && d.name() == last) continue;
+      out.emplace_back(d.ino(), d.name());
+    }
+    if (n < static_cast<int>(kListDentryPage)) break;
+    last = resp.dentries(n - 1).name();
+  }
+  return true;
+}
+
+// Read one directory level (routed to `ino`'s owner): its single-level
+// {files, length} and the list of sub-directories to recurse into.
+LevelResult ReadLevel(OwnerRouter& router, Ino ino, const WalkOptions& opts) {
+  LevelResult lr;
+  MDSClient* owner = router.ClientForIno(ino);
+  if (owner == nullptr) {
+    LOG(ERROR) << fmt::format(
+        "no owner mds for ino({}); subtree skipped, result incomplete", ino);
+    return lr;  // ok=false, vanished=false -> incomplete
+  }
+
+  const bool strict = opts.strict || !opts.dirstats_enabled;
+  if (!strict) {
+    // FAST: trust the stored single-level stat (the owner folds its own
+    // unflushed delta), and only enumerate sub-directories when there are any.
+    auto resp = owner->GetDirStat(ino);
+    if (!IsOk(resp.error())) {
+      lr.vanished = IsNotFound(resp.error());
+      if (!lr.vanished)
+        LOG(ERROR) << fmt::format("GetDirStat ino({}) fail: {}", ino,
+                                  resp.error().errmsg());
+      return lr;
+    }
+    const auto& ds = resp.dir_stat();
+    const int64_t dirs = ds.dirs();
+    lr.files = ds.inodes() - dirs;
+    lr.length = ds.length();
+    if (dirs > 0 && !ListSubdirs(owner, ino, lr.subdirs, lr.vanished)) {
+      if (!lr.vanished)
+        LOG(ERROR) << fmt::format("ListDentry ino({}) fail; result incomplete",
+                                  ino);
+      return lr;
+    }
+    lr.ok = true;
+    return lr;
+  }
+
+  // STRICT: authoritative dentry scan. The dentry type is the source of truth
+  // and file lengths come from the inode attrs in the same response.
+  std::string last;
+  for (;;) {
+    auto resp = owner->ReadDir(ino, last, /*with_attr=*/true,
+                               /*is_refresh=*/false, kReadDirPage);
+    if (!IsOk(resp.error())) {
+      lr.vanished = IsNotFound(resp.error());
+      if (!lr.vanished)
+        LOG(ERROR) << fmt::format("ReadDir ino({}) fail; result incomplete",
+                                  ino);
+      return lr;
+    }
+    const int n = resp.entries_size();
+    for (const auto& e : resp.entries()) {
+      if (!last.empty() && e.name() == last)
+        continue;  // boundary dedup (see ListSubdirs)
+      if (e.inode().type() == FileType::DIRECTORY) {
+        lr.subdirs.emplace_back(e.ino(), e.name());
+      } else {
+        ++lr.files;
+        if (e.inode().type() == FileType::FILE)
+          lr.length += static_cast<int64_t>(e.inode().length());
+      }
+    }
+    if (n < kReadDirPage) break;
+    last = resp.entries(n - 1).name();
+  }
+  lr.ok = true;
+  return lr;
+}
+
+// Push-based parallel directory walk. `visit(ino)` does the per-directory work
+// (synchronizing its own aggregation) and returns the child directory inos to
+// schedule. A worker never blocks on its children (no parent->child join), so a
+// fixed pool cannot deadlock; the walk ends when the queue drains with no task
+// in flight.
+template <typename Visit>
+void ParallelWalk(Ino root, uint32_t threads, Visit visit) {
+  if (threads < 1) threads = 1;
+
+  std::mutex mu;
+  std::condition_variable cv;
+  std::deque<Ino> queue;
+  int64_t active = 0;
+  bool stop = false;
+  queue.push_back(root);
+
+  auto worker = [&]() {
+    for (;;) {
+      Ino ino;
+      {
+        std::unique_lock<std::mutex> lk(mu);
+        cv.wait(lk, [&] { return stop || !queue.empty(); });
+        if (stop) return;
+        ino = queue.front();
+        queue.pop_front();
+        ++active;
+      }
+
+      std::vector<Ino> children = visit(ino);
+
+      {
+        std::unique_lock<std::mutex> lk(mu);
+        for (Ino c : children) queue.push_back(c);
+        --active;
+        if (queue.empty() && active == 0) stop = true;
+      }
+      cv.notify_all();
+    }
+  };
+
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  for (uint32_t i = 0; i < threads; ++i) workers.emplace_back(worker);
+  for (auto& t : workers) t.join();
+}
+
+// Per-directory single-level data captured during a WalkTree traversal, used to
+// build the TreeSummary offline (in-memory, single-threaded) afterwards.
+struct NodeData {
+  int64_t files{0};
+  int64_t length{0};
+  std::vector<std::pair<Ino, std::string>> subdirs;
+};
+
+// Build the TreeSummary node for `ino` from the captured `nodes`, returning its
+// recursive {dirs, files, length}. Expands child nodes while `depth > 0`; at
+// depth 0 it only aggregates (no further expansion). Each directory appears
+// once (a tree has a single parent per node), so no memoization is needed.
+DirAgg BuildNode(const std::unordered_map<Ino, NodeData>& nodes, Ino ino,
+                 uint32_t depth, uint32_t top_n, pb::mds::TreeSummary* node) {
+  auto it = nodes.find(ino);
+  if (it == nodes.end()) {
+    // Vanished or unreadable during the walk: an empty subtree.
+    if (node != nullptr) {
+      node->set_dirs(0);
+      node->set_files(0);
+      node->set_length(0);
+    }
+    return {};
+  }
+
+  const NodeData& nd = it->second;
+  DirAgg agg{nd.files, /*dirs=*/1, nd.length};  // count this directory itself
+  for (const auto& [cino, cname] : nd.subdirs) {
+    if (depth > 0) {
+      auto* child = node->add_children();
+      child->set_ino(cino);
+      child->set_path(cname);
+      child->set_type(FileType::DIRECTORY);
+      DirAgg c = BuildNode(nodes, cino, depth - 1, top_n, child);
+      agg.files += c.files;
+      agg.dirs += c.dirs;
+      agg.length += c.length;
+    } else {
+      DirAgg c = BuildNode(nodes, cino, 0, top_n, nullptr);
+      agg.files += c.files;
+      agg.dirs += c.dirs;
+      agg.length += c.length;
+    }
+  }
+
+  if (node != nullptr) {
+    node->set_files(agg.files);
+    node->set_dirs(agg.dirs);
+    node->set_length(agg.length);
+    if (depth > 0) CollapseChildrenTopN(*node, top_n);
+  }
+  return agg;
+}
+
+}  // namespace
+
+bool WalkAggregate(OwnerRouter& router, Ino root, const WalkOptions& opts,
+                   DirAgg& out) {
+  std::atomic<int64_t> files{0};
+  std::atomic<int64_t> dirs{0};
+  std::atomic<int64_t> length{0};
+  std::atomic<bool> incomplete{false};
+
+  ParallelWalk(root, opts.threads, [&](Ino ino) -> std::vector<Ino> {
+    LevelResult lr = ReadLevel(router, ino, opts);
+    if (!lr.ok) {
+      if (!lr.vanished) incomplete.store(true);
+      return {};
+    }
+    dirs.fetch_add(1);
+    files.fetch_add(lr.files);
+    length.fetch_add(lr.length);
+
+    std::vector<Ino> children;
+    children.reserve(lr.subdirs.size());
+    for (const auto& s : lr.subdirs) children.push_back(s.first);
+    return children;
+  });
+
+  out.files = files.load();
+  out.dirs = dirs.load();
+  out.length = length.load();
+  return !incomplete.load();
+}
+
+bool ReadDirStatStrict(OwnerRouter& router, Ino ino, DirAgg& out) {
+  out = DirAgg{};
+  WalkOptions opts;
+  opts.strict = true;  // force the authoritative dentry scan
+  LevelResult lr = ReadLevel(router, ino, opts);
+  if (!lr.ok) return false;  // no owner / read error / ENOT_FOUND
+  out.files = lr.files;
+  out.dirs = static_cast<int64_t>(lr.subdirs.size());  // direct sub-dir count
+  out.length = lr.length;
+  return true;
+}
+
+bool ReadDirStatFast(OwnerRouter& router, Ino ino, DirAgg& out) {
+  out = DirAgg{};
+  MDSClient* owner = router.ClientForIno(ino);
+  if (owner == nullptr) {
+    LOG(ERROR) << fmt::format("no owner mds for ino({})", ino);
+    return false;
+  }
+  auto resp = owner->GetDirStat(ino);
+  if (!IsOk(resp.error())) {
+    if (!IsNotFound(resp.error()))
+      LOG(ERROR) << fmt::format("GetDirStat ino({}) fail: {}", ino,
+                                resp.error().errmsg());
+    return false;
+  }
+  const auto& ds = resp.dir_stat();
+  const int64_t dirs = ds.dirs();
+  out.files = ds.inodes() - dirs;
+  out.dirs = dirs;
+  out.length = ds.length();
+  return true;
+}
+
+bool WalkTree(OwnerRouter& router, Ino root, const WalkOptions& opts,
+              uint32_t depth, uint32_t top_n, pb::mds::TreeSummary& out) {
+  std::mutex map_mu;
+  std::unordered_map<Ino, NodeData> nodes;
+  std::atomic<bool> incomplete{false};
+
+  // One parallel pass over the whole subtree captures every directory's
+  // single-level data; the structured tree is then built offline.
+  ParallelWalk(root, opts.threads, [&](Ino ino) -> std::vector<Ino> {
+    LevelResult lr = ReadLevel(router, ino, opts);
+    if (!lr.ok) {
+      if (!lr.vanished) incomplete.store(true);
+      return {};
+    }
+    std::vector<Ino> children;
+    children.reserve(lr.subdirs.size());
+    for (const auto& s : lr.subdirs) children.push_back(s.first);
+
+    NodeData nd;
+    nd.files = lr.files;
+    nd.length = lr.length;
+    nd.subdirs = std::move(lr.subdirs);
+    {
+      std::lock_guard<std::mutex> lg(map_mu);
+      nodes[ino] = std::move(nd);
+    }
+    return children;
+  });
+
+  // A real read error means the caller aborts without printing, so skip building
+  // a tree nobody will read. (Benign concurrent rmdir does not set `incomplete`;
+  // that subtree is still built and rendered as an empty node.)
+  if (incomplete.load()) return false;
+
+  out.set_ino(root);
+  out.set_type(FileType::DIRECTORY);
+  // The root row's path is supplied by the renderer (base_path); leave it
+  // empty.
+  BuildNode(nodes, root, depth, top_n, &out);
+  return true;
+}
+
+bool WalkSyncDirStat(OwnerRouter& router, Ino root, const WalkOptions& opts,
+                     bool repair,
+                     std::vector<pb::mds::DirStatMismatch>& mismatches) {
+  std::mutex mismatches_mu;
+  std::atomic<bool> incomplete{false};
+
+  ParallelWalk(root, opts.threads, [&](Ino ino) -> std::vector<Ino> {
+    MDSClient* owner = router.ClientForIno(ino);
+    if (owner == nullptr) {
+      LOG(ERROR) << fmt::format(
+          "no owner mds for ino({}); subtree skipped, result incomplete", ino);
+      incomplete.store(true);
+      return {};
+    }
+
+    // Single-level check/repair for this directory.
+    auto resp = owner->SyncDirStat(ino, repair);
+    if (IsOk(resp.error())) {
+      if (resp.mismatches_size() > 0) {
+        std::lock_guard<std::mutex> lg(mismatches_mu);
+        for (const auto& b : resp.mismatches()) mismatches.push_back(b);
+      }
+    } else if (!IsNotFound(resp.error())) {
+      LOG(ERROR) << fmt::format(
+          "SyncDirStat ino({}) fail: {}; result incomplete", ino,
+          resp.error().errmsg());
+      incomplete.store(true);
+    }
+
+    // Enumerate sub-directories (dentry truth) to recurse into.
+    std::vector<std::pair<Ino, std::string>> subdirs;
+    bool vanished = false;
+    if (!ListSubdirs(owner, ino, subdirs, vanished)) {
+      if (!vanished) {
+        LOG(ERROR) << fmt::format("ListDentry ino({}) fail; result incomplete",
+                                  ino);
+        incomplete.store(true);
+      }
+      return {};
+    }
+    std::vector<Ino> children;
+    children.reserve(subdirs.size());
+    for (const auto& s : subdirs) children.push_back(s.first);
+    return children;
+  });
+
+  std::sort(mismatches.begin(), mismatches.end(),
+            [](const pb::mds::DirStatMismatch& a,
+               const pb::mds::DirStatMismatch& b) {
+              return a.ino() < b.ino();
+            });
+  return !incomplete.load();
+}
+
+void CollapseChildrenTopN(pb::mds::TreeSummary& node, uint32_t top_n) {
+  auto* children = node.mutable_children();
+  std::sort(children->begin(), children->end(),
+            [](const pb::mds::TreeSummary& a, const pb::mds::TreeSummary& b) {
+              return a.length() > b.length();
+            });
+
+  if (top_n == 0 || static_cast<uint32_t>(children->size()) <= top_n) return;
+
+  // Merge the omitted (lower-ranked) sub-directories into a single "..." node.
+  pb::mds::TreeSummary omit;
+  omit.set_path("...");
+  omit.set_type(FileType::FILE);
+  for (int i = static_cast<int>(top_n); i < children->size(); ++i) {
+    const auto& c = children->Get(i);
+    omit.set_length(omit.length() + c.length());
+    omit.set_files(omit.files() + c.files());
+    omit.set_dirs(omit.dirs() + c.dirs());
+  }
+  children->DeleteSubrange(static_cast<int>(top_n),
+                           children->size() - static_cast<int>(top_n));
+  *children->Add() = omit;
+}
+
+}  // namespace client
+}  // namespace mds
+}  // namespace dingofs

--- a/src/tools/mds-cli/dir_tree_walker.h
+++ b/src/tools/mds-cli/dir_tree_walker.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DINGOFS_MDS_CLIENT_DIR_TREE_WALKER_H_
+#define DINGOFS_MDS_CLIENT_DIR_TREE_WALKER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "dingofs/mds.pb.h"
+#include "mds/common/type.h"
+#include "tools/mds-cli/owner_router.h"
+
+namespace dingofs {
+namespace mds {
+namespace client {
+
+// Client-driven directory-tree usage walk. The recursion lives here (in the CLI)
+// instead of on the MDS: each directory level is a single-level RPC routed to the
+// owning MDS via OwnerRouter, parallelized across a thread pool. This removes the
+// server-side bthread stack-depth cap (deep trees no longer fail) and makes the
+// result correct across a multi-MDS partition (every level hits its true owner).
+struct WalkOptions {
+  // Force the authoritative per-level dentry scan (ReadDir) instead of trusting
+  // the stored single-level dir-stat. Also implied when the fs has no dir-stats.
+  bool strict{false};
+  // The fs has dir-stats enabled; without it every level must scan dentries.
+  bool dirstats_enabled{false};
+  // Parallel fan-out (directories visited concurrently).
+  uint32_t threads{50};
+};
+
+// Recursive subtree totals. Signed so intermediate subtraction can clamp at zero
+// (the rendered values are unsigned).
+struct DirAgg {
+  int64_t files{0};
+  int64_t dirs{0};
+  int64_t length{0};
+};
+
+// Walk the whole subtree under `root` and aggregate recursive {files, dirs,
+// length}; `root` itself is counted as one directory. Returns false when the
+// tree could not be fully traversed (an inode had no owner route, or a non
+// not-found error); partial totals are still filled and the problem is logged.
+bool WalkAggregate(OwnerRouter& router, Ino root, const WalkOptions& opts, DirAgg& out);
+
+// Build a TreeSummary under `root` expanded to `depth` levels (deeper levels fold
+// into each node's recursive aggregate), keeping the top `top_n` sub-directories
+// per level by length and merging the rest into a synthetic "..." node. Returns
+// false on an incomplete traversal (see WalkAggregate).
+bool WalkTree(OwnerRouter& router, Ino root, const WalkOptions& opts, uint32_t depth, uint32_t top_n,
+              pb::mds::TreeSummary& out);
+
+// Walk every directory under `root` and run a single-level dir-stat check/repair
+// on each, routed to its owner; collects the mismatches (sorted by inode).
+// Returns false on an incomplete traversal.
+bool WalkSyncDirStat(OwnerRouter& router, Ino root, const WalkOptions& opts, bool repair,
+                     std::vector<pb::mds::DirStatMismatch>& mismatches);
+
+// Authoritative single-level stat for ONE directory (no recursion). Always does
+// the dentry scan (strict): files = direct non-dir children, dirs = direct
+// sub-directory count, length = direct FILE child lengths. Routed to ino's owner.
+// Returns false on a read failure / no owner (logged); out is zeroed on entry so
+// it is always 0 on a false return.
+bool ReadDirStatStrict(OwnerRouter& router, Ino ino, DirAgg& out);
+
+// Single-level stat for ONE directory from the maintained counter (stored record
+// + owner's unflushed delta), routed to ino's owner. Fast sibling of
+// ReadDirStatStrict. Returns false on no owner / read error; out zeroed on entry.
+bool ReadDirStatFast(OwnerRouter& router, Ino ino, DirAgg& out);
+
+// Sort `node`'s children by length (desc) and, when top_n>0 and there are more
+// than top_n of them, merge the tail into a synthetic "..." child (type FILE)
+// aggregating their dirs/files/length. Mirrors the removed server-side collapse.
+// Exposed for unit testing.
+void CollapseChildrenTopN(pb::mds::TreeSummary& node, uint32_t top_n);
+
+}  // namespace client
+}  // namespace mds
+}  // namespace dingofs
+
+#endif  // DINGOFS_MDS_CLIENT_DIR_TREE_WALKER_H_

--- a/src/tools/mds-cli/interaction.h
+++ b/src/tools/mds-cli/interaction.h
@@ -82,7 +82,12 @@ butil::Status Interaction::SendRequest(const std::string& service_name, const st
                 std::is_same_v<Request, pb::mds::ListMembersRequest> ||
                 std::is_same_v<Request, pb::mds::UnLockMemberRequest> ||
                 std::is_same_v<Request, pb::mds::DeleteMemberRequest>) {
-  } else {
+  } else if (request.context().epoch() == 0) {
+    // Default epoch for requests whose caller did not set one. A caller that
+    // needs the real partition epoch (e.g. ReadSlice, which the MDS validates)
+    // sets it explicitly via MDSClient::SetEpoch and is honored here -- without
+    // this guard the hardcoded 1 was rejected once the fs was rebalanced past
+    // epoch 1 (JoinFs/QuitFs bump it).
     request.mutable_context()->set_epoch(1);
   }
 

--- a/src/tools/mds-cli/main.cc
+++ b/src/tools/mds-cli/main.cc
@@ -59,6 +59,12 @@ DEFINE_string(name, "", "name");
 DEFINE_string(prefix, "", "prefix");
 
 DEFINE_uint64(ino, 0, "ino");
+DEFINE_string(
+    path, "",
+    "directory path for dir-stats commands; an absolute OS mount path (e.g. "
+    "/mnt/dingofs/a/b) is recommended -- it also renders the full info header; "
+    "a mount-relative path (e.g. a/b) still resolves the inode but the path "
+    "header is degraded; alternative to --ino");
 DEFINE_uint64(parent, 0, "parent");
 DEFINE_string(parents, "", "parents");
 DEFINE_uint32(num, 1, "num");
@@ -111,6 +117,27 @@ DEFINE_bool(enable_uid_gid_map, true,
             "internal ids in [10000, 2^32). "
             "ALL mounting clients of this fs must support the feature.");
 
+DEFINE_bool(enable_dir_stats, true,
+            "per-fs: when true, tracks per-directory usage statistics. "
+            "Set at createfs, or hot-switched later via the "
+            "updatefsenabledirstats command.");
+
+// dir-stats subcommand flags
+DEFINE_uint32(
+    depth, 2,
+    "summary tree depth (0-10; values > 10 are clamped to 10 with a warning)");
+DEFINE_uint32(entries, 10,
+              "summary top-N entries per level (0-100; values > 100 are "
+              "clamped to 100 with a warning)");
+DEFINE_uint32(dir_threads, 50,
+              "concurrency for the client-side directory-tree walk "
+              "(info -r / summary / syncdirstat)");
+DEFINE_bool(strict, false, "strict (accurate, full traversal)");
+DEFINE_bool(recursive, false, "recursive");
+DEFINE_bool(repair, false, "repair inconsistent dir stats");
+DEFINE_bool(
+    raw, false,
+    "info: for a file, show raw chunks/slices (sliceId) instead of objects");
 static std::string GetDefaultCoorAddrPath() {
   if (!FLAGS_coor_addr.empty()) {
     return FLAGS_coor_addr;
@@ -218,6 +245,7 @@ int main(int argc, char* argv[]) {
     options.cluster_id = FLAGS_cluster_id;
     options.fs_id = FLAGS_fs_id;
     options.ino = FLAGS_ino;
+    options.path = FLAGS_path;
     options.parent = FLAGS_parent;
     options.parents = FLAGS_parents;
     options.name = FLAGS_name;
@@ -245,12 +273,21 @@ int main(int argc, char* argv[]) {
     options.trash_days = FLAGS_trash_days;
     options.immediate_trash_quota = FLAGS_immediate_trash_quota;
     options.enable_uid_gid_map = FLAGS_enable_uid_gid_map;
+    options.enable_dir_stats = FLAGS_enable_dir_stats;
     // trash restore
     options.trash_put_back = FLAGS_put_back;
     options.trash_threads = FLAGS_restore_threads;
     if (!FLAGS_hours.empty()) {
       dingofs::mds::Helper::SplitString(FLAGS_hours, ',', options.trash_hours);
     }
+
+    options.depth = FLAGS_depth;
+    options.entries = FLAGS_entries;
+    options.dir_threads = FLAGS_dir_threads;
+    options.strict = FLAGS_strict;
+    options.recursive = FLAGS_recursive;
+    options.repair = FLAGS_repair;
+    options.raw = FLAGS_raw;
 
     auto& s3_info = options.s3_info;
     s3_info.ak = FLAGS_s3_ak;

--- a/src/tools/mds-cli/mds.cc
+++ b/src/tools/mds-cli/mds.cc
@@ -15,18 +15,26 @@
 #include "tools/mds-cli/mds.h"
 
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 
+#include <algorithm>
+#include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
+#include "common/block/block_key.h"
+#include "common/block/block_utils.h"
 #include "dingofs/error.pb.h"
 #include "dingofs/mds.pb.h"
 #include "fmt/format.h"
 #include "glog/logging.h"
 #include "mds/common/helper.h"
+#include "tools/mds-cli/dir_tree_walker.h"
+#include "tools/mds-cli/owner_router.h"
 #include "tools/mds-cli/trash_restore.h"
 #include "utils/time.h"
 #include "utils/uuid.h"
@@ -96,10 +104,6 @@ GetMDSListResponse MDSClient::GetMdsList() {
     return response;
   }
 
-  for (const auto& mds : response.mdses()) {
-    std::cout << "mds: " << mds.ShortDebugString();
-  }
-
   return response;
 }
 
@@ -156,6 +160,7 @@ CreateFsResponse MDSClient::CreateFs(const std::string& fs_name,
   request.set_trash_days(params.trash_days);
   request.set_immediate_trash_quota(params.immediate_trash_quota);
   request.set_enable_uid_gid_map(params.enable_uid_gid_map);
+  request.set_enable_dir_stats(params.enable_dir_stats);
 
   if (params.partition_type == "mono") {
     request.set_partition_type(
@@ -343,14 +348,16 @@ GetFsInfoResponse MDSClient::GetFs(uint32_t fs_id) {
   GetFsInfoResponse response;
 
   if (fs_id == 0) {
-    response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EILLEGAL_PARAMTETER);
+    response.mutable_error()->set_errcode(
+        dingofs::pb::error::Errno::EILLEGAL_PARAMTETER);
     response.mutable_error()->set_errmsg("fs_id is 0");
     return response;
   }
 
   request.set_fs_id(fs_id);
 
-  auto status = interaction_->SendRequest("MDSService", "GetFsInfo", request, response);
+  auto status =
+      interaction_->SendRequest("MDSService", "GetFsInfo", request, response);
   if (!status.ok()) {
     response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
     response.mutable_error()->set_errmsg(status.error_str());
@@ -448,7 +455,8 @@ RmDirResponse MDSClient::RmDir(Ino parent, const std::string& name) {
 }
 
 ReadDirResponse MDSClient::ReadDir(Ino ino, const std::string& last_name,
-                                   bool with_attr, bool is_refresh) {
+                                   bool with_attr, bool is_refresh,
+                                   uint32_t limit) {
   CHECK(fs_id_ > 0) << "fs_id_ is zero";
   ReadDirRequest request;
   ReadDirResponse response;
@@ -458,7 +466,7 @@ ReadDirResponse MDSClient::ReadDir(Ino ino, const std::string& last_name,
   request.set_fs_id(fs_id_);
   request.set_ino(ino);
   request.set_last_name(last_name);
-  request.set_limit(100);
+  request.set_limit(limit);
   request.set_with_attr(with_attr);
   request.set_is_refresh(is_refresh);
 
@@ -572,6 +580,33 @@ ListDentryResponse MDSClient::ListDentry(Ino parent, bool is_only_dir) {
   return response;
 }
 
+ListDentryResponse MDSClient::ListDentryPaged(Ino parent,
+                                              const std::string& last,
+                                              uint32_t limit,
+                                              bool is_only_dir) {
+  CHECK(fs_id_ > 0) << "fs_id_ is zero";
+
+  ListDentryRequest request;
+  ListDentryResponse response;
+
+  request.mutable_context()->set_epoch(epoch_);
+
+  request.set_fs_id(fs_id_);
+  request.set_parent(parent);
+  request.set_last(last);
+  request.set_limit(limit);
+  request.set_is_only_dir(is_only_dir);
+
+  auto status =
+      interaction_->SendRequest("MDSService", "ListDentry", request, response);
+  if (!status.ok()) {
+    response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
+    response.mutable_error()->set_errmsg(status.error_str());
+  }
+
+  return response;
+}
+
 GetInodeResponse MDSClient::GetInode(Ino ino) {
   CHECK(fs_id_ > 0) << "fs_id_ is zero";
 
@@ -588,11 +623,6 @@ GetInodeResponse MDSClient::GetInode(Ino ino) {
   if (!status.ok()) {
     response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
     response.mutable_error()->set_errmsg(status.error_str());
-    return response;
-  }
-
-  if (response.error().errcode() == dingofs::pb::error::Errno::OK) {
-    std::cout << "inode: " << response.inode().ShortDebugString() << "\n";
   }
 
   return response;
@@ -752,6 +782,68 @@ LookupResponse MDSClient::Lookup(Ino parent, const std::string& name) {
   }
 
   return response;
+}
+
+bool MDSClient::ResolvePath(const std::string& path, Ino& out_ino) {
+  // For an ABSOLUTE path that exists locally (the DingoFS mount path, e.g.
+  // /mnt/dingofs/a/b), its st_ino IS the MDS inode -- use it directly. We only
+  // stat absolute paths so a mount-relative arg like "a/b" is never
+  // accidentally resolved against an unrelated directory in the current working
+  // directory.
+  // "/" alone is the mount root; never stat it (that would hit the OS root).
+  //
+  // Trust the OS st_ino only when the path is genuinely INSIDE the DingoFS
+  // mount
+  // -- i.e. the path itself or some ancestor reports st_ino==1 (the fs root).
+  // Otherwise an unrelated OS path like /a/b that merely happens to exist
+  // outside the mount would be silently mis-resolved to its OS inode; such a
+  // path falls through to the mount-relative walk below instead.
+  if (path.size() > 1 && path.front() == '/') {
+    struct stat st;
+    if (::stat(path.c_str(), &st) == 0) {
+      bool in_mount = (st.st_ino == 1);
+      std::string cur = path;
+      while (cur.size() > 1 && cur.back() == '/') cur.pop_back();
+      while (!in_mount) {
+        auto pos = cur.find_last_of('/');
+        if (pos == std::string::npos || pos == 0) break;
+        cur = cur.substr(0, pos);
+        struct stat as;
+        if (::stat(cur.c_str(), &as) == 0 && as.st_ino == 1) in_mount = true;
+      }
+      if (in_mount) {
+        out_ino = st.st_ino;
+        return true;
+      }
+    }
+  }
+
+  // Otherwise treat it as a path relative to the mount point (== fs root), e.g.
+  // "a/b/c", "/a/b/c", or "." / "/" for the root itself. Walk components from
+  // the root via Lookup, skipping empty and "." segments.
+  Ino cur = 1;  // fs root ino is always 1
+  const size_t n = path.size();
+  size_t i = 0;
+  while (i < n) {
+    while (i < n && path[i] == '/') ++i;  // skip slashes
+    size_t j = i;
+    while (j < n && path[j] != '/') ++j;
+    if (j > i) {
+      std::string name = path.substr(i, j - i);
+      if (name != ".") {
+        auto resp = Lookup(cur, name);
+        if (resp.error().errcode() != dingofs::pb::error::Errno::OK) {
+          std::cerr << fmt::format("resolve path '{}' fail at '{}': {}\n", path,
+                                   name, resp.error().errmsg());
+          return false;
+        }
+        cur = resp.inode().ino();
+      }
+    }
+    i = j;
+  }
+  out_ino = cur;
+  return true;
 }
 
 OpenResponse MDSClient::Open(Ino ino, std::string& session_id) {
@@ -1219,6 +1311,32 @@ ReadSliceResponse MDSClient::ReadSlice(Ino ino, int64_t chunk_index) {
     response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
     response.mutable_error()->set_errmsg(status.error_str());
     return response;
+  }
+
+  return response;
+}
+
+ReadSliceResponse MDSClient::ReadSliceAll(Ino ino, int64_t chunk_num) {
+  CHECK(fs_id_ > 0) << "fs_id_ is zero";
+
+  ReadSliceRequest request;
+  ReadSliceResponse response;
+
+  request.mutable_context()->set_epoch(epoch_);
+  // Read the authoritative store, not a possibly-stale chunk cache snapshot.
+  request.mutable_context()->set_is_bypass_cache(true);
+
+  request.set_fs_id(fs_id_);
+  request.set_ino(ino);
+  for (int64_t i = 0; i < chunk_num; ++i) {
+    request.add_chunk_descriptors()->set_index(i);
+  }
+
+  auto status =
+      interaction_->SendRequest("MDSService", "ReadSlice", request, response);
+  if (!status.ok()) {
+    response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
+    response.mutable_error()->set_errmsg(status.error_str());
   }
 
   return response;
@@ -1712,6 +1830,519 @@ void MDSClient::UpdateFsEnableUidGidMap(const std::string& fs_name,
   UpdateFs(fs_name, fs_info);
 }
 
+void MDSClient::UpdateFsEnableDirStats(const std::string& fs_name,
+                                       bool enable) {
+  if (fs_name.empty()) {
+    std::cerr << "fs_name is empty\n";
+    return;
+  }
+
+  auto fs_response = GetFs(fs_name);
+  pb::mds::FsInfo fs_info;
+  fs_info.CopyFrom(fs_response.fs_info());
+  if (fs_info.fs_id() == 0) {
+    std::cerr << "not found fs: " << fs_name << "\n";
+    return;
+  }
+
+  // Read-modify-write: round-trip the full current FsInfo and flip only this
+  // one runtime-mutable field; the server merges it (store_operation.cc).
+  fs_info.set_enable_dir_stats(enable);
+  UpdateFs(fs_name, fs_info);
+}
+
+GetDirStatResponse MDSClient::GetDirStat(Ino ino) {
+  CHECK(fs_id_ > 0) << "fs_id_ is zero";
+  CHECK(ino > 0) << "ino is zero";
+
+  GetDirStatRequest request;
+  GetDirStatResponse response;
+
+  request.set_fs_id(fs_id_);
+  request.set_ino(ino);
+
+  auto status =
+      interaction_->SendRequest("MDSService", "GetDirStat", request, response);
+  if (!status.ok()) {
+    response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
+    response.mutable_error()->set_errmsg(status.error_str());
+    return response;
+  }
+
+  if (response.error().errcode() != dingofs::pb::error::Errno::OK) {
+    std::cerr << "GetDirStat fail, error: " << response.ShortDebugString()
+              << "\n";
+  }
+
+  return response;
+}
+
+namespace {
+
+// Client-side upper bounds for `summary` knobs: a deeper/wider tree walk is
+// costly server-side and the rendered table is unreadable past these. Values
+// above are clamped (with a warning) rather than rejected.
+constexpr uint32_t kMaxSummaryDepth = 10;
+constexpr uint32_t kMaxSummaryEntries = 100;
+
+// Human-readable size in 1024-based units, matching `juicefs summary`
+// (go-humanize IBytes): one decimal below 10 of a unit, none at/above.
+std::string HumanizeIBytes(uint64_t s) {
+  constexpr double kBase = 1024.0;
+  static const char* kSizes[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"};
+  if (s < 1024) return fmt::format("{} B", s);
+  double val = static_cast<double>(s);
+  int i = 0;
+  while (val >= kBase && i < 6) {
+    val /= kBase;
+    ++i;
+  }
+  return val < 10.0 ? fmt::format("{:.1f} {}", val, kSizes[i])
+                    : fmt::format("{:.0f} {}", val, kSizes[i]);
+}
+
+struct SummaryRow {
+  std::string path;
+  std::string length;
+  std::string dirs;
+  std::string files;
+};
+
+// Depth-first preorder flatten into table rows. Each row's PATH is the node's
+// full path: the queried directory (`path`) for the root, and `path/<name>`
+// for descendants (the synthetic "..." aggregate becomes `path/...`).
+void FlattenTree(const pb::mds::TreeSummary& node, const std::string& path,
+                 std::vector<SummaryRow>& rows) {
+  rows.push_back({path, HumanizeIBytes(node.length()),
+                  std::to_string(node.dirs()), std::to_string(node.files())});
+  for (const auto& c : node.children()) {
+    // When this node is the mount root (shown as "/" or "."), children are bare
+    // mount-relative names ("dir11"); otherwise append under the parent path.
+    std::string child_path =
+        (path == "/" || path == ".") ? c.path() : path + "/" + c.path();
+    FlattenTree(c, child_path, rows);
+  }
+}
+
+void PrintSummaryTable(const std::vector<SummaryRow>& rows) {
+  size_t wp = 4, ws = 6, wd = 4,
+         wf = 5;  // header widths: PATH/LENGTH/DIRS/FILES
+  for (const auto& r : rows) {
+    wp = std::max(wp, r.path.size());
+    ws = std::max(ws, r.length.size());
+    wd = std::max(wd, r.dirs.size());
+    wf = std::max(wf, r.files.size());
+  }
+  auto border = [&]() {
+    std::cout << fmt::format("+{}+{}+{}+{}+\n", std::string(wp + 2, '-'),
+                             std::string(ws + 2, '-'), std::string(wd + 2, '-'),
+                             std::string(wf + 2, '-'));
+  };
+  border();
+  std::cout << fmt::format("| {:^{}} | {:^{}} | {:^{}} | {:^{}} |\n", "PATH",
+                           wp, "LENGTH", ws, "DIRS", wd, "FILES", wf);
+  border();
+  for (const auto& r : rows) {
+    std::cout << fmt::format("| {:<{}} | {:>{}} | {:>{}} | {:>{}} |\n", r.path,
+                             wp, r.length, ws, r.dirs, wd, r.files, wf);
+  }
+  border();
+}
+
+// Render a `summary` tree response as a table. The root row's PATH is the
+// queried directory (`base_path`); descendants append under it. Falls back to
+// "/" when only --ino was given, and normalizes the mount root.
+void PrintTreeTable(const pb::mds::TreeSummary& tree,
+                    const std::string& base_path) {
+  std::string base = base_path.empty() ? "/" : base_path;
+  while (base.size() > 1 && base.back() == '/') base.pop_back();
+  if (base == ".") base = "/";
+
+  std::vector<SummaryRow> rows;
+  FlattenTree(tree, base, rows);
+  PrintSummaryTable(rows);
+}
+
+// Canonical whole-system absolute path of the user-supplied --path (e.g.
+// /mnt/dingofs/a/b), via realpath. Empty when --path was not given (--ino
+// mode).
+std::string AbsOsPath(const std::string& input) {
+  if (input.empty()) return "";
+  char buf[PATH_MAX];
+  if (::realpath(input.c_str(), buf) != nullptr) return buf;
+  return input;  // fall back to the raw arg if realpath fails
+}
+
+// Mount-relative absolute fs path (e.g. /a/b) derived from a whole-system
+// absolute path: walk ancestors and find the mount root -- the DingoFS root
+// inode is always 1 (see ResolvePath) -- then strip that prefix. Empty when
+// os_path is empty or no ancestor reports st_ino==1.
+std::string MountRelPath(const std::string& os_path) {
+  if (os_path.empty()) return "";
+  std::string p = os_path;
+  while (p.size() > 1 && p.back() == '/') p.pop_back();
+  std::string mount;
+  for (std::string cur = p;;) {
+    struct stat st;
+    if (::stat(cur.c_str(), &st) == 0 && st.st_ino == 1) {
+      mount = cur;
+      break;
+    }
+    auto pos = cur.find_last_of('/');
+    if (pos == std::string::npos || pos == 0) break;
+    cur = cur.substr(0, pos);
+  }
+  if (mount.empty()) return "";
+  std::string rel = p.substr(mount.size());
+  return rel.empty() ? "/" : rel;
+}
+
+// JuiceFS-style `info` header block (size/tier dimensions intentionally
+// dropped). Header line shows the whole-system absolute path; `path:` shows the
+// mount-relative fs path. Either is omitted when unknown (--ino mode).
+void PrintInfoBlock(const std::string& os_path, const std::string& fs_path,
+                    Ino ino, int64_t files, int64_t dirs, int64_t length) {
+  if (!os_path.empty()) {
+    std::cout << fmt::format("{} :\n", os_path);
+  } else {
+    std::cout << fmt::format("inode {} :\n", ino);
+  }
+  std::cout << fmt::format("  inode: {}\n", ino);
+  std::cout << fmt::format("  files: {}\n", files);
+  std::cout << fmt::format("   dirs: {}\n", dirs);
+  std::cout << fmt::format(" length: {} ({} Bytes)\n", HumanizeIBytes(length),
+                           length);
+  if (!fs_path.empty()) {
+    std::cout << fmt::format("   path: {}\n", fs_path);
+  }
+}
+
+// `info` on a single file, raw view: one row per slice (sliceId dimension),
+// matching `juicefs info --raw`.
+// Render a bordered table with dynamic column widths (header included).
+// `aligns` has one char per column: '<' left-justify, '>' right-justify.
+void PrintTable(const std::vector<std::string>& headers,
+                const std::vector<std::vector<std::string>>& rows,
+                const std::string& aligns) {
+  const size_t n = headers.size();
+  std::vector<size_t> w(n);
+  for (size_t i = 0; i < n; ++i) w[i] = headers[i].size();
+  for (const auto& r : rows) {
+    for (size_t i = 0; i < n; ++i) w[i] = std::max(w[i], r[i].size());
+  }
+  auto border = [&]() {
+    std::string s = "+";
+    for (size_t i = 0; i < n; ++i) s += std::string(w[i] + 2, '-') + "+";
+    std::cout << s << "\n";
+  };
+  border();
+  std::string h = "|";
+  for (size_t i = 0; i < n; ++i)
+    h += fmt::format(" {:^{}} |", headers[i], w[i]);
+  std::cout << h << "\n";
+  border();
+  for (const auto& r : rows) {
+    std::string line = "|";
+    for (size_t i = 0; i < n; ++i) {
+      line += (aligns[i] == '<') ? fmt::format(" {:<{}} |", r[i], w[i])
+                                 : fmt::format(" {:>{}} |", r[i], w[i]);
+    }
+    std::cout << line << "\n";
+  }
+  border();
+}
+
+void PrintChunksTable(
+    const google::protobuf::RepeatedPtrField<pb::mds::Chunk>& chunks) {
+  std::cout << " chunks:\n";
+  std::vector<std::vector<std::string>> rows;
+  for (const auto& chunk : chunks) {
+    for (const auto& slice : chunk.slices()) {
+      rows.push_back({std::to_string(chunk.index()), std::to_string(slice.id()),
+                      std::to_string(slice.size()), std::to_string(slice.pos()),
+                      std::to_string(slice.len())});
+    }
+  }
+  PrintTable({"chunkIndex", "sliceId", "size", "offset", "length"}, rows,
+             ">>>>>");
+}
+
+// `info` on a single file, default view: one row per object (block) in the
+// object store, matching `juicefs info`. objectName is computed client-side via
+// BlockKey (the MDS stores only slice ids). pos is the object's start offset
+// within the whole file. chunk_size/block_size come from FsInfo so the layout
+// is correct even when a stored chunk omits them.
+void PrintObjectsTable(
+    const google::protobuf::RepeatedPtrField<pb::mds::Chunk>& chunks,
+    uint64_t chunk_size, uint32_t block_size) {
+  std::cout << " objects:\n";
+  std::vector<std::vector<std::string>> rows;
+  for (const auto& chunk : chunks) {
+    for (const auto& slice : chunk.slices()) {
+      uint64_t base = chunk.index() * chunk_size + slice.pos();
+      for (const auto& bk :
+           EnumerateBlockKeys(slice.id(), slice.size(), block_size)) {
+        uint64_t pos = base + static_cast<uint64_t>(bk.index) * block_size;
+        rows.push_back({std::to_string(chunk.index()), bk.StoreKey(),
+                        std::to_string(bk.size), std::to_string(pos)});
+      }
+    }
+  }
+  PrintTable({"chunkIndex", "objectName", "size", "pos"}, rows, "><>>");
+}
+
+// Resolve the target inode for a dir-stats subcommand: prefer --path (absolute
+// fs path resolved via Lookup) and fall back to --ino. Returns false (after
+// printing why) when neither yields a usable inode.
+bool ResolveDirStatIno(MDSClient& client,
+                       const MdsCommandRunner::Options& options, Ino& ino) {
+  if (!options.path.empty()) {
+    return client.ResolvePath(options.path, ino);
+  }
+  if (ino == 0) {
+    std::cout << "specify a directory with --path=/a/b/c or --ino=N.\n";
+    return false;
+  }
+  return true;
+}
+
+// Build the owner router and walk options shared by the client-side dir-stat
+// commands (info -r / summary / syncdirstat). Returns false (and prints) when
+// the router cannot be built -- a multi-RPC walk must not silently fall back to
+// a single fixed MDS, which would scatter stale, mis-routed reads across the
+// tree.
+bool SetupWalk(MDSClient& mds_client, uint32_t fs_id,
+               const MdsCommandRunner::Options& options, OwnerRouter& router,
+               WalkOptions& wopts) {
+  auto fs_resp = mds_client.GetFs(fs_id);
+  if (fs_resp.error().errcode() != dingofs::pb::error::Errno::OK) {
+    std::cerr << "get fs info fail: " << fs_resp.ShortDebugString() << "\n";
+    return false;
+  }
+  if (!router.Init(fs_id, mds_client)) {
+    std::cerr << "cannot resolve owner mds routing; aborting walk\n";
+    return false;
+  }
+  wopts.strict = options.strict;
+  wopts.dirstats_enabled = fs_resp.fs_info().enable_dir_stats();
+  wopts.threads = options.dir_threads;
+  return true;
+}
+
+// Print the JuiceFS-style break lines from a (whole-tree) syncdirstat walk.
+void PrintSyncDirStatResult(
+    const std::vector<pb::mds::DirStatMismatch>& mismatches, bool repair) {
+  if (mismatches.empty()) {
+    std::cout << "all dir-stats are consistent\n";
+    return;
+  }
+  for (const auto& b : mismatches) {
+    // Report recomputed (want) vs stored (got); {inodes, length} -- DingoFS has
+    // no separate size dimension.
+    std::cout << fmt::format(
+        "usage stat of inode {} should be {{inodes:{} length:{}}}, but got "
+        "{{inodes:{} length:{}}}{}\n",
+        b.ino(), b.want_inodes(), b.want_length(), b.got_inodes(),
+        b.got_length(), b.found() ? "" : " (no stored record)");
+    std::cout << (repair ? fmt::format(
+                               "  stat of inode {} is successfully synced\n",
+                               b.ino())
+                         : fmt::format("  stat of inode {} should be synced, "
+                                       "re-run with --repair to fix it\n",
+                                       b.ino()));
+  }
+}
+
+void HandleSummary(MDSClient& mds_client, uint32_t fs_id,
+                   const MdsCommandRunner::Options& options) {
+  Ino ino = options.ino;
+  if (!ResolveDirStatIno(mds_client, options, ino)) return;
+
+  uint32_t depth = options.depth;
+  if (depth > kMaxSummaryDepth) {
+    std::cerr << fmt::format("warn: depth should be less than {}\n",
+                             kMaxSummaryDepth + 1);
+    depth = kMaxSummaryDepth;
+  }
+  uint32_t entries = options.entries;
+  if (entries > kMaxSummaryEntries) {
+    std::cerr << fmt::format("warn: entries should be less than {}\n",
+                             kMaxSummaryEntries + 1);
+    entries = kMaxSummaryEntries;
+  }
+
+  OwnerRouter router;
+  WalkOptions wopts;
+  if (!SetupWalk(mds_client, fs_id, options, router, wopts)) return;
+  pb::mds::TreeSummary tree;
+  if (!WalkTree(router, ino, wopts, depth, entries, tree)) {
+    // Fail loud: a summary is only useful if it is complete. Rather than print
+    // a silently-undercounted tree behind a warning, abort so a skipped subtree
+    // (an unreachable/erroring owner mds) can never be mistaken for the truth.
+    std::cerr << "summary: directory walk failed (an owner mds was unreachable "
+                 "or errored); result would be incomplete, aborting\n";
+    return;
+  }
+  PrintTreeTable(tree, AbsOsPath(options.path));
+}
+
+// Check (and optionally repair) a single directory's dir-stat. Routes to the
+// owner and hard-fails on any error: a single level has no partial result to
+// salvage, so there is nothing to print but the failure itself.
+void SyncDirStatOneLevel(OwnerRouter& router, Ino ino, bool repair) {
+  MDSClient* owner = router.ClientForIno(ino);
+  if (owner == nullptr) {
+    std::cerr << fmt::format("no owner mds for ino({})\n", ino);
+    return;
+  }
+  auto resp = owner->SyncDirStat(ino, repair);
+  if (resp.error().errcode() != dingofs::pb::error::Errno::OK) {
+    std::cerr << "syncdirstat fail, error: " << resp.ShortDebugString() << "\n";
+    return;
+  }
+  std::vector<pb::mds::DirStatMismatch> mismatches(resp.mismatches().begin(),
+                                                   resp.mismatches().end());
+  PrintSyncDirStatResult(mismatches, repair);
+}
+
+void HandleSyncDirStat(MDSClient& mds_client, uint32_t fs_id,
+                       const MdsCommandRunner::Options& options) {
+  Ino ino = options.ino;
+  if (!ResolveDirStatIno(mds_client, options, ino)) return;
+  OwnerRouter router;
+  WalkOptions wopts;
+  if (!SetupWalk(mds_client, fs_id, options, router, wopts)) return;
+
+  if (!options.recursive) {
+    SyncDirStatOneLevel(router, ino, options.repair);
+    return;
+  }
+
+  // Recursive: tolerate per-directory errors instead of aborting, so a --repair
+  // that already fixed some directories still reports them. An error only flags
+  // the walk as incomplete (warning), never discards the results gathered so
+  // far.
+  std::vector<pb::mds::DirStatMismatch> mismatches;
+  bool complete =
+      WalkSyncDirStat(router, ino, wopts, options.repair, mismatches);
+  PrintSyncDirStatResult(mismatches, options.repair);
+  if (!complete)
+    std::cerr
+        << "warn: directory walk incomplete; some directories were skipped\n";
+}
+
+void HandleInfo(MDSClient& mds_client, uint32_t fs_id,
+                const MdsCommandRunner::Options& options) {
+  // `info`: directory -> single-level stat (--strict: authoritative dentry
+  // scan; -r: recursive subtree aggregate); file -> data layout (objects, or
+  // chunks/slices with --raw).
+  Ino ino = options.ino;
+  if (!ResolveDirStatIno(mds_client, options, ino)) return;
+  const std::string os_path = AbsOsPath(options.path);
+  const std::string fs_path = MountRelPath(os_path);
+
+  auto inode_resp = mds_client.GetInode(ino);
+  if (inode_resp.error().errcode() != dingofs::pb::error::Errno::OK) {
+    std::cerr << "info: get inode fail, error: "
+              << inode_resp.ShortDebugString() << "\n";
+    return;
+  }
+  const auto& inode = inode_resp.inode();
+
+  if (inode.type() == pb::mds::FileType::DIRECTORY) {
+    // One owner-routed setup serves all three reads (fail-loud: a dir-stat read
+    // never falls back to a fixed --mds_addr, which would scatter stale/mis-
+    // routed values under multi-mds).
+    OwnerRouter router;
+    WalkOptions wopts;
+    if (!SetupWalk(mds_client, fs_id, options, router, wopts)) return;
+
+    DirAgg agg;
+    bool ok;
+    if (options.recursive) {
+      ok = WalkAggregate(router, ino, wopts, agg);  // counts root itself
+    } else if (options.strict) {
+      ok = ReadDirStatStrict(router, ino, agg);  // authoritative dentry scan
+    } else {
+      ok = ReadDirStatFast(router, ino, agg);  // maintained counter
+    }
+    if (!ok) {
+      // Fail loud: an incomplete read (a skipped subtree under -r, or a failed
+      // single-level stat) would print a silently-wrong number. Abort instead.
+      std::cerr
+          << "info: dir-stat read failed (an owner mds was unreachable or "
+             "errored); result would be incomplete, aborting\n";
+      return;
+    }
+    PrintInfoBlock(os_path, fs_path, ino, agg.files, agg.dirs, agg.length);
+  } else {
+    // file / symlink: header block, then (for regular files) the data layout.
+    PrintInfoBlock(os_path, fs_path, ino, 1, 0,
+                   static_cast<int64_t>(inode.length()));
+    if (inode.type() == pb::mds::FileType::FILE && inode.length() > 0) {
+      auto fs_resp = mds_client.GetFs(fs_id);
+      if (fs_resp.error().errcode() != dingofs::pb::error::Errno::OK) {
+        std::cerr << "info: get fs info fail, error: "
+                  << fs_resp.ShortDebugString() << "\n";
+        return;
+      }
+      const uint64_t chunk_size = fs_resp.fs_info().chunk_size();
+      const uint32_t block_size = fs_resp.fs_info().block_size();
+      if (chunk_size == 0 || block_size == 0) {
+        std::cerr << "info: fs chunk_size/block_size is 0\n";
+        return;
+      }
+      const int64_t chunk_num = (inode.length() + chunk_size - 1) / chunk_size;
+      // ReadSlice is epoch-validated on the MDS; without a fresh partition
+      // epoch the default 0 is treated as 1 and rejected once the fs has been
+      // rebalanced (JoinFs/QuitFs bump the epoch). Seed it from the fs_info we
+      // just fetched so `info <file>` works after any partition change.
+      mds_client.SetEpoch(fs_resp.fs_info().partition_policy().epoch());
+      auto rs = mds_client.ReadSliceAll(ino, chunk_num);
+      if (rs.error().errcode() != dingofs::pb::error::Errno::OK) {
+        std::cerr << "info: read slice fail, error: " << rs.ShortDebugString()
+                  << "\n";
+        return;
+      }
+      if (options.raw) {
+        PrintChunksTable(rs.chunks());
+      } else {
+        PrintObjectsTable(rs.chunks(), chunk_size, block_size);
+      }
+    }
+  }
+}
+
+}  // namespace
+
+SyncDirStatResponse MDSClient::SyncDirStat(Ino ino, bool repair) {
+  CHECK(fs_id_ > 0) << "fs_id_ is zero";
+  CHECK(ino > 0) << "ino is zero";
+
+  SyncDirStatRequest request;
+  SyncDirStatResponse response;
+
+  request.mutable_context()->set_epoch(epoch_);
+
+  request.set_fs_id(fs_id_);
+  request.set_ino(ino);
+  request.set_repair(repair);
+  // Single-level check/repair: the server reads the authoritative store
+  // (critical for repair=true, so it never repairs off a stale cache). The
+  // recursive walk lives in the CLI (dir_tree_walker), which calls this per
+  // directory routed to the owning MDS.
+  request.mutable_context()->set_is_bypass_cache(true);
+
+  auto status =
+      interaction_->SendRequest("MDSService", "SyncDirStat", request, response);
+  if (!status.ok()) {
+    response.mutable_error()->set_errcode(dingofs::pb::error::Errno::EINTERNAL);
+    response.mutable_error()->set_errmsg(status.error_str());
+  }
+
+  return response;
+}
+
 bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
                            const std::string& cmd, uint32_t fs_id) {
   static std::set<std::string> mds_cmd = {
@@ -1754,6 +2385,10 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
       "restoretrash",
       "updatefstrashdays",
       "updatefsenableuidgidmap",
+      "updatefsenabledirstats",
+      "info",
+      "summary",
+      "syncdirstat",
   };
 
   if (mds_cmd.count(cmd) == 0) return false;
@@ -1770,7 +2405,10 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
   }
 
   if (cmd == Helper::ToLowerCase("GetMdsList")) {
-    mds_client.GetMdsList();
+    auto response = mds_client.GetMdsList();
+    for (const auto& mds : response.mdses()) {
+      std::cout << "mds: " << mds.ShortDebugString() << "\n";
+    }
 
   } else if (cmd == Helper::ToLowerCase("CreateFs")) {
     dingofs::mds::client::MDSClient::CreateFsParams params;
@@ -1785,6 +2423,7 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
     params.trash_days = options.trash_days;
     params.immediate_trash_quota = options.immediate_trash_quota;
     params.enable_uid_gid_map = options.enable_uid_gid_map;
+    params.enable_dir_stats = options.enable_dir_stats;
 
     mds_client.CreateFs(options.fs_name, params);
 
@@ -1806,6 +2445,10 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
   } else if (cmd == Helper::ToLowerCase("UpdateFsEnableUidGidMap")) {
     mds_client.UpdateFsEnableUidGidMap(options.fs_name,
                                        options.enable_uid_gid_map);
+
+  } else if (cmd == Helper::ToLowerCase("UpdateFsEnableDirStats")) {
+    mds_client.UpdateFsEnableDirStats(options.fs_name,
+                                      options.enable_dir_stats);
 
   } else if (cmd == Helper::ToLowerCase("GetFs")) {
     mds_client.GetFs(options.fs_name);
@@ -1836,7 +2479,12 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
     mds_client.ListDentry(options.parent, false);
 
   } else if (cmd == Helper::ToLowerCase("GetInode")) {
-    mds_client.GetInode(options.parent);
+    auto resp = mds_client.GetInode(options.parent);
+    if (resp.error().errcode() == dingofs::pb::error::Errno::OK) {
+      std::cout << "inode: " << resp.inode().ShortDebugString() << "\n";
+    } else {
+      std::cerr << "GetInode fail, error: " << resp.ShortDebugString() << "\n";
+    }
 
   } else if (cmd == Helper::ToLowerCase("BatchGetInode")) {
     std::vector<int64_t> inos;
@@ -2006,6 +2654,15 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
       return true;
     }
     runner.Run();
+
+  } else if (cmd == Helper::ToLowerCase("Info")) {
+    HandleInfo(mds_client, fs_id, options);
+
+  } else if (cmd == Helper::ToLowerCase("Summary")) {
+    HandleSummary(mds_client, fs_id, options);
+
+  } else if (cmd == Helper::ToLowerCase("SyncDirStat")) {
+    HandleSyncDirStat(mds_client, fs_id, options);
   }
 
   return true;

--- a/src/tools/mds-cli/mds.cc
+++ b/src/tools/mds-cli/mds.cc
@@ -609,6 +609,7 @@ ListDentryResponse MDSClient::ListDentryPaged(Ino parent,
 
 GetInodeResponse MDSClient::GetInode(Ino ino) {
   CHECK(fs_id_ > 0) << "fs_id_ is zero";
+  CHECK(ino > 0) << "ino is zero";
 
   GetInodeRequest request;
   GetInodeResponse response;
@@ -2479,7 +2480,11 @@ bool MdsCommandRunner::Run(const Options& options, const std::string& mds_addr,
     mds_client.ListDentry(options.parent, false);
 
   } else if (cmd == Helper::ToLowerCase("GetInode")) {
-    auto resp = mds_client.GetInode(options.parent);
+    if (options.ino == 0) {
+      std::cout << "ino is empty.\n";
+      return true;
+    }
+    auto resp = mds_client.GetInode(options.ino);
     if (resp.error().errcode() == dingofs::pb::error::Errno::OK) {
       std::cout << "inode: " << resp.inode().ShortDebugString() << "\n";
     } else {

--- a/src/tools/mds-cli/mds.h
+++ b/src/tools/mds-cli/mds.h
@@ -181,6 +181,11 @@ using pb::mds::UnLockMemberResponse;
 using pb::mds::DeleteMemberRequest;
 using pb::mds::DeleteMemberResponse;
 
+using pb::mds::GetDirStatRequest;
+using pb::mds::GetDirStatResponse;
+using pb::mds::SyncDirStatRequest;
+using pb::mds::SyncDirStatResponse;
+
 class MDSClient {
  public:
   MDSClient(uint32_t fs_id);
@@ -215,6 +220,8 @@ class MDSClient {
     // See FsInfo.enable_uid_gid_map. Runtime-mutable (clients hot-apply via
     // heartbeat).
     bool enable_uid_gid_map{false};
+    // See FsInfo.enable_dir_stats. Create-time only.
+    bool enable_dir_stats{false};
   };
 
   CreateFsResponse CreateFs(const std::string& fs_name,
@@ -235,7 +242,7 @@ class MDSClient {
                   const std::string& prefix, size_t num);
   RmDirResponse RmDir(Ino parent, const std::string& name);
   ReadDirResponse ReadDir(Ino ino, const std::string& last_name, bool with_attr,
-                          bool is_refresh);
+                          bool is_refresh, uint32_t limit = 100);
 
   MkNodResponse MkNod(Ino parent, const std::string& name);
   void BatchMkNod(const std::vector<int64_t>& parents,
@@ -243,6 +250,9 @@ class MDSClient {
 
   GetDentryResponse GetDentry(Ino parent, const std::string& name);
   ListDentryResponse ListDentry(Ino parent, bool is_only_dir);
+  // Render-silent, paged variant for the client-side tree walk: returns one page
+  // (entries after `last`, up to `limit`) without printing.
+  ListDentryResponse ListDentryPaged(Ino parent, const std::string& last, uint32_t limit, bool is_only_dir);
   GetInodeResponse GetInode(Ino ino);
   BatchGetInodeResponse BatchGetInode(const std::vector<int64_t>& inos);
   BatchGetXAttrResponse BatchGetXattr(const std::vector<int64_t>& inos);
@@ -253,6 +263,11 @@ class MDSClient {
   void GetFsPerSecondStats(const std::string& fs_name);
 
   LookupResponse Lookup(Ino parent, const std::string& name);
+
+  // Resolve an absolute fs path ("/", "/a/b/c") to its inode by walking
+  // components from the root via Lookup. Returns false (and logs) on any
+  // missing component.
+  bool ResolvePath(const std::string& path, Ino& out_ino);
 
   OpenResponse Open(Ino ino, std::string& session_id);
   ReleaseResponse Release(Ino ino, const std::string& session_id);
@@ -288,6 +303,16 @@ class MDSClient {
   AllocSliceIdResponse AllocSliceId(uint32_t alloc_num, uint64_t min_slice_id);
   WriteSliceResponse WriteSlice(Ino parent, Ino ino, int64_t chunk_index);
   ReadSliceResponse ReadSlice(Ino ino, int64_t chunk_index);
+  // Read all chunks [0, chunk_num) of a file in one request (for `info` file
+  // data layout). Always bypasses the chunk cache so the layout is authoritative.
+  ReadSliceResponse ReadSliceAll(Ino ino, int64_t chunk_num);
+
+  // dir-stats operations
+  GetDirStatResponse GetDirStat(Ino ino);
+  // Single-level check/repair for one directory; the recursive tree walk lives in
+  // the CLI (dir_tree_walker) and calls this per directory routed to the owner.
+  // Render-silent: the caller aggregates and prints.
+  SyncDirStatResponse SyncDirStat(Ino ino, bool repair);
 
   // quota operations
   SetFsQuotaResponse SetFsQuota(const QuotaEntry& quota);
@@ -323,6 +348,7 @@ class MDSClient {
                          const RadosInfo& rados_info);
   void UpdateFsTrashDays(const std::string& fs_name, uint32_t trash_days);
   void UpdateFsEnableUidGidMap(const std::string& fs_name, bool enable);
+  void UpdateFsEnableDirStats(const std::string& fs_name, bool enable);
 
  private:
   uint32_t fs_id_{0};
@@ -367,11 +393,24 @@ class MdsCommandRunner {
     uint32_t trash_days{0};
     bool immediate_trash_quota{true};
     bool enable_uid_gid_map{false};
+    bool enable_dir_stats{false};
 
     // trash restore (`restoretrash` subcommand)
     std::vector<std::string> trash_hours;
     bool trash_put_back{false};
     uint32_t trash_threads{10};
+
+    // dir-stats subcommands
+    std::string path;  // absolute fs path, e.g. /a/b/c; resolved to ino if set
+    uint32_t depth{2};
+    uint32_t entries{10};
+    // concurrency for the client-side directory-tree walk (info -r/summary/syncdirstat)
+    uint32_t dir_threads{50};
+    bool strict{false};
+    bool recursive{false};
+    bool repair{false};
+    // info: for a file, show raw chunks/slices instead of objects.
+    bool raw{false};
 
     S3Info s3_info;
     RadosInfo rados_info;

--- a/src/tools/mds-cli/owner_router.cc
+++ b/src/tools/mds-cli/owner_router.cc
@@ -1,0 +1,110 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/mds-cli/owner_router.h"
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <iostream>
+#include <string>
+#include <unordered_set>
+
+#include "dingofs/error.pb.h"
+
+namespace dingofs {
+namespace mds {
+namespace client {
+
+bool OwnerRouter::Init(uint32_t fs_id, MDSClient& bootstrap) {
+  fs_id_ = fs_id;
+
+  auto fs_resp = bootstrap.GetFs(fs_id);
+  if (fs_resp.error().errcode() != pb::error::OK) {
+    std::cerr << fmt::format("get fs info fail: {} ({})\n", fs_resp.error().errmsg(),
+                             static_cast<int>(fs_resp.error().errcode()));
+    return false;
+  }
+  partition_policy_ = fs_resp.fs_info().partition_policy();
+
+  auto mds_resp = bootstrap.GetMdsList();
+  if (mds_resp.error().errcode() != pb::error::OK) {
+    std::cerr << fmt::format("get mds list fail: {} ({})\n", mds_resp.error().errmsg(),
+                             static_cast<int>(mds_resp.error().errcode()));
+    return false;
+  }
+  std::unordered_map<uint64_t, std::string> mds_addrs;
+  for (const auto& mds : mds_resp.mdses()) {
+    mds_addrs[mds.id()] = fmt::format("{}:{}", mds.location().host(), mds.location().port());
+  }
+
+  std::unordered_set<uint64_t> owner_mds_ids;
+  if (partition_policy_.type() == pb::mds::PartitionType::MONOLITHIC_PARTITION) {
+    owner_mds_ids.insert(partition_policy_.mono().mds_id());
+
+  } else if (partition_policy_.type() == pb::mds::PartitionType::PARENT_ID_HASH_PARTITION) {
+    if (partition_policy_.parent_hash().bucket_num() == 0) {
+      std::cerr << "parent hash bucket_num is 0\n";
+      return false;
+    }
+    for (const auto& [mds_id, bucket_set] : partition_policy_.parent_hash().distributions()) {
+      owner_mds_ids.insert(mds_id);
+      for (const auto& bucket_id : bucket_set.bucket_ids()) bucket_to_mds_[bucket_id] = mds_id;
+    }
+
+  } else {
+    std::cerr << fmt::format("unknown partition type({})\n", pb::mds::PartitionType_Name(partition_policy_.type()));
+    return false;
+  }
+
+  for (uint64_t mds_id : owner_mds_ids) {
+    auto it = mds_addrs.find(mds_id);
+    if (it == mds_addrs.end()) {
+      LOG(ERROR) << fmt::format("mds({}) not in mds list, inodes owned by it cannot be routed", mds_id);
+      continue;
+    }
+    auto mds_client = std::make_unique<MDSClient>(fs_id_);
+    if (!mds_client->Init(it->second)) {
+      LOG(ERROR) << fmt::format("init client for mds({}) at {} fail, inodes owned by it cannot be routed", mds_id,
+                                it->second);
+      continue;
+    }
+    // Seed the partition epoch so epoch-validated RPCs (ReadDir / ListDentry /
+    // SyncDirStat) issued through this client are accepted after a rebalance.
+    mds_client->SetEpoch(partition_policy_.epoch());
+    mds_clients_[mds_id] = std::move(mds_client);
+  }
+
+  return true;
+}
+
+MDSClient* OwnerRouter::ClientForIno(Ino ino) {
+  uint64_t mds_id = 0;
+  if (partition_policy_.type() == pb::mds::PartitionType::MONOLITHIC_PARTITION) {
+    mds_id = partition_policy_.mono().mds_id();
+
+  } else {
+    auto it = bucket_to_mds_.find(static_cast<uint32_t>(ino % partition_policy_.parent_hash().bucket_num()));
+    if (it != bucket_to_mds_.end()) mds_id = it->second;
+  }
+
+  auto it = mds_clients_.find(mds_id);
+  if (it != mds_clients_.end()) return it->second.get();
+
+  return nullptr;
+}
+
+}  // namespace client
+}  // namespace mds
+}  // namespace dingofs

--- a/src/tools/mds-cli/owner_router.h
+++ b/src/tools/mds-cli/owner_router.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DINGOFS_MDS_CLIENT_OWNER_ROUTER_H_
+#define DINGOFS_MDS_CLIENT_OWNER_ROUTER_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "dingofs/mds.pb.h"
+#include "mds/common/type.h"
+#include "tools/mds-cli/mds.h"
+
+namespace dingofs {
+namespace mds {
+namespace client {
+
+// Routes an inode to the MDS that owns its partition under the fs partition
+// policy (same parent-hash scheme the FUSE client uses), and hands back a
+// client connected to that MDS.
+//
+// Why this matters: requests whose correctness depends on the owner's in-memory
+// state -- a fresh partition cache, or an unflushed dir-stat delta that lives
+// only on the owner -- must be sent to the owner, not to an arbitrary MDS.
+// RestoreFromTrash (trash restore) and GetDirStat (single-directory stat) both
+// need this.
+//
+// Read-only after Init, so concurrent ClientForIno() calls need no locking.
+class OwnerRouter {
+ public:
+  OwnerRouter() = default;
+  ~OwnerRouter() = default;
+
+  OwnerRouter(const OwnerRouter&) = delete;
+  OwnerRouter& operator=(const OwnerRouter&) = delete;
+
+  // Fetch the fs partition policy (via bootstrap.GetFs) and the MDS list (via
+  // bootstrap.GetMdsList), then build one MDSClient per owner MDS. `bootstrap`
+  // is an already-Init'd client to any reachable MDS, used only for these two
+  // setup RPCs. Returns false on failure (errors are logged / printed).
+  bool Init(uint32_t fs_id, MDSClient& bootstrap);
+
+  // Client connected to the MDS that owns `ino`'s partition (ino is used as the
+  // parent-hash key, i.e. the directory whose children/stat we want). Returns
+  // nullptr when no route is known or the owner's client is unavailable; the
+  // caller should handle that instead of misrouting to another MDS.
+  MDSClient* ClientForIno(Ino ino);
+
+ private:
+  uint32_t fs_id_{0};
+  pb::mds::PartitionPolicy partition_policy_;
+  std::unordered_map<uint32_t, uint64_t> bucket_to_mds_;                  // parent-hash only
+  std::unordered_map<uint64_t, std::unique_ptr<MDSClient>> mds_clients_;  // mds_id -> client
+};
+
+}  // namespace client
+}  // namespace mds
+}  // namespace dingofs
+
+#endif  // DINGOFS_MDS_CLIENT_OWNER_ROUTER_H_

--- a/test/unit/mds/CMakeLists.txt
+++ b/test/unit/mds/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(test_mds
   mds_quota
   mds_statistics
   mds_storage
-  
+
   dingofs_utils
 
   absl::log_internal_message

--- a/test/unit/mds/common/test_codec.cc
+++ b/test/unit/mds/common/test_codec.cc
@@ -534,6 +534,57 @@ TEST_F(MetaDataCodecTest, ParseKeyFromHexTruncated) {
   EXPECT_NE(desc.find("truncated"), std::string::npos) << desc;
 }
 
+TEST_F(MetaDataCodecTest, DirStatKey) {
+  uint32_t fs_id = 7;
+  Ino ino = 123456;
+  std::string key = MetaCodec::EncodeDirStatKey(fs_id, ino);
+  EXPECT_TRUE(MetaCodec::IsDirStatKey(key));
+  uint32_t out_fs_id = 0;
+  Ino out_ino = 0;
+  MetaCodec::DecodeDirStatKey(key, out_fs_id, out_ino);
+  EXPECT_EQ(out_fs_id, fs_id);
+  EXPECT_EQ(out_ino, ino);
+}
+
+TEST_F(MetaDataCodecTest, DirStatValue) {
+  DirStatEntry in;
+  in.set_length(1000);
+  in.set_inodes(3);
+  in.set_dirs(2);
+  std::string value = MetaCodec::EncodeDirStatValue(in);
+  auto out = MetaCodec::DecodeDirStatValue(value);
+  EXPECT_EQ(out.length(), 1000);
+  EXPECT_EQ(out.inodes(), 3);
+  EXPECT_EQ(out.dirs(), 2);
+}
+
+// Regression: a freshly-seeded (all-zero) DirStat must NOT encode to an empty
+// value. dingo-store rejects empty values ("value is empty"), which otherwise
+// fails every MkDir txn (DummyStorage accepts empty Puts, hiding the bug). The
+// encoded value must be non-empty yet still parse back to the same zero record,
+// and a legacy empty value already in the store must still decode to zero.
+TEST_F(MetaDataCodecTest, DirStatValueZeroIsNonEmpty) {
+  DirStatEntry zero;
+  std::string value = MetaCodec::EncodeDirStatValue(zero);
+  EXPECT_FALSE(value.empty());  // would be "" without the sentinel -> store rejects
+
+  auto out = MetaCodec::DecodeDirStatValue(value);
+  EXPECT_EQ(out.length(), 0);
+  EXPECT_EQ(out.inodes(), 0);
+  EXPECT_EQ(out.dirs(), 0);
+
+  // Back-compat: a legacy empty value already in the store still decodes to zero.
+  auto legacy = MetaCodec::DecodeDirStatValue("");
+  EXPECT_EQ(legacy.length(), 0);
+  EXPECT_EQ(legacy.inodes(), 0);
+  EXPECT_EQ(legacy.dirs(), 0);
+
+  // Self-cleaning: a non-zero record serializes normally (no sentinel appended).
+  DirStatEntry nonzero;
+  nonzero.set_inodes(1);
+  EXPECT_EQ(MetaCodec::EncodeDirStatValue(nonzero), nonzero.SerializeAsString());
+}
+
 }  // namespace unit_test
 }  // namespace mds
 }  // namespace dingofs

--- a/test/unit/mds/filesystem/test_dir_stat_operation.cc
+++ b/test/unit/mds/filesystem/test_dir_stat_operation.cc
@@ -35,7 +35,12 @@ class DirStatOperationTest : public ::testing::Test {
     ASSERT_TRUE(processor->Init()) << "init operation processor fail.";
   }
 
-  static void TearDownTestSuite() {}
+  static void TearDownTestSuite() {
+    if (processor != nullptr) {
+      processor->Destroy();
+      processor = nullptr;
+    }
+  }
 
   void SetUp() override {}
   void TearDown() override {}

--- a/test/unit/mds/filesystem/test_dir_stat_operation.cc
+++ b/test/unit/mds/filesystem/test_dir_stat_operation.cc
@@ -1,0 +1,293 @@
+// Copyright (c) 2025 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <map>
+
+#include "gtest/gtest.h"
+#include "mds/common/tracing.h"
+#include "mds/common/type.h"
+#include "mds/filesystem/store_operation.h"
+#include "mds/storage/dummy_storage.h"
+
+namespace dingofs {
+namespace mds {
+namespace unit_test {
+
+class DirStatOperationTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    auto kv_storage = DummyStorage::New();
+    ASSERT_TRUE(kv_storage->Init("")) << "init kv storage fail.";
+
+    processor = OperationProcessor::New(kv_storage);
+    ASSERT_TRUE(processor->Init()) << "init operation processor fail.";
+  }
+
+  static void TearDownTestSuite() {}
+
+  void SetUp() override {}
+  void TearDown() override {}
+
+ public:
+  static OperationProcessorSPtr processor;
+};
+
+OperationProcessorSPtr DirStatOperationTest::processor = nullptr;
+
+TEST_F(DirStatOperationTest, SetGetFlush) {
+  uint32_t fs_id = 1000;
+  dingofs::mds::Ino ino = 10;
+
+  // set
+  {
+    dingofs::mds::DirStatEntry st;
+    st.set_length(100);
+    st.set_inodes(1);
+    Trace trace;
+    std::map<uint64_t, dingofs::mds::DirStatEntry> one{{ino, st}};
+    dingofs::mds::BatchSetDirStatOperation op(trace, fs_id, std::move(one));
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+  }
+
+  // get
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    ASSERT_TRUE(op.GetResult().found);
+    EXPECT_EQ(op.GetResult().dir_stat.inodes(), 1);
+  }
+
+  // flush delta on existing key
+  {
+    std::map<uint64_t, dingofs::mds::DirStatDelta> deltas;
+    deltas[ino] = {50, 1};
+    Trace trace;
+    dingofs::mds::FlushDirStatsOperation op(trace, fs_id, deltas);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_TRUE(op.GetResult().missing_inos.empty());
+  }
+
+  // verify accumulated
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_EQ(op.GetResult().dir_stat.length(), 150);
+    EXPECT_EQ(op.GetResult().dir_stat.inodes(), 2);
+  }
+
+  // flush delta on missing key -> reported
+  {
+    std::map<uint64_t, dingofs::mds::DirStatDelta> deltas;
+    deltas[999] = {1, 1};
+    Trace trace;
+    dingofs::mds::FlushDirStatsOperation op(trace, fs_id, deltas);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    ASSERT_EQ(op.GetResult().missing_inos.size(), 1u);
+    EXPECT_EQ(op.GetResult().missing_inos[0], 999u);
+  }
+}
+
+TEST_F(DirStatOperationTest, Delete) {
+  uint32_t fs_id = 1000;
+  dingofs::mds::Ino ino = 30;
+  // seed
+  {
+    dingofs::mds::DirStatEntry st;
+    st.set_length(100);
+    st.set_inodes(1);
+    Trace trace;
+    std::map<uint64_t, dingofs::mds::DirStatEntry> one{{ino, st}};
+    dingofs::mds::BatchSetDirStatOperation op(trace, fs_id, std::move(one));
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+  }
+  // delete
+  {
+    Trace trace;
+    dingofs::mds::DeleteDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+  }
+  // get -> not found
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_FALSE(op.GetResult().found);
+  }
+}
+
+TEST_F(DirStatOperationTest, FlushNegativeReportedNotWritten) {
+  uint32_t fs_id = 1000;
+  dingofs::mds::Ino ino = 20;
+  // seed a small stat
+  {
+    dingofs::mds::DirStatEntry st;
+    st.set_length(10);
+    st.set_inodes(1);
+    Trace trace;
+    std::map<uint64_t, dingofs::mds::DirStatEntry> one{{ino, st}};
+    dingofs::mds::BatchSetDirStatOperation op(trace, fs_id, std::move(one));
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+  }
+  // flush a delta that would drive length negative
+  {
+    std::map<uint64_t, dingofs::mds::DirStatDelta> deltas;
+    deltas[ino] = {-100, 0};
+    Trace trace;
+    dingofs::mds::FlushDirStatsOperation op(trace, fs_id, deltas);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    ASSERT_EQ(op.GetResult().missing_inos.size(), 1u);
+    EXPECT_EQ(op.GetResult().missing_inos[0], ino);
+  }
+  // stored value must be UNCHANGED (not negative)
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    ASSERT_TRUE(op.GetResult().found);
+    EXPECT_EQ(op.GetResult().dir_stat.length(), 10);
+  }
+}
+
+// Seed creates an absent record and never clobbers an existing one.
+TEST_F(DirStatOperationTest, SeedNoClobber) {
+  uint32_t fs_id = 1000;
+  dingofs::mds::Ino ino = 50;
+
+  // seed on absent -> created.
+  {
+    dingofs::mds::DirStatEntry calc;
+    calc.set_length(700);
+    calc.set_inodes(3);
+    Trace trace;
+    dingofs::mds::SeedDirStatOperation op(trace, fs_id, ino, calc);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_TRUE(op.GetResult().seeded);
+  }
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    ASSERT_TRUE(op.GetResult().found);
+    EXPECT_EQ(op.GetResult().dir_stat.length(), 700);
+  }
+
+  // seed again with a different value -> no-op, existing record untouched.
+  {
+    dingofs::mds::DirStatEntry calc;
+    calc.set_length(999);
+    calc.set_inodes(9);
+    Trace trace;
+    dingofs::mds::SeedDirStatOperation op(trace, fs_id, ino, calc);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_FALSE(op.GetResult().seeded);
+  }
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_EQ(op.GetResult().dir_stat.length(), 700);
+  }
+}
+
+// Repair: check-only never writes; repair overwrites a mismatch and leaves a
+// match untouched.
+TEST_F(DirStatOperationTest, RepairCheckAndWrite) {
+  uint32_t fs_id = 1000;
+  dingofs::mds::Ino ino = 60;
+  {
+    dingofs::mds::DirStatEntry st;
+    st.set_length(10);
+    st.set_inodes(1);
+    Trace trace;
+    std::map<uint64_t, dingofs::mds::DirStatEntry> one{{ino, st}};
+    dingofs::mds::BatchSetDirStatOperation op(trace, fs_id, std::move(one));
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+  }
+
+  dingofs::mds::DirStatEntry calc;
+  calc.set_length(42);
+  calc.set_inodes(5);
+
+  // check-only (repair=false): reports mismatch, writes nothing.
+  {
+    Trace trace;
+    dingofs::mds::RepairDirStatOperation op(trace, fs_id, ino, calc, /*repair=*/false);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_TRUE(op.GetResult().found);
+    EXPECT_TRUE(op.GetResult().mismatch);
+    EXPECT_FALSE(op.GetResult().wrote);
+  }
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_EQ(op.GetResult().dir_stat.length(), 10);  // unchanged
+  }
+
+  // repair: overwrites with calc.
+  {
+    Trace trace;
+    dingofs::mds::RepairDirStatOperation op(trace, fs_id, ino, calc, /*repair=*/true);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_TRUE(op.GetResult().mismatch);
+    EXPECT_TRUE(op.GetResult().wrote);
+  }
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_EQ(op.GetResult().dir_stat.length(), 42);
+    EXPECT_EQ(op.GetResult().dir_stat.inodes(), 5);
+  }
+
+  // repair when already matching: no write.
+  {
+    Trace trace;
+    dingofs::mds::RepairDirStatOperation op(trace, fs_id, ino, calc, /*repair=*/true);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_FALSE(op.GetResult().mismatch);
+    EXPECT_FALSE(op.GetResult().wrote);
+  }
+}
+
+// Repair on an absent record creates it (found=false).
+TEST_F(DirStatOperationTest, RepairAbsentCreates) {
+  uint32_t fs_id = 1000;
+  dingofs::mds::Ino ino = 70;
+  dingofs::mds::DirStatEntry calc;
+  calc.set_length(3);
+  calc.set_inodes(2);
+  {
+    Trace trace;
+    dingofs::mds::RepairDirStatOperation op(trace, fs_id, ino, calc, /*repair=*/true);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    EXPECT_FALSE(op.GetResult().found);
+    EXPECT_TRUE(op.GetResult().mismatch);
+    EXPECT_TRUE(op.GetResult().wrote);
+  }
+  {
+    Trace trace;
+    dingofs::mds::GetDirStatOperation op(trace, fs_id, ino);
+    ASSERT_TRUE(processor->RunAlone(&op).ok());
+    ASSERT_TRUE(op.GetResult().found);
+    EXPECT_EQ(op.GetResult().dir_stat.inodes(), 2);
+  }
+}
+
+}  // namespace unit_test
+}  // namespace mds
+}  // namespace dingofs

--- a/test/unit/mds/filesystem/test_filesystem.cc
+++ b/test/unit/mds/filesystem/test_filesystem.cc
@@ -1121,6 +1121,50 @@ TEST_F(FileSystemTest, CalcDirStat) {
   EXPECT_EQ(st.length(), 6000);
 }
 
+// A same-directory hardlink (`ln f hl`) puts two dentries on one inode, so the
+// inode number repeats in the dentry scan. CalcDirStat must not hand BatchGet a
+// duplicate inode key (the store txn rejects duplicates) and must still charge
+// the inode's length once per dentry (matching `find`).
+TEST_F(FileSystemTest, CalcDirStatSameDirHardlink) {
+  auto fs = Fs();
+  Context ctx;
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno;
+  dp.name = "calc_hl_d";
+  dp.mode = 0777;
+  dp.uid = 1;
+  dp.gid = 1;
+  dp.rdev = 0;
+  EntryOut dout;
+  ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino d = dout.attr.ino();
+
+  FileSystem::MkNodParam p;
+  p.parent = d;
+  p.name = "f";
+  p.mode = 0644;
+  p.uid = 1;
+  p.gid = 1;
+  p.rdev = 0;
+  EntryOut o;
+  ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+  Ino f = o.attr.ino();
+  FileSystem::FlushFileParam fp;
+  fp.length = 7777;
+  EntryOut fo;
+  ASSERT_TRUE(fs->FlushFile(ctx, f, fp, fo).ok());
+
+  // hardlink the file under a second name in the SAME directory.
+  EntryOut lo;
+  ASSERT_TRUE(fs->Link(ctx, f, d, "f_hl", lo).ok());
+
+  DirStatEntry st;
+  auto status = fs->CalcDirStat(ctx, d, st);
+  ASSERT_TRUE(status.ok()) << "CalcDirStat fail: " << status.error_str();
+  EXPECT_EQ(st.inodes(), 2);         // two dentries (f, f_hl)
+  EXPECT_EQ(st.length(), 7777 * 2);  // length charged once per dentry
+}
+
 TEST_F(FileSystemTest, UpdateDirStatOnWrite) {
   auto fs = Fs();
   ASSERT_TRUE(fs->EnableDirStats());

--- a/test/unit/mds/filesystem/test_filesystem.cc
+++ b/test/unit/mds/filesystem/test_filesystem.cc
@@ -27,12 +27,27 @@
 #include "mds/common/trash.h"
 #include "mds/coordinator/dummy_coordinator_client.h"
 #include "mds/filesystem/filesystem.h"
+#include "mds/filesystem/id_generator.h"
 #include "mds/filesystem/store_operation.h"
 #include "mds/storage/dummy_storage.h"
 
 namespace dingofs {
 namespace mds {
 namespace unit_test {
+
+// Drain the in-memory dir-stat delta log (summed per ino) and clear it, mirroring
+// what a flush consumes. The production flush uses GetFlushSnapshot + Compact so a
+// delta arriving mid-flush survives; tests run with inplace workers so nothing
+// races, and this drains everything for per-op delta assertions/isolation.
+static std::map<uint64_t, DirStatDelta> DrainDirStats(dir_stat::DirStatManager& m) {
+  auto snap = m.GetFlushSnapshot();
+  std::map<uint64_t, DirStatDelta> out;
+  for (const auto& [ino, fe] : snap) {
+    out[ino] = fe.delta;
+    m.Compact(ino, fe.timepoint);
+  }
+  return out;
+}
 
 const std::string kFsAutoIncrementIdName = "dingofs-fs-id";
 const std::string kInoAutoIncrementIdName = "dingofs-inode-id";
@@ -65,7 +80,7 @@ static pb::mds::FsInfo CreateFsInfo(
   fs_info.set_status(pb::mds::FsStatus::NORMAL);
   fs_info.set_block_size(1024 * 1024);
   fs_info.set_chunk_size(1024 * 1024 * 64);
-  fs_info.set_enable_dir_stats(false);
+  fs_info.set_enable_dir_stats(true);
   fs_info.set_owner("dengzh");
   fs_info.set_capacity(1024 * 1024 * 1024);
   fs_info.set_recycle_time_hour(24);
@@ -122,7 +137,7 @@ class FileSystemSetTest : public testing::Test {
     fs_set =
         FileSystemSet::New(coordinator_client, std::move(fs_id_generator),
                            slice_id_generator, kv_storage, mds_meta,
-                           mds_meta_map, operation_processor, nullptr, nullptr);
+                           mds_meta_map, operation_processor, nullptr, nullptr, nullptr);
     ASSERT_TRUE(fs_set->Init()) << "init fs set fail.";
   }
 
@@ -156,26 +171,33 @@ class FileSystemTest : public testing::Test {
     ASSERT_TRUE(coordinator_client->Init(""))
         << "init coordinator client fail.";
 
-    auto fs_id_generator = CoorAutoIncrementIdGenerator::New(
-        coordinator_client, kFsAutoIncrementIdName, kFsTableId, 1000000, 8);
-
-    auto inode_id_generator = CoorAutoIncrementIdGenerator::NewShare(
-        coordinator_client, kInoAutoIncrementIdName, kInodeTableId, 1000000000,
-        8);
-
     auto kv_storage = DummyStorage::New();
     ASSERT_TRUE(kv_storage->Init("")) << "init kv storage fail.";
 
+    // KV-backed id generators work with DummyStorage.
+    auto inode_id_generator = NewInodeIdGenerator(1000, kv_storage);
+    ASSERT_TRUE(inode_id_generator->Init())
+        << "init inode id generator fail.";
+
+    auto slice_id_generator = NewSliceIdGenerator(kv_storage);
+    ASSERT_TRUE(slice_id_generator->Init())
+        << "init slice id generator fail.";
+
     operation_processor = OperationProcessor::New(kv_storage);
     ASSERT_TRUE(operation_processor->Init()) << "init mutation merger fail.";
+
+    // quota worker set (needed to avoid nullptr crash in AsyncUpdateDirUsage).
+    auto quota_worker_set =
+        SimpleWorkerSet::New("fs_test_quota", 1, 1024, false, /*is_inplace_run=*/true);
+    ASSERT_TRUE(quota_worker_set->Init()) << "init quota worker set fail.";
 
     pb::mds::FsInfo fs_info = CreateFsInfo(
         1000, "test_fs", pb::mds::PartitionType::MONOLITHIC_PARTITION);
 
     fs = FileSystem::New(kMdsId, FsInfo::New(fs_info),
-                         std::move(fs_id_generator), inode_id_generator,
-                         kv_storage, operation_processor, nullptr, nullptr,
-                         nullptr);
+                         std::move(inode_id_generator), slice_id_generator,
+                         kv_storage, operation_processor, nullptr,
+                         quota_worker_set, quota_worker_set, nullptr);
     auto status = fs->CreateRoot();
     ASSERT_TRUE(status.ok())
         << "create root fail, error: " << status.error_str();
@@ -1054,6 +1076,491 @@ TEST_F(FileSystemSetTest, CreateFs_PropagatesEnableUidGidMapDefaultFalse) {
   auto status = fs_set->CreateFs(param, fs_info);
   ASSERT_TRUE(status.ok()) << "create fs fail: " << status.error_str();
   EXPECT_FALSE(fs_info.enable_uid_gid_map());
+}
+
+TEST_F(FileSystemTest, CalcDirStat) {
+  auto fs = Fs();
+  Context ctx;
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno;
+  dp.name = "calc_d";
+  dp.mode = 0777;
+  dp.uid = 1;
+  dp.gid = 1;
+  dp.rdev = 0;
+  EntryOut dout;
+  auto mkdir_status = fs->MkDir(ctx, dp, dout);
+  ASSERT_TRUE(mkdir_status.ok()) << "mkdir fail: " << mkdir_status.error_str();
+  Ino d = dout.attr.ino();
+
+  auto mk = [&](const std::string& name, uint64_t len) {
+    FileSystem::MkNodParam p;
+    p.parent = d;
+    p.name = name;
+    p.mode = 0644;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    auto mn = fs->MkNod(ctx, p, o);
+    EXPECT_TRUE(mn.ok()) << "mknod fail: " << mn.error_str();
+    if (len > 0) {
+      FileSystem::FlushFileParam fp;
+      fp.length = len;
+      EntryOut fo;
+      auto sa = fs->FlushFile(ctx, o.attr.ino(), fp, fo);
+      EXPECT_TRUE(sa.ok()) << "flushfile fail: " << sa.error_str();
+    }
+  };
+  mk("f1", 1000);
+  mk("f2", 5000);
+
+  DirStatEntry st;
+  ASSERT_TRUE(fs->CalcDirStat(ctx, d, st).ok());
+  EXPECT_EQ(st.inodes(), 2);
+  EXPECT_EQ(st.length(), 6000);
+}
+
+TEST_F(FileSystemTest, UpdateDirStatOnWrite) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno;
+  dp.name = "upd_d";
+  dp.mode = 0777;
+  dp.uid = 1;
+  dp.gid = 1;
+  dp.rdev = 0;
+  EntryOut dout;
+  ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino d = dout.attr.ino();
+  DrainDirStats(fs->GetDirStatManager());  // drain whatever accumulated so far
+
+  // mknod a file under d: +1 inode, +0 length.
+  FileSystem::MkNodParam p;
+  p.parent = d;
+  p.name = "g";
+  p.mode = 0644;
+  p.uid = 1;
+  p.gid = 1;
+  p.rdev = 0;
+  EntryOut o;
+  ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+  {
+    auto deltas = DrainDirStats(fs->GetDirStatManager());
+    ASSERT_TRUE(deltas.count(d));
+    EXPECT_EQ(deltas[d].inodes, 1);
+    EXPECT_EQ(deltas[d].length, 0);
+  }
+
+  // set g's length to 5000 via FlushFile (a wired length-change site):
+  // length 0->5000 => +5000 length, inodes unchanged.
+  {
+    FileSystem::FlushFileParam fp;
+    fp.length = 5000;
+    EntryOut fo;
+    ASSERT_TRUE(fs->FlushFile(ctx, o.attr.ino(), fp, fo).ok());
+    auto deltas = DrainDirStats(fs->GetDirStatManager());
+    ASSERT_TRUE(deltas.count(d));
+    EXPECT_EQ(deltas[d].inodes, 0);
+    EXPECT_EQ(deltas[d].length, 5000);
+  }
+
+  // unlink g (file length now 5000): -1 inode, -5000 length.
+  {
+    EntryOut uo;
+    ASSERT_TRUE(fs->UnLink(ctx, d, "g", uo).ok());
+    auto deltas = DrainDirStats(fs->GetDirStatManager());
+    ASSERT_TRUE(deltas.count(d));
+    EXPECT_EQ(deltas[d].inodes, -1);
+    EXPECT_EQ(deltas[d].length, -5000);
+  }
+
+  // mkdir a subdir under d then rmdir it: subdir create gives d +1 inode/+0
+  // length, rmdir gives d -1 inode/-0 length. Drain after create so the rmdir
+  // delta is isolated.
+  {
+    FileSystem::MkDirParam sp;
+    sp.parent = d;
+    sp.name = "sub";
+    sp.mode = 0777;
+    sp.uid = 1;
+    sp.gid = 1;
+    sp.rdev = 0;
+    EntryOut so;
+    ASSERT_TRUE(fs->MkDir(ctx, sp, so).ok());
+    {
+      auto deltas = DrainDirStats(fs->GetDirStatManager());
+      ASSERT_TRUE(deltas.count(d));
+      EXPECT_EQ(deltas[d].inodes, 1);
+      EXPECT_EQ(deltas[d].length, 0);
+    }
+    Ino sub_ino = 0;
+    EntryOut ro;
+    ASSERT_TRUE(fs->RmDir(ctx, d, "sub", sub_ino, ro).ok());
+    auto deltas = DrainDirStats(fs->GetDirStatManager());
+    ASSERT_TRUE(deltas.count(d));
+    EXPECT_EQ(deltas[d].inodes, -1);
+    EXPECT_EQ(deltas[d].length, 0);
+  }
+
+  // symlink under d: +1 inode, +0 length (non-FILE).
+  {
+    EntryOut sym_out;
+    ASSERT_TRUE(fs->Symlink(ctx, "/target", d, "lnk", 1, 1, sym_out).ok());
+    auto deltas = DrainDirStats(fs->GetDirStatManager());
+    ASSERT_TRUE(deltas.count(d));
+    EXPECT_EQ(deltas[d].inodes, 1);
+    EXPECT_EQ(deltas[d].length, 0);
+  }
+}
+
+// Cross-check the accumulated single-level deltas against the CalcDirStat
+// source-of-truth: build a small tree under a fresh dir, drain the buffer,
+// perform the ops, sum the deltas, and assert they match a fresh CalcDirStat.
+TEST_F(FileSystemTest, UpdateDirStatMatchesCalc) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno;
+  dp.name = "match_d";
+  dp.mode = 0777;
+  dp.uid = 1;
+  dp.gid = 1;
+  dp.rdev = 0;
+  EntryOut dout;
+  ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino d = dout.attr.ino();
+  DrainDirStats(fs->GetDirStatManager());  // drain
+
+  auto mk = [&](const std::string& name, uint64_t len) {
+    FileSystem::MkNodParam p;
+    p.parent = d;
+    p.name = name;
+    p.mode = 0644;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+    if (len > 0) {
+      FileSystem::FlushFileParam fp;
+      fp.length = len;
+      EntryOut fo;
+      ASSERT_TRUE(fs->FlushFile(ctx, o.attr.ino(), fp, fo).ok());
+    }
+  };
+  mk("a", 1000);
+  mk("b", 5000);
+
+  auto deltas = DrainDirStats(fs->GetDirStatManager());
+  ASSERT_TRUE(deltas.count(d));
+
+  DirStatEntry st;
+  ASSERT_TRUE(fs->CalcDirStat(ctx, d, st).ok());
+
+  EXPECT_EQ(deltas[d].inodes, st.inodes());
+  EXPECT_EQ(deltas[d].length, st.length());
+}
+
+TEST_F(FileSystemTest, FlushDirStats) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno; dp.name = "flush_d"; dp.mode = 0777; dp.uid = 1; dp.gid = 1; dp.rdev = 0;
+  EntryOut dout; ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino d = dout.attr.ino();
+
+  FileSystem::MkNodParam p; p.parent = d; p.name = "x"; p.mode = 0644; p.uid = 1; p.gid = 1; p.rdev = 0;
+  EntryOut o; ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+
+  ASSERT_TRUE(fs->GetDirStatManager().FlushDirStats().ok());
+
+  DirStatEntry st;
+  ASSERT_TRUE(fs->GetDirStatManager().GetDirStat(ctx, d, st).ok());
+  EXPECT_EQ(st.inodes(), 1);
+  EXPECT_EQ(st.length(), 0);  // one empty file
+}
+
+// MkDir writes a zero-valued dir-stat record in the SAME txn, so a freshly
+// created directory is tracked from birth: it has a stored {0,0,0} record
+// immediately, so the first flush takes the in-place increment path (delta
+// applied on top of the seeded record) rather than missing->recompute.
+TEST_F(FileSystemTest, MkDirSeedsZeroDirStat) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno; dp.name = "seed_d"; dp.mode = 0777; dp.uid = 1; dp.gid = 1; dp.rdev = 0;
+  EntryOut dout; ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino d = dout.attr.ino();
+
+  DirStatEntry seeded;
+  ASSERT_TRUE(fs->GetDirStatManager().GetDirStat(ctx, d, seeded).ok());
+  EXPECT_EQ(seeded.inodes(), 0);
+  EXPECT_EQ(seeded.length(), 0);
+
+  FileSystem::MkNodParam p; p.parent = d; p.name = "x"; p.mode = 0644; p.uid = 1; p.gid = 1; p.rdev = 0;
+  EntryOut o; ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+  ASSERT_TRUE(fs->GetDirStatManager().FlushDirStats().ok());
+
+  DirStatEntry after;
+  ASSERT_TRUE(fs->GetDirStatManager().GetDirStat(ctx, d, after).ok());
+  EXPECT_EQ(after.inodes(), 1);
+  EXPECT_EQ(after.length(), 0);
+}
+
+// BatchMkDir seeds a zero-valued dir-stat record for the directory inode(s) it
+// creates, in the same txn as the inode write.
+TEST_F(FileSystemTest, BatchMkDirSeedsZeroDirStat) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+
+  std::vector<FileSystem::MkDirParam> params;
+  for (const auto& name : {"bseed_a", "bseed_b"}) {
+    FileSystem::MkDirParam p;
+    p.parent = kRootIno; p.name = name; p.mode = 0777; p.uid = 1; p.gid = 1; p.rdev = 0;
+    params.push_back(p);
+  }
+  EntryOut out;
+  ASSERT_TRUE(fs->BatchMkDir(ctx, params, out).ok());
+  ASSERT_FALSE(out.attrs.empty());
+
+  for (const auto& attr : out.attrs) {
+    DirStatEntry st;
+    ASSERT_TRUE(fs->GetDirStatManager().GetDirStat(ctx, attr.ino(), st).ok());
+    EXPECT_EQ(st.inodes(), 0);
+    EXPECT_EQ(st.length(), 0);
+  }
+}
+
+TEST_F(FileSystemTest, SyncDirStatSingleLevelRepair) {
+  auto fs = Fs();
+  Context ctx;
+  auto mkdir = [&](Ino parent, const std::string& name) -> Ino {
+    FileSystem::MkDirParam p;
+    p.parent = parent;
+    p.name = name;
+    p.mode = 0777;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    EXPECT_TRUE(fs->MkDir(ctx, p, o).ok());
+    return o.attr.ino();
+  };
+  auto mkfile = [&](Ino parent, const std::string& name, uint64_t len) {
+    FileSystem::MkNodParam p;
+    p.parent = parent;
+    p.name = name;
+    p.mode = 0644;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+    if (len > 0) {
+      FileSystem::FlushFileParam fp;
+      fp.length = len;
+      EntryOut fo;
+      ASSERT_TRUE(fs->FlushFile(ctx, o.attr.ino(), fp, fo).ok());
+    }
+  };
+
+  Ino s = mkdir(kRootIno, "sum_s");
+  Ino a = mkdir(s, "a");
+  mkfile(a, "f1", 1000);
+  mkfile(s, "f2", 5000);
+
+  // Single-level: s's direct children are {a (dir), f2 (file, 5000)} -> inodes=2,
+  // dirs=1, length=5000 (f1 lives under a, not s). The stored stat lags (seeded
+  // zero at MkDir plus buffered, un-flushed deltas), so a read-only check reports
+  // one break for s carrying the recomputed (want) value.
+  std::vector<dir_stat::DirStatManager::DirStatMismatch> mismatches;
+  ASSERT_TRUE(fs->GetDirStatManager().SyncDirStat(ctx, s, /*repair=*/false, mismatches).ok());
+  ASSERT_EQ(mismatches.size(), 1u);
+  EXPECT_EQ(mismatches[0].ino, s);
+  EXPECT_EQ(mismatches[0].want.inodes(), 2);
+  EXPECT_EQ(mismatches[0].want.dirs(), 1);
+  EXPECT_EQ(mismatches[0].want.length(), 5000);
+
+  // Repair persists the recomputed value (and discards the buffered delta), so a
+  // subsequent read-only check is clean and the stored record equals CalcDirStat.
+  mismatches.clear();
+  ASSERT_TRUE(fs->GetDirStatManager().SyncDirStat(ctx, s, /*repair=*/true, mismatches).ok());
+  EXPECT_EQ(mismatches.size(), 1u);
+
+  mismatches.clear();
+  ASSERT_TRUE(fs->GetDirStatManager().SyncDirStat(ctx, s, /*repair=*/false, mismatches).ok());
+  EXPECT_TRUE(mismatches.empty());
+
+  DirStatEntry calc, stored;
+  ASSERT_TRUE(fs->CalcDirStat(ctx, s, calc).ok());
+  ASSERT_TRUE(fs->GetDirStatManager().GetDirStat(ctx, s, stored).ok());
+  EXPECT_EQ(stored.inodes(), calc.inodes());
+  EXPECT_EQ(stored.dirs(), calc.dirs());
+  EXPECT_EQ(stored.length(), calc.length());
+}
+
+// Regression: GetAttr on a directory inode that has no stored record (deleted,
+// or never created) must return ENOT_FOUND, not crash. The dir-branch scan in
+// GetInodeAttrOperation comes back empty and previously left a default zero-ino
+// attr that UpsertInodeCache rejects with LOG(FATAL) -- crashing the MDS on a
+// GetAttr of any missing directory.
+TEST_F(FileSystemTest, GetAttrMissingDirReturnsNotFound) {
+  auto fs = Fs();
+  Context ctx;
+
+  // An odd inode is treated as a directory (IsDir); pick one well below the
+  // allocated range so it has no inode key and is not cached -> store read.
+  Ino missing_dir = 123456789;
+  ASSERT_TRUE(IsDir(missing_dir));
+
+  EntryOut got;
+  auto status = fs->GetAttr(ctx, missing_dir, got);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.error_code(), pb::error::ENOT_FOUND);
+}
+
+// Fallocate that extends a file must charge the growth to the parent dir-stat
+// (and quota). Regression: the delta was computed by re-reading the cached inode
+// AFTER UpsertInodeCache mutated it in place, yielding a constant 0 and silently
+// dropping both the dir-stat and quota updates. The delta is now taken from the
+// operation's txn (FallocateOperation::Result::length_delta).
+TEST_F(FileSystemTest, FallocateChargesDirStat) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+  auto mkdir = [&](Ino parent, const std::string& name) -> Ino {
+    FileSystem::MkDirParam p;
+    p.parent = parent;
+    p.name = name;
+    p.mode = 0777;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    EXPECT_TRUE(fs->MkDir(ctx, p, o).ok());
+    return o.attr.ino();
+  };
+  auto mknod = [&](Ino parent, const std::string& name) -> Ino {
+    FileSystem::MkNodParam p;
+    p.parent = parent;
+    p.name = name;
+    p.mode = 0644;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    EXPECT_TRUE(fs->MkNod(ctx, p, o).ok());
+    return o.attr.ino();
+  };
+
+  Ino d = mkdir(kRootIno, "fa_d");
+  Ino f = mknod(d, "f");  // empty file, length 0
+
+  // fallocate(mode=0) extends f from 0 to 4096.
+  EntryWithChunkOut eo;
+  ASSERT_TRUE(fs->Fallocate(ctx, f, /*mode=*/0, /*offset=*/0, /*len=*/4096, eo).ok());
+  EXPECT_EQ(eo.attr.length(), 4096u);
+
+  // The parent dir-stat length must reflect the 4096-byte growth (folding the
+  // buffered delta). Without the fix this stays 0.
+  DirStatEntry stat;
+  ASSERT_TRUE(fs->GetDirStatManager().GetDirStat(ctx, d, stat, /*with_pending=*/true).ok());
+  EXPECT_EQ(stat.length(), 4096);
+  EXPECT_EQ(stat.inodes(), 1);  // just f
+  EXPECT_EQ(stat.dirs(), 0);
+}
+
+// BatchUnLink must apply the aggregated dir-stat delta once (single lock) and
+// account every removed child, not silently drop any.
+TEST_F(FileSystemTest, BatchUnLinkAggregatesDirStatDelta) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno;
+  dp.name = "batch_unlink_d";
+  dp.mode = 0777;
+  dp.uid = 1;
+  dp.gid = 1;
+  dp.rdev = 0;
+  EntryOut dout;
+  ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino d = dout.attr.ino();
+
+  std::vector<std::string> names = {"a", "b", "c"};
+  for (const auto& name : names) {
+    FileSystem::MkNodParam p;
+    p.parent = d;
+    p.name = name;
+    p.mode = 0644;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+  }
+
+  DrainDirStats(fs->GetDirStatManager());  // drain create deltas
+
+  EntryOut out;
+  ASSERT_TRUE(fs->BatchUnLink(ctx, d, names, out).ok());
+
+  auto deltas = DrainDirStats(fs->GetDirStatManager());
+  ASSERT_TRUE(deltas.count(d));
+  EXPECT_EQ(deltas[d].inodes, -3);  // all three children removed
+  EXPECT_EQ(deltas[d].length, 0);   // empty files
+}
+
+// ForEachDentry pages with last_name; the store-backed scan is inclusive of
+// last_name, so without skip-first the page-boundary entry is counted twice.
+// Force the store path via a bypass-cache context over >1 page of children.
+TEST_F(FileSystemTest, CalcDirStatNoPageBoundaryDoubleCount) {
+  auto fs = Fs();
+  Context ctx;
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno;
+  dp.name = "page_d";
+  dp.mode = 0777;
+  dp.uid = 1;
+  dp.gid = 1;
+  dp.rdev = 0;
+  EntryOut dout;
+  ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino d = dout.attr.ino();
+
+  // One more than the internal scan page size (1000) so the scan spans 2 pages.
+  constexpr int kCount = 1001;
+  for (int i = 0; i < kCount; ++i) {
+    FileSystem::MkNodParam p;
+    p.parent = d;
+    // zero-padded names keep a deterministic sorted order across the boundary.
+    p.name = fmt::format("f{:05d}", i);
+    p.mode = 0644;
+    p.uid = 1;
+    p.gid = 1;
+    p.rdev = 0;
+    EntryOut o;
+    ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+  }
+
+  // bypass-cache forces ListDentryFromStore (the inclusive scan path).
+  pb::mds::Context ce;
+  ce.set_is_bypass_cache(true);
+  Context bypass_ctx(ce, "test", "CalcDirStatNoPageBoundaryDoubleCount");
+
+  DirStatEntry st;
+  ASSERT_TRUE(fs->CalcDirStat(bypass_ctx, d, st).ok());
+  EXPECT_EQ(st.inodes(), kCount);  // exactly kCount, not kCount + (boundary dups)
 }
 
 }  // namespace unit_test

--- a/test/unit/mds/filesystem/test_trash.cc
+++ b/test/unit/mds/filesystem/test_trash.cc
@@ -38,6 +38,18 @@ namespace dingofs {
 namespace mds {
 namespace unit_test {
 
+// Drain the in-memory dir-stat delta log (summed per ino) and clear it -- the
+// new manager has no SwapOut; production flush uses GetFlushSnapshot + Compact.
+static std::map<uint64_t, DirStatDelta> DrainDirStats(dir_stat::DirStatManager& m) {
+  auto snap = m.GetFlushSnapshot();
+  std::map<uint64_t, DirStatDelta> out;
+  for (const auto& [ino, fe] : snap) {
+    out[ino] = fe.delta;
+    m.Compact(ino, fe.timepoint);
+  }
+  return out;
+}
+
 // ============================================================================
 // Unit Tests — Trash FileSystem behavior
 //
@@ -58,7 +70,8 @@ static pb::mds::S3Info CreateS3Info() {
 
 static pb::mds::FsInfo CreateFsInfoWithTrash(uint32_t fs_id,
                                              const std::string& fs_name,
-                                             uint32_t trash_days) {
+                                             uint32_t trash_days,
+                                             bool enable_dir_stats = false) {
   pb::mds::FsInfo fs_info;
   fs_info.set_fs_id(fs_id);
   fs_info.set_fs_name(fs_name);
@@ -66,7 +79,7 @@ static pb::mds::FsInfo CreateFsInfoWithTrash(uint32_t fs_id,
   fs_info.set_status(pb::mds::FsStatus::NORMAL);
   fs_info.set_block_size(1024 * 1024);
   fs_info.set_chunk_size(1024 * 1024 * 64);
-  fs_info.set_enable_dir_stats(false);
+  fs_info.set_enable_dir_stats(enable_dir_stats);
   fs_info.set_owner("test_user");
   fs_info.set_capacity(1024 * 1024 * 1024);
   fs_info.set_recycle_time_hour(24);
@@ -103,7 +116,7 @@ class TrashFileSystemTest : public testing::Test {
     // Create a quota worker set (needed to avoid nullptr crash in
     // AsyncUpdateDirUsage).
     quota_worker_set =
-        SimpleWorkerSet::New("trash_test_quota", 1, 1024, false, false);
+        SimpleWorkerSet::New("trash_test_quota", 1, 1024, false, /*is_inplace_run=*/true);
     ASSERT_TRUE(quota_worker_set->Init()) << "init quota worker set fail.";
 
     pb::mds::FsInfo fs_info = CreateFsInfoWithTrash(kFsId, "trash_test_fs", 7);
@@ -111,7 +124,7 @@ class TrashFileSystemTest : public testing::Test {
     fs = FileSystem::New(kTrashMdsId, FsInfo::New(fs_info),
                          std::move(ino_id_generator), slice_id_generator,
                          kv_storage, operation_processor, nullptr,
-                         quota_worker_set, nullptr);
+                         quota_worker_set, quota_worker_set, nullptr);
     auto status = fs->CreateRoot();
     ASSERT_TRUE(status.ok())
         << "create root fail, error: " << status.error_str();
@@ -788,8 +801,10 @@ TEST_F(TrashFileSystemTest, RestoreHardlinkOneOfTwo) {
   EntryOut unlink_src;
   status = fs->UnLink(ctx, kRootIno, "hl_src", unlink_src);
   ASSERT_TRUE(status.ok()) << status.error_str();
+  // hl_src still has a live hardlink (hl_dst at root), so its parents list is
+  // [root(live), sub_trash_bucket]; pick the actual trash bucket from parents.
   Ino sub_trash_ino = FindTrashBucketParent(unlink_src.attr);
-  ASSERT_NE(sub_trash_ino, 0);
+  ASSERT_NE(sub_trash_ino, 0u) << "no trash bucket in parents";
 
   EntryOut unlink_dst;
   status = fs->UnLink(ctx, kRootIno, "hl_dst", unlink_dst);
@@ -1711,6 +1726,120 @@ TEST_F(TrashFileSystemTest, ScanDentryOperationDecodesBucketEntry) {
   EXPECT_EQ(seen_name, trash_name)
       << "trash entry " << trash_name << " missing from bucket scan";
   EXPECT_EQ(seen_ino, file_ino);
+}
+
+// ============================================================================
+// Trash x dir-stats: a fixture with BOTH trash and per-directory usage stats
+// enabled, to verify dir-stat accounting across trash-move and restore.
+// ============================================================================
+class TrashDirStatTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    kv_storage = DummyStorage::New();
+    ASSERT_TRUE(kv_storage->Init("")) << "init kv storage fail.";
+
+    const uint32_t kFsId = 3000;
+    auto ino_id_generator = NewInodeIdGenerator(kFsId, kv_storage);
+    ASSERT_TRUE(ino_id_generator->Init()) << "init inode id generator fail.";
+    auto slice_id_generator = NewSliceIdGenerator(kv_storage);
+    ASSERT_TRUE(slice_id_generator->Init()) << "init slice id generator fail.";
+
+    operation_processor = OperationProcessor::New(kv_storage);
+    ASSERT_TRUE(operation_processor->Init()) << "init operation processor fail.";
+
+    auto quota_worker_set =
+        SimpleWorkerSet::New("trash_ds_quota", 1, 1024, false, /*is_inplace_run=*/true);
+    ASSERT_TRUE(quota_worker_set->Init()) << "init quota worker set fail.";
+
+    pb::mds::FsInfo fs_info = CreateFsInfoWithTrash(
+        kFsId, "trash_ds_fs", /*trash_days=*/7, /*enable_dir_stats=*/true);
+
+    fs = FileSystem::New(kTrashMdsId, FsInfo::New(fs_info),
+                         std::move(ino_id_generator), slice_id_generator,
+                         kv_storage, operation_processor, nullptr,
+                         quota_worker_set, quota_worker_set, nullptr);
+    ASSERT_TRUE(fs->CreateRoot().ok());
+  }
+
+  static void TearDownTestSuite() {}
+
+ public:
+  static FileSystemSPtr fs;
+  static KVStorageSPtr kv_storage;
+  static OperationProcessorSPtr operation_processor;
+  static FileSystemSPtr Fs() { return fs; }
+};
+
+FileSystemSPtr TrashDirStatTest::fs = nullptr;
+KVStorageSPtr TrashDirStatTest::kv_storage = nullptr;
+OperationProcessorSPtr TrashDirStatTest::operation_processor = nullptr;
+
+// Regression: tree-rebuild grafts a child back onto a (trashed) user directory
+// with allow_trash_parent=true. The grafted-into directory is a real user dir
+// (normal-range inode), so its dir-stat MUST be credited -- otherwise a later
+// put_back of the directory carries the child along without ever accounting for
+// it, leaving the restored directory's stat under-counted. The credit must be
+// gated on "dst is not a trash bucket", not on allow_trash_parent.
+TEST_F(TrashDirStatTest, TreeRebuildGraftCreditsGraftedIntoDirStat) {
+  auto fs = Fs();
+  ASSERT_TRUE(fs->EnableDirStats());
+  Context ctx;
+
+  // mkdir /sub
+  FileSystem::MkDirParam dp;
+  dp.parent = kRootIno;
+  dp.name = "sub";
+  dp.mode = 0755;
+  dp.uid = 1;
+  dp.gid = 1;
+  dp.rdev = 0;
+  EntryOut dout;
+  ASSERT_TRUE(fs->MkDir(ctx, dp, dout).ok());
+  Ino sub_ino = dout.attr.ino();
+
+  // create /sub/child and give it length 5000.
+  FileSystem::MkNodParam fp;
+  fp.parent = sub_ino;
+  fp.name = "child";
+  fp.mode = 0644;
+  fp.uid = 1;
+  fp.gid = 1;
+  fp.rdev = 0;
+  EntryOut fo;
+  ASSERT_TRUE(fs->MkNod(ctx, fp, fo).ok());
+  Ino child_ino = fo.attr.ino();
+  {
+    FileSystem::FlushFileParam ffp;
+    ffp.length = 5000;
+    EntryOut ffo;
+    ASSERT_TRUE(fs->FlushFile(ctx, child_ino, ffp, ffo).ok());
+  }
+
+  // unlink child (-> trash, debits sub), then rmdir sub (-> trash). sub is now
+  // a trashed user directory; child is a flat entry in the same hour bucket.
+  EntryOut uo;
+  ASSERT_TRUE(fs->UnLink(ctx, sub_ino, "child", uo).ok());
+  Ino sub_trash_ino = uo.attr.parents(0);
+  Ino removed = 0;
+  EntryOut ro;
+  ASSERT_TRUE(fs->RmDir(ctx, kRootIno, "sub", removed, ro).ok());
+
+  // Drain accumulated deltas so the graft's delta is isolated.
+  DrainDirStats(fs->GetDirStatManager());
+
+  // Tree-rebuild: graft child back onto the trashed sub.
+  std::string child_trash_name =
+      BuildTrashEntryName(sub_ino, child_ino, "child");
+  auto status = fs->RestoreFromTrash(ctx, sub_trash_ino, child_trash_name,
+                                     /*allow_trash_parent=*/true);
+  ASSERT_TRUE(status.ok()) << "tree-rebuild graft fail: " << status.error_str();
+
+  // The graft must credit sub: +1 inode, +5000 length.
+  auto deltas = DrainDirStats(fs->GetDirStatManager());
+  ASSERT_TRUE(deltas.count(sub_ino))
+      << "graft produced no dir-stat delta for the grafted-into directory";
+  EXPECT_EQ(deltas[sub_ino].inodes, 1);
+  EXPECT_EQ(deltas[sub_ino].length, 5000);
 }
 
 }  // namespace unit_test

--- a/test/unit/mds/statistics/CMakeLists.txt
+++ b/test/unit/mds/statistics/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(test_mds_statistics
 target_link_libraries(test_mds_statistics
   PROTO_OBJS
 
+  mds_common
   mds_statistics
   mds_storage
 

--- a/test/unit/mds/statistics/test_dir_stat_manager.cc
+++ b/test/unit/mds/statistics/test_dir_stat_manager.cc
@@ -1,0 +1,117 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "mds/statistics/dir_stat_manager.h"
+
+namespace dingofs {
+namespace mds {
+namespace dir_stat {
+
+// These tests exercise only the in-memory delta buffer, so operation_processor
+// and worker_set stay null; the manager just needs an FsInfo to read fs_id from.
+static FsInfoSPtr MakeFsInfo(uint32_t fs_id) {
+  FsInfoEntry entry;
+  entry.set_fs_id(fs_id);
+  return FsInfo::New(entry);
+}
+
+// UpdateDirStat appends to a per-directory log; GetPending folds the log;
+// GetFlushSnapshot reports the summed delta plus the newest timepoint without
+// removing anything.
+TEST(DirStatManagerTest, AccumulateAndSnapshot) {
+  DirStatManager mgr(MakeFsInfo(1000), nullptr, nullptr);
+  mgr.UpdateDirStat(5, 100, 1, 0, "test");
+  mgr.UpdateDirStat(5, -30, 0, 0, "test");
+  mgr.UpdateDirStat(6, 10, 1, 0, "test");
+  EXPECT_EQ(mgr.Size(), 2u);
+
+  EXPECT_EQ(mgr.GetPending(5).length, 70);
+  EXPECT_EQ(mgr.GetPending(5).inodes, 1);
+  EXPECT_EQ(mgr.GetPending(6).length, 10);
+
+  auto snap = mgr.GetFlushSnapshot();
+  ASSERT_EQ(snap.size(), 2u);
+  EXPECT_EQ(snap[5].delta.length, 70);
+  EXPECT_EQ(snap[5].delta.inodes, 1);
+  EXPECT_EQ(snap[6].delta.length, 10);
+  EXPECT_GT(snap[5].timepoint, 0u);
+
+  // GetFlushSnapshot does not remove: the buffer is unchanged.
+  EXPECT_EQ(mgr.Size(), 2u);
+  EXPECT_EQ(mgr.GetPending(5).length, 70);
+}
+
+// Compact pops only the prefix with time_ns <= timepoint; deltas that arrive
+// after the captured timepoint survive (the "delta arrives during flush" case).
+TEST(DirStatManagerTest, CompactKeepsPostTimepointDeltas) {
+  DirStatManager mgr(MakeFsInfo(1000), nullptr, nullptr);
+  mgr.UpdateDirStat(5, 100, 1, 0, "first");
+
+  auto snap = mgr.GetFlushSnapshot();
+  ASSERT_TRUE(snap.count(5));
+  uint64_t timepoint = snap[5].timepoint;
+
+  // a delta appended after the snapshot timepoint must survive the compaction.
+  mgr.UpdateDirStat(5, 7, 0, 0, "during-flush");
+
+  mgr.Compact(5, timepoint);
+
+  // only the post-timepoint delta remains.
+  EXPECT_EQ(mgr.GetPending(5).length, 7);
+  EXPECT_EQ(mgr.GetPending(5).inodes, 0);
+  EXPECT_EQ(mgr.Size(), 1u);
+
+  // compacting past the newest timepoint drains the ino and drops the map entry.
+  mgr.Compact(5, mgr.PeekMaxTimeNs(5));
+  EXPECT_EQ(mgr.Size(), 0u);
+  EXPECT_EQ(mgr.PeekMaxTimeNs(5), 0u);
+}
+
+// PeekMaxTimeNs returns the newest buffered timestamp (0 when empty), and each
+// directory's logical clock is strictly monotonic across its own appends.
+TEST(DirStatManagerTest, MonotonicTimestamps) {
+  DirStatManager mgr(MakeFsInfo(1000), nullptr, nullptr);
+  EXPECT_EQ(mgr.PeekMaxTimeNs(9), 0u);
+
+  mgr.UpdateDirStat(9, 1, 0, 0, "a");
+  uint64_t t1 = mgr.PeekMaxTimeNs(9);
+  mgr.UpdateDirStat(9, 1, 0, 0, "b");
+  uint64_t t2 = mgr.PeekMaxTimeNs(9);
+  EXPECT_GT(t2, t1);
+
+  // Each directory keeps its own clock (mirrors quota's per-Quota last_time_ns_):
+  // a fresh directory just starts a new strictly-increasing sequence. Cross-
+  // directory ordering is neither needed nor guaranteed -- every timestamp
+  // comparison (Compact/flush/reconcile) is scoped to a single directory.
+  mgr.UpdateDirStat(10, 1, 0, 0, "c");
+  uint64_t u1 = mgr.PeekMaxTimeNs(10);
+  EXPECT_GT(u1, 0u);
+  mgr.UpdateDirStat(10, 1, 0, 0, "d");
+  EXPECT_GT(mgr.PeekMaxTimeNs(10), u1);
+}
+
+// Compact on an unknown ino is a no-op (no crash, nothing removed elsewhere).
+TEST(DirStatManagerTest, CompactUnknownInoIsNoop) {
+  DirStatManager mgr(MakeFsInfo(1000), nullptr, nullptr);
+  mgr.UpdateDirStat(5, 100, 1, 0, "test");
+  mgr.Compact(999, 1u << 30);
+  EXPECT_EQ(mgr.Size(), 1u);
+  EXPECT_EQ(mgr.GetPending(5).length, 100);
+}
+
+}  // namespace dir_stat
+}  // namespace mds
+}  // namespace dingofs


### PR DESCRIPTION
Add per-directory usage statistics (files/dirs/length counts) maintained incrementally across all directory-mutating operations, with a periodic flush via UsageStatsSynchronizer and a hot-switchable enable_dir_stats flag.

MDS:
- dir-stat KV codec, store ops (set/get/flush), in-memory delta buffer
- wire deltas into all directory-mutating ops; seed zero record at mkdir
- FileSystem CalcDirStat/GetDirStat/SyncDirStat/GetSummary/GetTreeSummary
- RPC handlers: GetDirStat/GetTreeSummary/SyncDirStat
- tree-summary dir-only semantics; restore-graft dir-stat credit
- fallocate accounting fix; correctness fixes (page-boundary double-count, flush delta loss, stale fast-summary, negative-value guards, DoS guard)
- show EnableDirStats in fsstat dashboard

mds-client:
- dir-stats CLI aligned with info/summary/syncdirstat, --path resolution, humanized summary table; include dir-stat records in fsmeta backup/restore

<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
