### PR TITLE
[feat][client] Enable rados admin socket by default for objecter/perf introspection

### DIFF
--- a/src/common/blockaccess/rados/rados_accesser.cc
+++ b/src/common/blockaccess/rados/rados_accesser.cc
@@ -31,6 +31,7 @@
 #include <variant>
 #include <vector>
 
+#include "common/directory.h"
 #include "common/options/blockaccess.h"
 #include "common/status.h"
 #include "utils/scoped_cleanup.h"
@@ -46,6 +47,12 @@ DEFINE_int64(rados_objecter_inflight_op_bytes, 1048576000,
 DEFINE_int64(rados_ms_async_op_threads, 16, "number of rados async op threads");
 DEFINE_int64(rados_ms_dispatch_throttle_bytes, 1048576000,
              "number of rados ms dispatch throttle bytes");
+
+DEFINE_bool(rados_enable_admin_socket, true,
+            "enable librados admin socket for objecter_requests/perf dump "
+            "introspection; socket goes to the dingofs run dir alongside "
+            "fd_comm_socket: GetDefaultDir(run)/rados.<pid>.asok "
+            "(root -> /var/dingofs/run, non-root -> $HOME/.dingofs/run)");
 
 namespace {
 
@@ -141,6 +148,29 @@ bool RadosAccesser::Init() {
                << FLAGS_rados_ms_dispatch_throttle_bytes
                << ", err: " << strerror(-err);
     return false;
+  }
+
+  // librados admin socket (default on): same dir as dingofs fd_comm_socket via
+  // GetDefaultDir(kSocketDir) -- root -> /var/dingofs/run, non-root ->
+  // $HOME/.dingofs/run -- so it follows whoever runs the process. Keyed by pid.
+  // Non-fatal: a failure here only loses introspection, never blocks mount.
+  if (FLAGS_rados_enable_admin_socket) {
+    const std::string socket_dir = GetDefaultDir(kSocketDir);
+    if (!Helper::CreateDirectory(socket_dir)) {
+      LOG(WARNING)
+          << "Create admin socket dir failed, skip rados admin socket: "
+          << socket_dir;
+    } else {
+      const std::string asok =
+          fmt::format("{}/rados.{}.asok", socket_dir, getpid());
+      int aerr = rados_conf_set(cluster_, "admin_socket", asok.c_str());
+      if (aerr < 0) {
+        LOG(WARNING) << "Set rados admin_socket failed, value: " << asok
+                     << ", err: " << strerror(-aerr);
+      } else {
+        LOG(INFO) << "Rados admin socket enabled: " << asok;
+      }
+    }
   }
 
   err = rados_connect(cluster_);


### PR DESCRIPTION
## What

Enable the librados **admin socket** by default for every `RadosAccesser` consumer (dingo-client / dingo-mds), created in the dingofs runtime dir keyed by pid:

- `GetDefaultDir(kSocketDir)/rados.<pid>.asok`
- root → `/var/dingofs/run/rados.<pid>.asok`
- non-root → `$HOME/.dingofs/run/rados.<pid>.asok`

i.e. the same directory as the existing `fd_comm_socket`, so it follows whoever runs the process.

## Why

The client's high-level block metrics (`block_put_*`, `dingofs_block_*` bvars) can tell you a block put got slow, but not *which OSD/PG/object*, the op age, or whether an op was resent. The librados/Objecter layer already exposes this; it just needs an admin socket:

```
ceph --admin-daemon <asok> perf dump | jq '.objecter'        # op_active/op_w/op_send_bytes/op_latency/op_resend
ceph --admin-daemon <asok> objecter_requests | jq '.ops[]'   # per in-flight op: tid/osd/pg/object/age/attempts
ceph --admin-daemon <asok> config diff                       # effective rados tuning
```

This mirrors the practice Ceph recommends for RBD/OpenStack clients (`[client] admin socket = ...`).

## Details

- New gflag `rados_enable_admin_socket` (default `true`); set `--rados_enable_admin_socket=false` to disable.
- Set via `rados_conf_set("admin_socket", ...)` after `rados_create2()` and before `rados_connect()` (so `common_init_finish()` brings the socket up).
- **Non-fatal**: if the dir can't be created or the conf set fails, it logs a WARNING and continues — it never blocks the mount.
- Overhead is negligible (idle listener thread; Objecter perfcounters are always-on regardless).

## Verified

Built all targets (`make -j`) and deployed MDS + client (rados backend) from this branch:

- **root** mount: asok auto-created at `/var/dingofs/run/rados.<pid>.asok`; `perf dump` / `objecter_requests` / `config diff` / `dump_mempools` all return data; `op_w` / `op_send_bytes` track real writes (64MB → op_w=16, op_resend=0).
- **non-root** mount: asok auto-created at `$HOME/.dingofs/run/rados.<pid>.asok`; same commands work for the running user.

The v5.1 branch carries the identical change in PR #932.