### PR TITLE
[fix][client] Require all parents in trash for IsInodeInTrash

### DIFF
--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -1421,16 +1421,27 @@ Status MDSMetaSystem::GetAttr(ContextSPtr ctx, Ino ino, Attr* attr) {
 bool MDSMetaSystem::IsInodeInTrash(ContextSPtr ctx, Ino ino) {
   AssertStop();
 
+  // An inode is "in trash" only when ALL of its parents are trash buckets,
+  // mirroring the MDS-side gate (mds/filesystem.cc IsInodeInTrash). This is
+  // the deferred-delete-on-last-hardlink model: an inode with a surviving
+  // hardlink in a normal directory keeps that real parent alongside the
+  // sub_trash entry and stays mutable. Note the ALL-of-empty trap -- an
+  // inode with no known parents is NOT in trash.
+  auto all_parents_trashed = [](const auto& parents) {
+    if (parents.empty()) return false;
+    for (auto p : parents) {
+      if (!mds::IsTrashInode(p)) return false;
+    }
+    return true;
+  };
+
   // Hot path: read parents directly from the inode cache (no RPC, no proto
   // round-trip). Cache is populated by Lookup/Open/Unlink and stays in sync
   // with mv-to-trash via PutInodeToCache, so a hit reflects the latest known
   // parent set for this client.
   auto inode = GetInodeFromCache(ino);
   if (inode != nullptr) {
-    for (auto p : inode->Parents()) {
-      if (mds::IsTrashBucketChild(p)) return true;
-    }
-    return false;
+    return all_parents_trashed(inode->Parents());
   }
 
   // Cold cache: fall back to GetAttr (which itself prefers cache, then RPC).
@@ -1439,10 +1450,7 @@ bool MDSMetaSystem::IsInodeInTrash(ContextSPtr ctx, Ino ino) {
   // early-reject guarantee.
   Attr attr;
   if (!GetAttr(ctx, ino, &attr).ok()) return false;
-  for (auto p : attr.parents) {
-    if (mds::IsTrashBucketChild(p)) return true;
-  }
-  return false;
+  return all_parents_trashed(attr.parents);
 }
 
 Status MDSMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,

--- a/src/client/vfs/metasystem/meta_system.h
+++ b/src/client/vfs/metasystem/meta_system.h
@@ -165,10 +165,12 @@ class MetaSystem {
 
   virtual Status GetAttr(ContextSPtr ctx, Ino ino, Attr* attr) = 0;
 
-  // True iff `ino` lives directly under a sub-trash hour bucket (any parent
-  // satisfies `mds::IsTrashBucketChild`). Implementations should answer from
-  // local inode cache when possible to avoid a GetAttr round-trip on the Open
-  // hot path. Default returns false for backends without trash semantics.
+  // True iff `ino` is fully in trash, i.e. ALL of its parents are trash
+  // buckets (mirrors the MDS-side gate). An inode with a surviving hardlink
+  // in a normal directory keeps a real parent and stays mutable, so it is
+  // NOT in trash. Implementations should answer from local inode cache when
+  // possible to avoid a GetAttr round-trip on the Open hot path. Default
+  // returns false for backends without trash semantics.
   virtual bool IsInodeInTrash(ContextSPtr ctx, Ino ino) {
     (void)ctx;
     (void)ino;


### PR DESCRIPTION
Client IsInodeInTrash used an ANY-parent check, so a live file with a surviving hardlink in a normal directory (parents = [normal, sub_trash]) was wrongly treated as trashed and rejected at open for write/truncate with EPERM. Switch to an ALL-parents-in-trash check to mirror the MDS gate (mds/filesystem.cc), the deferred-delete-on-last-hardlink model. Guard the ALL-of-empty trap: an inode with no known parents is not in trash.

<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
