### PR TITLE
FUSE client hot-upgrade: controlled drain, READY/NACK handover, teardown fixes

### DIFF
--- a/docs/designs/dingofs-hot-upgrade-implementation.md
+++ b/docs/designs/dingofs-hot-upgrade-implementation.md
@@ -1,0 +1,359 @@
+# DingoFS dingo-client 热升级实现说明
+
+## 1. 结论
+
+DingoFS 这版热升级做的是同一条 FUSE connection 上的进程接管：挂载点不重新 mount，`/dev/fuse` fd 通过 UDS 传给新 dingo-client，新进程用 `/dev/fd/N` 复用旧连接继续服务。
+
+相对早期“传 fd 后让旧进程退出”的做法，当前代码补了几个控制点：
+
+- 旧进程不再收到裸 SIGHUP 就立刻退出，而是先确认新进程已经通过 UDS 发送 `kPrepare`。
+- 旧进程通过 libfuse controlled drain 停止继续读新请求，并等待已经读出的请求处理完。
+- drain 成功后，旧进程执行 `Stop(handover=true)`，释放运行时资源并 dump VFS 状态。
+- 新进程复用旧进程传来的 `/dev/fuse` fd 和 INIT buffer，再加载旧进程 dump 的状态。
+- drain 或 prepare 阶段失败时，旧进程可以 `resume_receive` 继续服务。
+
+这版还不是完整事务化热升级。分水岭在 checkpoint：一旦进入 `Stop(true) + Dump`，old 已经拆掉 VFS，后面 new 失败时 old 不能自动恢复服务。
+
+## 2. 早期热升级流程
+
+早期流程的基础是复用 FUSE connection，而不是重新 mount：
+
+1. 旧进程正常 mount，持有 `/dev/fuse` fd。
+2. 旧进程在 UDS 上等待新进程连接。
+3. 新进程从挂载点 `.stats` 中找到旧进程 pid 和 UDS path。
+4. 新进程连接旧进程 UDS，通过 `SCM_RIGHTS` 接收 `/dev/fuse` fd，同时接收旧进程保存的 INIT request buffer。
+5. 新进程给旧进程发 SIGHUP。
+6. 旧进程收到 SIGHUP 后退出 FUSE loop，不卸载真实挂载点，执行 VFS `Stop(true)` 并 dump 状态。
+7. 新进程用 `/dev/fd/N` 调用 `fuse_session_mount()`，让 libfuse 复用这条已存在的 FUSE connection。
+8. 新进程 replay INIT buffer，触发自己的 `FuseOpInit()`，再从旧进程 dump 的状态文件恢复 VFS。
+
+fd handoff 能保住 FUSE connection，靠的是内核 `struct file` 引用计数和 `SCM_RIGHTS` 传 fd 时的引用接力。只要 old 把 `/dev/fuse` fd 传给 new，并且 new 在 old 退出前成功持有这个 fd，内核侧 FUSE connection 就不会因为 old 进程退出而立刻消失。
+
+### 2.1 早期流程的问题
+
+这个流程可以跑通正常接管，但并发 IO 和失败路径上有几个问题。
+
+#### 2.1.1 没有受控 drain，已读请求可能丢失
+
+先看 FUSE 请求的位置：
+
+- pending：仍在内核 FUSE connection 队列中，任何持有 fd 的服务进程后续都可能读到。
+- processing：旧进程已经从 `/dev/fuse` read 出来，但还没有 reply。
+
+fd handoff 只能保证 pending 请求还在内核队列里。old 已经 read 出来的 processing 请求已经离开内核 pending 队列，新进程拿到同一个 fd 也读不到。old 如果在这些请求 reply 前退出，对应应用 syscall 可能长时间阻塞或失败。
+
+clone fd 模式下问题更复杂：不同 worker 可能阻塞在不同 fuse_dev 上。只看主 fd 或只调用 `fuse_session_exit()`，不能证明所有 clone worker 都已经停止读请求，也不能证明所有已读请求都已经 reply。
+
+#### 2.1.2 裸 SIGHUP 语义过弱
+
+旧设计里 SIGHUP 同时承担“触发升级”和“让旧进程退出”的含义。问题是：
+
+- 如果没有真实的新进程连接，裸 SIGHUP 也可能让旧进程进入退出流程。
+- 旧进程不知道新进程是否已经拿到 fd。
+- 旧进程不知道新进程是否真的准备接管。
+- 失败路径缺少明确的 NACK/resume 语义。
+
+热升级需要的是一个协议状态机，而不是一个裸信号。
+
+## 3. 设计要点
+
+当前实现按 checkpoint 分界：checkpoint 前失败，old 尽量回到正常服务；checkpoint 后失败，不再承诺自动回滚。
+
+### 3.1 fd handoff 只解决连接保活，不解决请求安全
+
+`SCM_RIGHTS` 传 `/dev/fuse` fd 只是复制 fd 引用，让新进程也持有同一条 FUSE connection。它能避免旧进程退出时连接立刻断开，但不能处理旧进程已经 read 出来的请求。
+
+所以 fd handoff 只是前提，请求安全靠 controlled drain。
+
+### 3.2 controlled drain 解决“旧进程手里还有请求”的问题
+
+旧进程在退出前需要：
+
+1. 暂停继续从 FUSE fd 读取新请求。
+2. 等已经 read 出来的请求全部处理完成。
+3. 确认 worker 不再阻塞在 read 路径上继续拿新请求。
+4. 成功后才允许进入 checkpoint。
+
+DingoFS 用 libfuse controlled drain 接口完成这件事：
+
+- `fuse_session_pause_receive`
+- `fuse_session_resume_receive`
+- `fuse_session_received_inflight`
+- `fuse_session_wait_drained`
+
+同时，DingoFS 侧用周期性 `statfs(mountpoint)` 作为 wakeup 手段，把阻塞在 read 上的 worker 顶出来，让它们回到 pause 检查点。
+
+这里有一个实现细节：statfs wakeup 线程不能在 drain 返回路径上 join。session 已经 pause 后，statfs 请求可能进了 FUSE pending 队列但没人读；如果 drain 超时路径 join 这个线程，controller 会卡在 join，后续 `kNack` 和 `ResumeReceive()` 都发不出去。当前处理是 stop + detach，等 resume 或新进程接管后，pending statfs 被处理，线程再自己退出。
+
+### 3.3 UDS 握手替代裸 SIGHUP
+
+新设计里，SIGHUP 只是唤醒旧进程 handover controller 的手段，不再单独代表“开始升级”。
+
+升级协议由 UDS 上的 4 字节 magic message 表示：
+
+| 消息 | 含义 |
+|---|---|
+| `kPrepare` | 新进程已经连接并准备接管，请旧进程进入 handover 流程 |
+| `kReadyToExit` | 旧进程已经完成 drain 和 checkpoint，准备退出 |
+| `kNack` | 旧进程拒绝本次 handover，新进程应失败退出 |
+
+这避免了“一个信号就触发退出”的问题。SIGHUP 到达后，old 还必须能从当前 UDS peer 上读到 `kPrepare`，否则不会进入 drain。
+
+当前代码时序如下，不是理想两阶段设计：
+
+1. 旧进程 UDS server `accept()` 新连接。
+2. 在发送 fd 之前先检查是否已经 committed、是否已有 live handover、INIT buffer 是否已经保存。
+3. 旧进程先 `SetClientFd(client_fd)`。
+4. 旧进程立刻通过 `SendFd()` 把 `/dev/fuse` fd 和 INIT buffer 发给新进程。
+5. 新进程收到 fd 后，才在同一条 UDS 连接上发送 `kPrepare`。
+6. 新进程随后 `kill(old_pid, SIGHUP)`，唤醒旧进程 controller。
+7. 旧进程 controller 收到 SIGHUP 后，必须从已保存的 `client_fd_` 上读到 `kPrepare`，否则忽略这次 SIGHUP。
+
+当前代码是：**fd/INIT 先给 new，new 先持有连接引用；`kPrepare + SIGHUP` 才触发 old drain**。fd 先给只是为了保住内核连接，不表示服务权已经切走。
+
+### 3.4 checkpoint 负责把用户态状态转移给新进程
+
+drain 只处理 FUSE 请求，不迁移 DingoFS 用户态状态。还需要迁移：
+
+- client id
+- mount root 信息
+- open handle 的身份信息
+- metadata system 状态
+- epoch / first start time
+
+当前 checkpoint 由 `FuseOpInit()` 注册，实际执行的是 `g_vfs->Stop(handover=true)`。`VFSWrapper::Stop(true)` 先调用底层 VFS stop，再 dump 状态文件。new 在 `VFSWrapper::Start(config, upgrade_from_pid)` 中读取该状态。
+
+### 3.5 checkpoint 前的失败处理
+
+新设计已经能处理 checkpoint 前的失败：
+
+- 没有 `kPrepare`：旧进程忽略 SIGHUP，继续服务。
+- drain 超时：旧进程发 `kNack`，`resume_receive`，继续服务。
+- handover peer 失效：新进程连接 UDS 后提前退出、关闭连接，或没有在超时时间内发送有效 `kPrepare`；旧进程关闭 handover client fd，不进入 drain/checkpoint，继续服务。
+
+checkpoint 之后的不可回滚场景统一放到“当前限制”里说明。
+
+## 4. 当前代码实现
+
+这一节只保留和实现关系最紧的主链路。细节按代码入口分散在 `fuse_server`、`handover_*`、`vfs_wrapper`、`vfs_hub` 和 `handle_manager` 中。
+
+### 4.1 主流程图
+
+```mermaid
+sequenceDiagram
+  participant New as new dingo-client
+  participant Old as old dingo-client
+  participant Conn as kernel FUSE connection
+  participant State as state file
+
+  Old->>Conn: normal serve
+  New->>Old: connect UDS
+  Old-->>New: /dev/fuse fd + INIT buffer
+  New->>Old: kPrepare
+  New->>Old: SIGHUP
+  Old->>Conn: pause receive + wait drained
+  alt drain or prepare failed
+    Old-->>New: kNack
+    Old->>Conn: resume receive
+    Old->>Conn: keep serving
+  else drained
+    Old->>State: Stop(true) + Dump
+    Old-->>New: kReadyToExit
+    Old->>Conn: exit old session
+    New->>Conn: mount /dev/fd/N + replay INIT
+    New->>State: Load old state
+    New->>Conn: serve
+  end
+```
+
+这张图只画进程边界和内核连接的交互。注意两个时序点：
+
+- old 侧是在 `SaveOpInitMsg()` 成功后才启动 UDS server，新进程不会拿到空 INIT。
+- `kReadyToExit` 是 old 的最终 READY 通知。发送这条消息前 old 已经完成 `Stop(true) + Dump`，发送后不再等待 new 回应，而是退出 old session。
+
+### 4.1.1 old 进程内部流程
+
+```mermaid
+flowchart LR
+  Start["启动完成"]
+  Serve["Serving<br/>保存 INIT<br/>启动 UDS"]
+  Prep{"收到有效<br/>kPrepare?"}
+  Drain["Draining<br/>PauseReceive<br/>WaitDrained"]
+  Drained{"drained?"}
+  Abort["Abort<br/>kNack<br/>ResumeReceive"]
+  Checkpoint["Checkpoint<br/>Stop(true)<br/>Dump state"]
+  Ready{"READY<br/>发送成功?"}
+  Exit["Exit<br/>session Exit"]
+
+  Start --> Serve --> Prep
+  Prep -- no --> Serve
+  Prep -- yes --> Drain --> Drained
+  Drained -- no --> Abort --> Serve
+  Drained -- yes --> Checkpoint --> Ready
+  Ready -- yes --> Exit
+  Ready -- no --> Exit
+
+  subgraph Rollback["checkpoint 前：old 仍可继续服务"]
+    Serve
+    Prep
+    Drain
+    Drained
+    Abort
+  end
+
+  subgraph NoRollback["checkpoint 后：VFS 已 teardown"]
+    Checkpoint
+    Ready
+    Exit
+  end
+```
+
+old 侧的回滚边界在 checkpoint 之前。`WaitHandoverPrepare()` 或 drain 失败时，old 不进入 `Stop(true)`；checkpoint 之后，VFS 已经拆掉，失败不再能自动恢复到继续服务。
+
+### 4.1.2 new 进程内部流程
+
+```mermaid
+flowchart LR
+  Start["SessionMount"]
+  Discover["Discover old<br/>读取 .stats<br/>找到 pid / UDS"]
+  HoldFd["Hold fd<br/>接收 /dev/fuse fd<br/>接收 INIT buffer"]
+  WaitOld["Wait old<br/>kPrepare + SIGHUP"]
+  Ready{"收到<br/>kReadyToExit?"}
+  MountFd["Mount fd<br/>fuse_session_mount<br/>/dev/fd/N"]
+  ReplayInit["Replay INIT<br/>SessionLoop"]
+  LoadState["Load state<br/>VFS Start<br/>upgrade_from_pid"]
+  Serving["Serving"]
+  Failed["Failed<br/>挂载流程失败"]
+
+  Start --> Discover --> HoldFd --> WaitOld --> Ready
+  Ready -- no --> Failed
+  Ready -- yes --> MountFd --> ReplayInit --> LoadState --> Serving
+  MountFd -- fail --> Failed
+  ReplayInit -- fail --> Failed
+  LoadState -- fail --> Failed
+
+  subgraph BeforeReady["READY 前：new 持有 fd，但不能服务"]
+    Discover
+    HoldFd
+    WaitOld
+    Ready
+  end
+
+  subgraph AfterReady["READY 后：开始本地接管"]
+    MountFd
+    ReplayInit
+    LoadState
+    Serving
+  end
+```
+
+new 侧 `Handshake()` 成功只表示已经收到 old 的 `kReadyToExit`。`/dev/fd/N` mount、INIT replay、VFS Load 都在 `TakeOver()` 返回之后。`TakeOver()` 内部失败会关闭收到的 fd；`TakeOver()` 成功后的 mount/load 失败属于后续挂载流程失败，通常需要进程退出或人工处理。
+
+### 4.2 失败行为
+
+这一节按回滚边界看，不按函数调用点逐条展开。
+
+1. **prepare 没成立**
+
+   典型场景：old 收到 SIGHUP，但 UDS 上没有有效 `kPrepare`；或者 new 连接 UDS 后退出、关闭连接、超时不发 `kPrepare`。
+
+   old 不进入 drain，也不执行 checkpoint。`HandoverController` 忽略这次 handover，或者关闭当前 handover client fd 后继续服务。
+
+   new 如果还在，会在等待 old 消息时失败；如果已经退出，本次接管自然结束。
+
+2. **drain 没成功**
+
+   典型场景：`WaitDrained(timeout)` 超时，或者 controlled drain 返回失败。
+
+   old 发送 `kNack`，调用 `ResumeReceive()`，状态切回 `kFuseNormal`，继续服务。statfs wakeup 线程在这里只 stop + detach，不 join，避免 controller 卡死在 pending statfs 上。
+
+   new 收到 `kNack` 后 `TakeOver()` 失败，关闭已经收到的 `/dev/fuse` fd，并退出本次挂载流程。
+
+3. **checkpoint 期间 peer 断开**
+
+   典型场景：drain 已经成功，old 进入 `Stop(true) + Dump`，但 new 在这段时间退出或关闭 UDS。
+
+   old 已经过了可回滚点。等 old 走到 commit 阶段，`kReadyToExit` 可能发送失败；当前代码只记录错误，然后继续 `session_->Exit()`，不会 resume。
+
+   new 收不到 READY，本次 `TakeOver()` 失败。如果 new 已经退出，最终 old/new 都不会继续服务这个 mount，需要重挂或人工介入。
+
+4. **READY 后 new 本地接管失败**
+
+   典型场景：new 已经收到 `kReadyToExit`，但后续 `fuse_session_mount(/dev/fd/N)`、INIT replay 或 VFS state load 失败。
+
+   old 在发送 READY 前已经完成 checkpoint，发送 READY 后也不会等 new 回应，已经退出或正在退出。new 本地接管失败后，没有 old 可以自动接回服务，需要重挂或人工介入。
+
+## 5. 当前已经补上的问题
+
+| 分类 | 早期问题 | 当前处理 |
+|---|---|---|
+| 协议触发与反馈 | 裸 SIGHUP 触发语义弱，失败路径缺少明确反馈 | SIGHUP 只唤醒 controller；是否进入交接取决于 UDS `kPrepare`，结果通过 `kReadyToExit` / `kNack` 表达 |
+| 请求 drain 安全 | 已读请求可能丢失；worker 卡在 read 时，单纯 pause 不足以证明可交接 | 引入 libfuse controlled drain；DingoFS 侧周期性 statfs wakeup，并以 `WaitDrained()` 作为交接判断 |
+| drain 超时恢复 | statfs wakeup 线程可能卡在 paused session 的 pending statfs 上，join 会卡死 controller | drain 成功和超时路径都 stop + detach wakeup 线程；超时后 controller 继续发送 `kNack` 并 `ResumeReceive()` |
+| 失败回滚 | drain 失败后旧进程无法恢复服务 | checkpoint 前失败会发送 `kNack`，调用 `ResumeReceive()`，状态回到 `kFuseNormal` |
+| 状态文件可靠性 | 状态文件在 `/tmp`，且存在半写风险 | 改到 data dir，并采用 temp + fsync + rename + fsync dir 原子发布 |
+| INIT buffer 生命周期 | 保存 INIT 后没有释放 public receive buffer | `SaveOpInitMsg()` 处理完 INIT 后正确 `free(fbuf.mem)` |
+
+## 6. 当前限制
+
+当前实现不是完整事务化热升级。原因很具体：checkpoint 仍然是 `Stop + Dump`，并且发生在 `kReadyToExit` 之前。一旦 checkpoint 执行，old 的 VFS 已经拆掉，后续 new 失败时，old 无法恢复服务。
+
+所以这版适合的前提是：MDS 和对象后端健康、同一挂载点只做一次升级、old/new 状态格式兼容。在这些前提下，它可以做 graceful handover；它不能覆盖任意失败点。
+
+### 6.1 checkpoint 后不可回滚
+
+checkpoint 现在执行的是 `Stop(true)`。这一步会拆 VFS 组件、释放 handle 运行时资源，并 dump 状态。它不是“只 flush 不 teardown”的可回滚 gate。
+
+因此：
+
+- checkpoint 前失败可以回滚：例如没有有效 `kPrepare`、drain 超时、handover peer 失效，old 会忽略本次 handover，或者 `ResumeReceive()` 后回到 `kFuseNormal` 继续服务。
+- checkpoint 后失败不能自动回滚：`Stop(true)` 已经拆掉 VFS，old 不再具备完整恢复服务的条件。典型场景包括 dump 失败导致 old 侧 fatal、old 发送 `kReadyToExit` 失败后仍继续退出、new 收到 READY 后 mount/load 失败。
+
+### 6.2 READY 不是 new 已经可服务
+
+old 发送 `kReadyToExit` 前已经完成 Stop/Dump。new 收到 `kReadyToExit` 后，`Handshake()` 就返回成功，随后才继续做：
+
+- 成功 mount `/dev/fd/N`
+- 成功 replay INIT
+- 成功 load VFS state
+- 进入 serving 状态
+
+所以 `kReadyToExit` 的语义只是：old 已经完成 checkpoint，准备退出。它不表示 new 已经可服务。
+
+代码里 `NotifyReadyToExit()` 只发送一次 `kReadyToExit`，不等 new 回应。发送成功后 old 继续 `session_->Exit()`；发送失败也只是记录错误，然后继续退出。READY 发送失败通常意味着 new 已经退出、关闭 UDS，或者接管流程中断。因为这个调用点已经在 checkpoint 之后，old 没有完整恢复服务的条件，所以这个场景下 old/new 都不会继续服务，需要重挂或人工介入。
+
+如果 new 在收到 READY 后 mount/load 失败，old 已经退出或正在退出，new 也没有完成接管，挂载点同样需要重挂或人工介入。要把这条路径做成强事务，teardown 必须后移到 new mount/load ready 之后。
+
+### 6.3 metadata flush 无界问题仍是生产约束
+
+当前 checkpoint 进入 `Stop()` 后，metadata flush 如果遇到 MDS 长时间不可达，可能无界等待。这样会造成：
+
+- old 卡在 checkpoint。
+- new 等不到 `kReadyToExit`。
+- 挂载点可能进入长时间不可用或半升级状态。
+
+所以当前版本应该只在 MDS 和对象后端健康时做热升级。
+
+### 6.4 handle 恢复失败只记录 error
+
+HandleManager dump 的是 `ino/fh/flags`。new load 时会逐个调用 `NewHandle(fh, ino, flags)` 重建 handle 运行态。
+
+按最新代码看，`FileReader::Open()` 和 `FileWriter::Open()` 目前基本只初始化后台任务并返回 OK，所以常规路径下 handle load 不太容易失败。`NewHandle()` 返回空的路径主要是：
+
+- writable handle 重建 writer 时，`WriterTable::AcquireWriter()` 发现 writer table 已经 stopped；
+- `FileWriter::Open()` 或后续 reader/writer open 逻辑如果变成真实资源初始化，可能返回失败；
+- `HandleManager::AddHandle()` 发现 handle manager 已经 stopped。
+
+当前代码的选择是：如果某个 `NewHandle()` 返回空，`HandleManager::Load()` 只打印 `LOG(ERROR)`，然后 `continue` 处理后面的 handle，最后仍然可能 `return true`。这里不是 fail-stop 语义，而是“尽量恢复，失败项记日志”。
+
+如果出现单个 fh 恢复失败，内核侧可能仍持有这个 fh，但 new 用户态没有对应 handle，后续访问会表现为 bad fd 或异常 IO。当前实现接受这个风险，不把它作为整体接管失败条件。
+
+### 6.5 状态格式缺少 schema version
+
+状态文件还需要补 `schema_version` 和兼容性校验。跨版本热升级时，如果状态字段新增、删除或语义变化，new 应该能明确判断“可兼容读取”还是“拒绝接管”，而不是只靠发布和部署策略保证 old/new 状态格式一致。
+
+## 7. 总结
+
+DingoFS 当前实现已经不再是简单 fd handoff。它有 UDS prepare、controlled drain、checkpoint、READY/NACK 和 checkpoint 前的回滚路径，能避免早期“old 直接退出导致已读请求丢失”的主要问题。
+
+使用上要记住分水岭：checkpoint 前失败，old 可以继续服务；checkpoint 后失败，就需要重挂或人工介入。后续要补的是独立的、有界的 `FlushForHandover`，以及 teardown-after-ready 的强提交语义。

--- a/src/client/fuse/CMakeLists.txt
+++ b/src/client/fuse/CMakeLists.txt
@@ -15,6 +15,10 @@
 add_library(fuse_client_lib
     fuse_op.cc
     fuse_server.cc
+    upgrade/handover_client.cc
+    upgrade/handover_controller.cc
+    upgrade/handover_server.cc
+    upgrade/handover_session_impl.cc
 )
 
 target_link_libraries(fuse_client_lib

--- a/src/client/fuse/fuse_op.cc
+++ b/src/client/fuse/fuse_op.cc
@@ -28,7 +28,7 @@
 #include "absl/strings/str_format.h"
 #include "client/common/const.h"
 #include "client/fuse/fs_context.h"
-#include "client/fuse/fuse_upgrade_manager.h"
+#include "client/fuse/upgrade/state_store.h"
 #include "client/vfs/common/helper.h"
 #include "client/vfs/data_buffer.h"
 #include "client/vfs/vfs_meta.h"
@@ -49,8 +49,8 @@ USING_FLAG(fuse_enable_parallel_dirops)
 USING_FLAG(fuse_dryrun_bench_mode)
 
 using dingofs::Status;
-using dingofs::client::fuse::FuseUpgradeManager;
 using dingofs::client::fuse::FuseUpgradeState;
+using dingofs::client::fuse::UpgradeStateStore;
 using dingofs::client::vfs::Attr;
 using dingofs::client::vfs::Attr2Str;
 using dingofs::client::vfs::FsStat;
@@ -393,9 +393,9 @@ void FuseOpInit(void* userdata, struct fuse_conn_info* conn) {
 
   g_vfs = new dingofs::client::VFSWrapper();
   int upgrade_from_pid = 0;
-  if (FuseUpgradeManager::GetInstance().GetFuseState() ==
+  if (UpgradeStateStore::GetInstance().GetFuseState() ==
       FuseUpgradeState::kFuseUpgradeNew) {
-    upgrade_from_pid = FuseUpgradeManager::GetInstance().GetOldFusePid();
+    upgrade_from_pid = UpgradeStateStore::GetInstance().GetOldFusePid();
   }
   Status s = g_vfs->Start(config, upgrade_from_pid);
   if (!s.ok()) {
@@ -403,6 +403,25 @@ void FuseOpInit(void* userdata, struct fuse_conn_info* conn) {
     fs_context->fuse_server->Shutdown();
     return;
   }
+
+  // Handover checkpoint: stop the VFS (which flushes dirty data + metadata
+  // internally) and dump state for the new process. We are past the drain here
+  // and tearing down, so there is no rollback: a stop/dump failure cores.
+  //
+  // CONSTRAINT: the metadata flush inside vfs Stop
+  // (MDSMetaSystem::FlushAllFile) is currently UNBOUNDED -- it hangs forever if
+  // the MDS is unreachable. So a bounded, fail-closed flush gate that could
+  // abort-and-resume is NOT possible yet; that needs the metasystem to make the
+  // flush bounded (decision A). Until then: only upgrade while the MDS is
+  // healthy. See handover-ack-handshake-design.md /
+  // dingofs-hotupgrade-constraints.md.
+  fs_context->fuse_server->SetHandoverCheckpoint([]() -> Status {
+    Status s = g_vfs->Stop(/*handover=*/true);
+    if (!s.ok()) {
+      LOG(FATAL) << "hot-upgrade: stop/dump failed";
+    }
+    return Status::OK();
+  });
 
   InitFuseConnInfo(conn);
 
@@ -414,7 +433,7 @@ void FuseOpInit(void* userdata, struct fuse_conn_info* conn) {
 void FuseOpDestroy(void* userdata) {
   VLOG(1) << "FuseOpDestroy userdata: " << userdata;
   if (g_vfs) {
-    const bool handover = (FuseUpgradeManager::GetInstance().GetFuseState() ==
+    const bool handover = (UpgradeStateStore::GetInstance().GetFuseState() ==
                            FuseUpgradeState::kFuseUpgradeOld);
     g_vfs->Stop(handover);
     delete g_vfs;

--- a/src/client/fuse/fuse_server.cc
+++ b/src/client/fuse/fuse_server.cc
@@ -286,13 +286,23 @@ int FuseServer::SaveOpInitMsg() {
     memcpy(init_fbuf_.mem, fbuf.mem, fbuf.size);
     fuse_session_process_buf(session_, &fbuf);
 
+    // fbuf.mem is allocated by the public fuse_session_receive_buf via a plain
+    // malloc (internal=false); process_buf only reads it and never takes
+    // ownership, so it must be freed here. Use free(), NOT fuse_buf_free():
+    // the latter reverses an internal aligned-alloc offset and would free a
+    // wrong pointer for an externally allocated buffer. INIT (~56B) is never
+    // spliced, so the buffer is always a memory buffer.
+    CHECK(!(fbuf.flags & FUSE_BUF_IS_FD)) << "INIT buf unexpectedly IS_FD";
+    free(fbuf.mem);
+
     return 0;
   }
 
-  // here shouble call fuse_buf_free(&fbuf);
-  // but function fuse_buf_free in libfuse is private, so we can not call it.
-  // In special case, there may be a memory leak here,but rarely occurs and
-  // can be tolerated. fuse_buf_free(&fbuf);
+  // receive_buf may have allocated fbuf.mem before the read failed; free it on
+  // the error path too (this branch previously leaked).
+  if (fbuf.mem != nullptr) {
+    free(fbuf.mem);
+  }
   fuse_session_reset(session_);
 
   return 1;

--- a/src/client/fuse/fuse_server.cc
+++ b/src/client/fuse/fuse_server.cc
@@ -17,24 +17,27 @@
 #include "client/fuse/fuse_server.h"
 
 #include <brpc/reloadable_flags.h>
-#include <sys/socket.h>
 
-#include <chrono>
+#include <cerrno>
 #include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <utility>
 
 #include "absl/strings/str_format.h"
 #include "client/fuse/fuse_common.h"
 #include "client/fuse/fuse_lowlevel_ops_func.h"
-#include "client/fuse/fuse_passfd.h"
-#include "client/fuse/fuse_upgrade_manager.h"
+#include "client/fuse/upgrade/handover_client.h"
+#include "client/fuse/upgrade/handover_controller.h"
+#include "client/fuse/upgrade/handover_server.h"
+#include "client/fuse/upgrade/handover_session_impl.h"
+#include "client/fuse/upgrade/state_store.h"
 #include "common/directory.h"
 #include "common/helper.h"
-#include "common/options/client.h"
+#include "common/status.h"
 #include "fmt/format.h"
 #include "fuse_opt.h"
 #include "glog/logging.h"
-#include "utils/concurrent/concurrent.h"
-#include "utils/scoped_cleanup.h"
 
 using ::dingofs::utils::BufToHexString;
 
@@ -42,20 +45,32 @@ namespace dingofs {
 namespace client {
 namespace fuse {
 
-USING_FLAG(fuse_fd_get_max_retries)
-USING_FLAG(fuse_fd_get_retry_interval_ms)
-USING_FLAG(fuse_check_alive_max_retries)
-USING_FLAG(fuse_check_alive_retry_interval_ms)
-
 // fuse mount options
 DEFINE_string(fuse_mount_options, "default_permissions",
               "mount options for libfuse");
+
 DEFINE_bool(fuse_use_single_thread, false, "use single thread for libfuse");
 DEFINE_validator(fuse_use_single_thread, brpc::PassValidate);
+
 DEFINE_bool(fuse_use_clone_fd, true, "use clone fd for libfuse");
 DEFINE_validator(fuse_use_clone_fd, brpc::PassValidate);
+
 DEFINE_uint32(fuse_max_threads, 64, "max threads for libfuse");
 DEFINE_validator(fuse_max_threads, brpc::PassValidate);
+
+// hot-upgrade controlled drain (#1): the old process drains in-flight FUSE
+// requests and runs the flush+dump checkpoint before exiting on SIGHUP.
+// Declared in common/options/client.h.
+DEFINE_uint32(fuse_hotupgrade_drain_timeout_ms, 30000,
+              "max time to wait for the session to drain before aborting the "
+              "handover and resuming service on the old process");
+DEFINE_uint32(fuse_hotupgrade_statfs_interval_ms, 50,
+              "interval between statfs(2) round-trips used to wake workers "
+              "blocked in read() while draining");
+
+// ===========================================================================
+// Construction / teardown
+// ===========================================================================
 
 FuseServer::FuseServer() = default;
 
@@ -77,11 +92,24 @@ int FuseServer::Init(const std::string& program_name,
   fd_comm_file_ =
       absl::StrFormat("%s/fd_comm_socket.%d", socket_path, getpid());
 
+  // Old-side handover endpoint. Constructed here but only Start()ed in Serve()
+  // after SaveOpInitMsg() fills init_fbuf_, so a connecting new process never
+  // gets an empty INIT. get_dev_fd reads the /dev/fuse fd lazily (the session
+  // is created later, in CreateSession).
+  handover_server_ = std::make_unique<HandoverServer>(
+      fd_comm_file_, [this]() { return GetDevFd(); }, &init_fbuf_);
+
   return 0;
 }
 
 FuseServer::~FuseServer() {
   unlink(fd_comm_file_.c_str());
+
+  // Stop both handover threads BEFORE freeing init_fbuf_: the handover server's
+  // accept loop reads &init_fbuf_ (init_msg_) when handing off, and the
+  // controller drives the server. Stop controller first, then the server.
+  if (handover_controller_) handover_controller_->Stop();
+  if (handover_server_) handover_server_->Stop();
 
   FreeFuseInitBuf();
   fuse_opt_free_args(&args_);
@@ -90,110 +118,15 @@ FuseServer::~FuseServer() {
     fuse_loop_cfg_destroy(config_);
   }
 
-  auto fuse_state = FuseUpgradeManager::GetInstance().GetFuseState();
+  auto fuse_state = UpgradeStateStore::GetInstance().GetFuseState();
   if (fuse_state == FuseUpgradeState::kFuseUpgradeOld) {
     LOG(INFO) << "transfer dingo-client session to others.";
   }
 }
 
-// allocate memory for fuse init message
-void FuseServer::AllocateFuseInitBuf() {
-  // init message size = sizeof(struct fuse_in_header) + sizeof(struct
-  // fuse_init_in),256 bytes is enough
-  init_fbuf_.mem_size = 256;
-  init_fbuf_.size = 0;
-  init_fbuf_.mem = malloc(init_fbuf_.mem_size);
-  memset(init_fbuf_.mem, 0, init_fbuf_.mem_size);
-}
-
-void FuseServer::FreeFuseInitBuf() {
-  if (init_fbuf_.mem != nullptr) {
-    free(init_fbuf_.mem);
-
-    init_fbuf_.mem = nullptr;
-    init_fbuf_.mem_size = 0;
-    init_fbuf_.size = 0;
-  }
-}
-
-int FuseServer::GetDevFd() const { return fuse_session_fd(session_); }
-
-void FuseServer::Shutdown() {
-  LOG(INFO) << "shutdown dingo-client";
-  fuse_session_exit(session_);
-}
-
-void FuseServer::MarkThenShutdown() {
-  LOG(INFO) << "mark dingo-client kFuseUpgradeOld";
-  FuseUpgradeManager::GetInstance().UpdateFuseState(
-      FuseUpgradeState::kFuseUpgradeOld);
-  Shutdown();
-}
-
-void FuseServer::UdsServerFunc() {
-  struct sockaddr_un addr;
-  int server_fd, client_fd;
-  socklen_t addrlen = sizeof(addr);
-
-  // create uds server
-  server_fd = socket(AF_UNIX, SOCK_STREAM, 0);
-  if (server_fd == -1) {
-    LOG(ERROR) << "uds server create failed, file: " << fd_comm_file_
-               << ", error: " << std::strerror(errno);
-    return;
-  }
-  auto defer_close = MakeScopedCleanup([&]() { close(server_fd); });
-  // bind address
-  memset(&addr, 0, sizeof(addr));
-  addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, fd_comm_file_.c_str(), sizeof(addr.sun_path) - 1);
-  unlink(fd_comm_file_.c_str());
-  if (bind(server_fd, (struct sockaddr*)&addr, addrlen) == -1) {
-    LOG(ERROR) << "uds server bind failed,, file: " << fd_comm_file_
-               << ", error: " << std::strerror(errno);
-    return;
-  }
-  // listening
-  if (listen(server_fd, 1) == -1) {
-    LOG(ERROR) << "uds server listen failed, file: " << fd_comm_file_
-               << ", error: " << std::strerror(errno);
-    return;
-  }
-
-  LOG(INFO) << "uds server listening on " << fd_comm_file_;
-  while (true) {
-    // accept uds client
-    client_fd = accept(server_fd, (struct sockaddr*)&addr, &addrlen);
-    if (client_fd == -1) {
-      LOG(ERROR) << "uds server accept failed, error: " << std::strerror(errno);
-      continue;
-    }
-
-    // process uds client request
-    int fuse_fd = GetDevFd();
-    int ret = SendFd(client_fd, fuse_fd, init_fbuf_.mem, init_fbuf_.size);
-    if (ret == -1) {
-      LOG(ERROR) << "send fuse fd failed, client_id: " << client_fd;
-    } else {
-      LOG(INFO) << "fuse fd send to client: " << client_fd
-                << ", fd: " << fuse_fd << ", data size: " << init_fbuf_.size;
-    }
-    close(client_fd);
-  }
-}
-
-void FuseServer::UdsServerStart() {
-  if (is_running_.load()) {
-    LOG(INFO) << "dingo-client uds server already started.";
-    return;
-  }
-
-  uds_thread_ = utils::Thread(&FuseServer::UdsServerFunc, this);
-  uds_thread_.detach();
-  is_running_.store(true);
-
-  LOG(INFO) << "dingo-client uds server started.";
-}
+// ===========================================================================
+// Mount-args / INIT-buffer helpers
+// ===========================================================================
 
 int FuseServer::AddMountOptions() {
   CHECK(!program_name_.empty()) << "program_name_ should not be empty";
@@ -217,6 +150,31 @@ int FuseServer::AddMountOptions() {
   return 0;
 }
 
+// allocate memory for fuse init message
+void FuseServer::AllocateFuseInitBuf() {
+  // init message size = sizeof(struct fuse_in_header) + sizeof(struct
+  // fuse_init_in),256 bytes is enough
+  init_fbuf_.mem_size = 256;
+  init_fbuf_.size = 0;
+  init_fbuf_.mem = malloc(init_fbuf_.mem_size);
+  memset(init_fbuf_.mem, 0, init_fbuf_.mem_size);
+}
+
+void FuseServer::FreeFuseInitBuf() {
+  if (init_fbuf_.mem != nullptr) {
+    free(init_fbuf_.mem);
+
+    init_fbuf_.mem = nullptr;
+    init_fbuf_.mem_size = 0;
+    init_fbuf_.size = 0;
+  }
+}
+
+// ===========================================================================
+// FUSE session lifecycle: CreateSession -> SessionMount -> Serve ->
+// SessionUnmount -> DestroySession
+// ===========================================================================
+
 int FuseServer::CreateSession(void* usedata) {
   // create fuse new session
   session_ = fuse_session_new(&args_, &kFuseOp, sizeof(kFuseOp), usedata);
@@ -228,15 +186,6 @@ int FuseServer::CreateSession(void* usedata) {
   return 0;
 }
 
-void FuseServer::DestroySsesion() {
-  LOG(INFO) << "destroy dingo-client session.";
-
-  if (session_ != nullptr) {
-    fuse_remove_signal_handlers(session_);
-    fuse_session_destroy(session_);
-  }
-}
-
 int FuseServer::SessionMount() {
   std::string mountpoint = mount_option_->mount_point;
 
@@ -244,18 +193,27 @@ int FuseServer::SessionMount() {
                            mount_option_->fs_name, mountpoint);
 
   if (CanShutdownGracefully(mountpoint)) {
-    bool is_shutdown = ShutdownGracefully(mountpoint);
-    if (!is_shutdown) {
+    // Take over the mount from the old dingo-client: receive its /dev/fuse fd
+    // (and INIT message into init_fbuf_) and run the handover handshake.
+    HandoverClient client;
+    int fuse_fd = client.TakeOver(mountpoint, &init_fbuf_);
+    if (fuse_fd <= 2) {
       LOG(ERROR) << "smooth upgrade failed, can't mount on: " << mountpoint;
       return 1;
     }
     LOG(INFO) << "old dingo-client is already shutdown";
     // new fuse processes
-    FuseUpgradeManager::GetInstance().UpdateFuseState(
+    UpgradeStateStore::GetInstance().UpdateFuseState(
         FuseUpgradeState::kFuseUpgradeNew);
 
-    // construct new mountpoint
-    mountpoint = absl::StrFormat("/dev/fd/%d", fuse_fd_);
+    // Reuse the received /dev/fuse fd: mounting on /dev/fd/N attaches to the
+    // existing kernel mount instead of creating a new one. OWNERSHIP: on a
+    // successful fuse_session_mount below, libfuse adopts this fd as se->fd
+    // (fuse_lowlevel.c: `se->fd = fd`, no dup) and closes it in
+    // fuse_session_destroy. So FuseServer must NOT close it (would
+    // double-close) nor hold it past mount. (On mount failure the process
+    // aborts, so the fd leaks only in a terminal path.)
+    mountpoint = absl::StrFormat("/dev/fd/%d", fuse_fd);
   }
 
   LOG(INFO) << "start mount on: " << mountpoint;
@@ -270,7 +228,7 @@ int FuseServer::SessionMount() {
 int FuseServer::SaveOpInitMsg() {
   // smooth upgrade do not save fuse init message
   // it's recv from old dingo-client
-  auto fuse_state = FuseUpgradeManager::GetInstance().GetFuseState();
+  auto fuse_state = UpgradeStateStore::GetInstance().GetFuseState();
   if (fuse_state == FuseUpgradeState::kFuseUpgradeNew) return 0;
 
   struct fuse_buf fbuf = {
@@ -317,7 +275,7 @@ void FuseServer::ProcessInitMsg() {
 }
 
 int FuseServer::SessionLoop() {
-  auto fuse_state = FuseUpgradeManager::GetInstance().GetFuseState();
+  auto fuse_state = UpgradeStateStore::GetInstance().GetFuseState();
   if (fuse_state == FuseUpgradeState::kFuseUpgradeNew) {
     ProcessInitMsg();
   }
@@ -332,17 +290,9 @@ int FuseServer::SessionLoop() {
   return fuse_session_loop_mt(session_, config_);
 }
 
-void FuseServer::ExportMetrics(const std::string& key,
-                               const std::string& value) {
-  fd_comm_metrics_.set_value(value);
-  fd_comm_metrics_.expose(butil::StringPiece(key));
-}
-
 int FuseServer::Serve() {
   // export fd_comm_path value for new dingo-client use
   ExportMetrics(kFdCommPathKey, fd_comm_file_);
-
-  UdsServerStart();
 
   LOG(INFO) << fmt::format(
       "dingo-client start loop, singlethread={} max_threads={}.",
@@ -352,6 +302,12 @@ int FuseServer::Serve() {
     LOG(ERROR) << "save fuse init message failed";
     return 1;
   }
+
+  // Start the handover endpoint only AFTER the INIT message is saved, so a new
+  // process can never connect and receive an empty INIT. (init_fbuf_ is already
+  // filled by the upgrade-takeover path for the new process.)
+  handover_server_->Start();
+
   /* Block until ctrl+c or fusermount -u */
   int ret = SessionLoop();
   LOG(INFO) << "dingo-client is shutdown, ret=" << ret;
@@ -360,7 +316,7 @@ int FuseServer::Serve() {
 }
 
 void FuseServer::SessionUnmount() {
-  auto fuse_state = FuseUpgradeManager::GetInstance().GetFuseState();
+  auto fuse_state = UpgradeStateStore::GetInstance().GetFuseState();
 
   if (fuse_state == FuseUpgradeState::kFuseUpgradeOld) {
     LOG(INFO)
@@ -380,65 +336,73 @@ void FuseServer::SessionUnmount() {
   }
 }
 
-// TODO: check the fstype to determain the dingo-client
-bool FuseServer::ShutdownGracefully(const std::string& mountpoint) {
-  // get old dingo-client pid
-  std::string file_name =
-      absl::StrFormat("%s/%s", mountpoint, dingofs::kStatsName);
+void FuseServer::DestroySession() {
+  LOG(INFO) << "destroy dingo-client session.";
 
-  int pid = 0;
-  uint32_t retry = 0;
-  do {
-    pid = GetDingoFusePid(file_name);
-    if (pid > 0) break;
+  // Stop the handover threads BEFORE destroying the session. The controller
+  // drives the session (pause/resume/wait_drained/exit) and may still be mid
+  // handover -- e.g. an external SIGTERM/SIGINT exits the loop while a drain is
+  // in flight. Joining it here guarantees it never touches a freed session.
+  // Stop is idempotent, so the dtor's later Stop is a no-op.
+  if (handover_controller_) handover_controller_->Stop();
+  if (handover_server_) handover_server_->Stop();
 
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(FLAGS_fuse_fd_get_retry_interval_ms));
-  } while (++retry <= FLAGS_fuse_fd_get_max_retries);
-
-  if (pid <= 0) {
-    LOG(ERROR) << "get pid fail, filepath=" << file_name;
-    return false;
+  if (session_ != nullptr) {
+    fuse_remove_signal_handlers(session_);
+    fuse_session_destroy(session_);
   }
-  LOG(INFO) << "get pid success, pid=" << pid;
+}
 
-  FuseUpgradeManager::GetInstance().SetOldFusePid(pid);
+// ===========================================================================
+// Misc helpers
+// ===========================================================================
 
-  // recv mount fd、fuse_init data from old dingo-client
-  std::string comm_path = GetFdCommFileName(file_name);
-  CHECK(!comm_path.empty());
-  LOG(INFO) << "get socket success, comm_path=" << comm_path;
+int FuseServer::GetDevFd() const { return fuse_session_fd(session_); }
 
-  fuse_fd_ = GetFuseFd(comm_path.c_str(), init_fbuf_.mem, init_fbuf_.mem_size,
-                       &init_fbuf_.size);
-  for (int i = 0; i < FLAGS_fuse_fd_get_max_retries && fuse_fd_ <= 2; i++) {
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(FLAGS_fuse_fd_get_retry_interval_ms));
-    fuse_fd_ = GetFuseFd(comm_path.c_str(), init_fbuf_.mem, init_fbuf_.mem_size,
-                         &init_fbuf_.size);
-  }
-  if (fuse_fd_ <= 2) {
-    LOG(ERROR) << "recv mount fd fail, comm_path=" << comm_path;
-    return false;
-  }
-  LOG(INFO) << "recv data from " << comm_path << ", mount fd = " << fuse_fd_
-            << ",data size = " << init_fbuf_.size;
+void FuseServer::Shutdown() {
+  LOG(INFO) << "shutdown dingo-client";
+  fuse_session_exit(session_);
+}
 
-  // send kill signal to old dingo-client
-  kill(pid, SIGHUP);
+void FuseServer::ExportMetrics(const std::string& key,
+                               const std::string& value) {
+  fd_comm_metrics_.set_value(value);
+  fd_comm_metrics_.expose(butil::StringPiece(key));
+}
 
-  // check old dingo-client is alive
-  for (int i = 0; i < FLAGS_fuse_check_alive_max_retries; i++) {
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(FLAGS_fuse_check_alive_retry_interval_ms));
-    if (!CheckProcessAlive(pid)) {
-      return true;
-    }
+// ===========================================================================
+// Hot-upgrade coordination: arm the controller, register the flush checkpoint,
+// and trigger a handover. The handover server (the controller's peer) and the
+// handover client live in their own files.
+// ===========================================================================
 
-    LOG(INFO) << "check old dingo-client is alive: YES";
-  }
+void FuseServer::ArmHandoverController() {
+  CHECK(handover_controller_ == nullptr) << "handover controller already armed";
 
-  return false;
+  HandoverOptions options;
+  options.mountpoint = mount_option_->mount_point;
+  options.drain_timeout_ms = FLAGS_fuse_hotupgrade_drain_timeout_ms;
+  options.statfs_interval_ms = FLAGS_fuse_hotupgrade_statfs_interval_ms;
+  session_handover_ = std::make_unique<HandoverSessionImpl>(session_);
+  handover_controller_ = std::make_unique<HandoverController>(
+      std::move(options), handover_server_.get(), session_handover_.get());
+  handover_controller_->Start();
+}
+
+void FuseServer::SetHandoverCheckpoint(std::function<Status()> checkpoint) {
+  // Called from FuseOpInit during Serve(), after ArmHandoverController().
+  CHECK(handover_controller_ != nullptr) << "handover controller not armed";
+  handover_controller_->SetCheckpoint(std::move(checkpoint));
+}
+
+void FuseServer::TriggerHandover() {
+  // Called from the graceful signal thread on SIGHUP (normal context, not an
+  // async signal handler). Just wakes the handover controller -- the controller
+  // runs the actual drain -> checkpoint -> exit on its own thread. It is armed
+  // in ArmHandoverController() before the signal thread starts, so it is always
+  // present here.
+  CHECK(handover_controller_ != nullptr) << "handover controller not armed";
+  handover_controller_->RequestHandover();
 }
 
 }  // namespace fuse

--- a/src/client/fuse/fuse_server.h
+++ b/src/client/fuse/fuse_server.h
@@ -17,79 +17,88 @@
 #ifndef DINGOFS_SRC_CLIENT_FUSE_FUSE_SERVER_H_
 #define DINGOFS_SRC_CLIENT_FUSE_FUSE_SERVER_H_
 
+#include <functional>
+#include <memory>
 #include <string>
 
 #include "bvar/status.h"
 #include "client/fuse/fuse_common.h"
+#include "common/status.h"
 #include "fuse3/fuse.h"
-#include "utils/concurrent/concurrent.h"
 
 namespace dingofs {
 namespace client {
 namespace fuse {
 
+class HandoverController;
+class HandoverServer;
+class HandoverSessionImpl;
+
 class FuseServer {
  public:
   explicit FuseServer();
+
   ~FuseServer();
+
   FuseServer(const FuseServer&) = delete;
   FuseServer& operator=(const FuseServer&) = delete;
 
   int Init(const std::string& program_name, struct MountOption* mount_option);
 
-  int AddMountOptions();
-
+  // FUSE session lifecycle: Create -> Mount -> Serve -> Unmount -> Destroy.
   int CreateSession(void* userdata);
-
-  void DestroySsesion();
-
   int SessionMount();
-
-  void SessionUnmount();
-
   int Serve();
+  void SessionUnmount();
+  void DestroySession();
 
+  // Exit the session loop (fuse_session_exit).
   void Shutdown();
 
-  void MarkThenShutdown();
+  // Hot-upgrade coordination (the handover server/client/controller do the
+  // actual work, in their own files).
+  void ArmHandoverController();
+  // Register the fail-able handover checkpoint run on the old process after the
+  // session is drained and before it exits. A non-OK return rolls the handover
+  // back (resume receive, keep serving). Set once during FuseOpInit, before any
+  // handover can be requested.
+  void SetHandoverCheckpoint(std::function<Status()> checkpoint);
+  // Wake the handover controller; called from the graceful signal thread.
+  void TriggerHandover();
 
  private:
+  int AddMountOptions();
   void AllocateFuseInitBuf();
-
   void FreeFuseInitBuf();
 
-  int GetDevFd() const;
-
-  void UdsServerFunc();
-
+  // Serve() helpers.
   int SaveOpInitMsg();
-
   void ProcessInitMsg();
-
   int SessionLoop();
-
-  bool ShutdownGracefully(const std::string& mountpoint);
-
-  void UdsServerStart();
-
   void ExportMetrics(const std::string& key, const std::string& value);
+
+  int GetDevFd() const;
 
   std::string program_name_;
 
   // libfuse
-  struct fuse_args args_{0, nullptr, 0};
+  struct fuse_args args_ {
+    0, nullptr, 0
+  };
+
   struct fuse_session* session_{nullptr};
   struct fuse_loop_config* config_{nullptr};
   struct MountOption* mount_option_{nullptr};
-  struct fuse_buf init_fbuf_{0};
-
-  // Manager uds thread
-  utils::Thread uds_thread_;
-  utils::Atomic<bool> is_running_{false};
+  struct fuse_buf init_fbuf_ {
+    0
+  };
 
   // Manager smooth upgrade
-  int fuse_fd_{-1};
   std::string fd_comm_file_;
+
+  std::unique_ptr<HandoverServer> handover_server_;
+  std::unique_ptr<HandoverSessionImpl> session_handover_;
+  std::unique_ptr<HandoverController> handover_controller_;
 
   // manager metrics
   bvar::Status<std::string> fd_comm_metrics_;

--- a/src/client/fuse/upgrade/handover_channel.h
+++ b/src/client/fuse/upgrade/handover_channel.h
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-#ifndef DINGOFS_SRC_CLIENT_FUSE_PASSFD_H
-#define DINGOFS_SRC_CLIENT_FUSE_PASSFD_H
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CHANNEL_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CHANNEL_H_
 
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
 
 #include "glog/logging.h"
 #include "utils/scoped_cleanup.h"
@@ -27,6 +31,74 @@
 namespace dingofs {
 namespace client {
 namespace fuse {
+
+// Build a 4-byte ASCII magic, e.g. MakeMagic('D','R','D','Y') == 'DRDY'.
+constexpr uint32_t MakeMagic(char a, char b, char c, char d) {
+  return (static_cast<uint32_t>(static_cast<unsigned char>(a)) << 24) |
+         (static_cast<uint32_t>(static_cast<unsigned char>(b)) << 16) |
+         (static_cast<uint32_t>(static_cast<unsigned char>(c)) << 8) |
+         static_cast<uint32_t>(static_cast<unsigned char>(d));
+}
+
+// Handover handshake messages exchanged over the UDS after the /dev/fuse fd is
+// passed. ASCII magic (not 1/2/3) so a version-mismatched or stray peer is
+// rejected as "unexpected" instead of silently matching a small integer.
+// Cross-version wire contract: never renumber existing values.
+enum class HandoverMessage : uint32_t {
+  kPrepare = MakeMagic('D', 'P', 'R', 'P'),  // new -> old: start the handover
+  kReadyToExit = MakeMagic('D', 'R', 'D', 'Y'),
+  kAck = MakeMagic('D', 'A', 'C', 'K'),
+  kNack = MakeMagic('D', 'N', 'A', 'K'),
+};
+
+inline bool SendAll(int fd, const void* data, size_t size) {
+  const char* p = static_cast<const char*>(data);
+  while (size > 0) {
+    ssize_t n = send(fd, p, size, MSG_NOSIGNAL);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (n == 0) {
+      errno = EPIPE;
+      return false;
+    }
+    p += n;
+    size -= n;
+  }
+  return true;
+}
+
+inline bool RecvAll(int fd, void* data, size_t size) {
+  char* p = static_cast<char*>(data);
+  while (size > 0) {
+    ssize_t n = recv(fd, p, size, 0);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (n == 0) {
+      errno = ECONNRESET;
+      return false;
+    }
+    p += n;
+    size -= n;
+  }
+  return true;
+}
+
+inline bool SendHandoverMessage(int fd, HandoverMessage msg) {
+  uint32_t raw = static_cast<uint32_t>(msg);
+  return SendAll(fd, &raw, sizeof(raw));
+}
+
+inline bool RecvHandoverMessage(int fd, HandoverMessage* msg) {
+  uint32_t raw = 0;
+  if (!RecvAll(fd, &raw, sizeof(raw))) return false;
+  *msg = static_cast<HandoverMessage>(raw);
+  return true;
+}
+
 /**
  * Send a file descriptor over a Unix domain socket.
  * Returns 0 on success, -1 on error.
@@ -59,7 +131,7 @@ inline int SendFd(int socket, int fd, void* data, size_t data_size) {
   msg.msg_iov = &iov;
   msg.msg_iovlen = 1;
 
-  return sendmsg(socket, &msg, 0);
+  return sendmsg(socket, &msg, MSG_NOSIGNAL);
 }
 
 /**
@@ -114,7 +186,8 @@ inline int GetFd(int socket, void* data_buf, size_t data_bufsize,
  * @param real_size real size of receive data
  */
 inline int GetFuseFd(const char* fd_comm_path, void* data_buf,
-                     size_t data_bufsize, size_t* real_size) {
+                     size_t data_bufsize, size_t* real_size,
+                     int* comm_fd = nullptr) {
   int client_fd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (client_fd == -1) {
     LOG(ERROR) << "create socket failed, path: " << fd_comm_path
@@ -139,6 +212,11 @@ inline int GetFuseFd(const char* fd_comm_path, void* data_buf,
     return -1;
   }
 
+  if (comm_fd != nullptr) {
+    *comm_fd = client_fd;
+    defer_close.cancel();
+  }
+
   return fuse_fd;
 }
 
@@ -146,4 +224,4 @@ inline int GetFuseFd(const char* fd_comm_path, void* data_buf,
 }  // namespace client
 }  // namespace dingofs
 
-#endif  // DINGOFS_SRC_CLIENT_FUSE_PASSFD_H
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CHANNEL_H_

--- a/src/client/fuse/upgrade/handover_client.cc
+++ b/src/client/fuse/upgrade/handover_client.cc
@@ -113,13 +113,7 @@ bool HandoverClient::Handshake(int comm_fd, int old_pid) {
     return false;
   }
 
-  if (!SendHandoverMessage(comm_fd, HandoverMessage::kAck)) {
-    LOG(ERROR) << "hot-upgrade: send handover ACK failed, error: "
-               << std::strerror(errno);
-    return false;
-  }
-
-  LOG(INFO) << "hot-upgrade: old process is ready to exit and ACKed";
+  LOG(INFO) << "hot-upgrade: old process is ready to exit";
   return true;
 }
 

--- a/src/client/fuse/upgrade/handover_client.cc
+++ b/src/client/fuse/upgrade/handover_client.cc
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/fuse/upgrade/handover_client.h"
+
+#include <brpc/reloadable_flags.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+
+#include "absl/strings/str_format.h"
+#include "client/fuse/fuse_common.h"
+#include "client/fuse/upgrade/handover_channel.h"
+#include "client/fuse/upgrade/state_store.h"
+#include "common/const.h"
+#include "fuse_lowlevel.h"
+#include "glog/logging.h"
+#include "utils/scoped_cleanup.h"
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+// Declared in common/options/client.h.
+DEFINE_uint32(fuse_fd_get_max_retries, 100,
+              "the max retries that get fuse fd from old dingo-client during "
+              "smooth upgrade");
+DEFINE_validator(fuse_fd_get_max_retries, brpc::PassValidate);
+
+DEFINE_uint32(fuse_fd_get_retry_interval_ms, 100,
+              "the interval in millseconds that get fuse fd from old "
+              "dingo-client during smooth upgrade");
+DEFINE_validator(fuse_fd_get_retry_interval_ms, brpc::PassValidate);
+
+int HandoverClient::FindOldPid(const std::string& stats_file) {
+  int pid = 0;
+  uint32_t retry = 0;
+  do {
+    pid = GetDingoFusePid(stats_file);
+    if (pid > 0) break;
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(FLAGS_fuse_fd_get_retry_interval_ms));
+  } while (++retry <= FLAGS_fuse_fd_get_max_retries);
+  return pid;
+}
+
+int HandoverClient::ReceiveFuseFd(const std::string& comm_path,
+                                  struct fuse_buf* init_msg, int* comm_fd) {
+  int fuse_fd = GetFuseFd(comm_path.c_str(), init_msg->mem, init_msg->mem_size,
+                          &init_msg->size, comm_fd);
+  for (int i = 0; i < FLAGS_fuse_fd_get_max_retries && fuse_fd <= 2; i++) {
+    if (*comm_fd >= 0) {
+      close(*comm_fd);
+      *comm_fd = -1;
+    }
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(FLAGS_fuse_fd_get_retry_interval_ms));
+    fuse_fd = GetFuseFd(comm_path.c_str(), init_msg->mem, init_msg->mem_size,
+                        &init_msg->size, comm_fd);
+  }
+  return fuse_fd;
+}
+
+bool HandoverClient::Handshake(int comm_fd, int old_pid) {
+  // Announce the handover on the live UDS connection, then wake the old
+  // process. The old drains only after reading this kPrepare, so a stray SIGHUP
+  // (or a stale connection) never triggers a drain. Send before the signal so
+  // the message is already buffered when the old process reads it.
+  if (!SendHandoverMessage(comm_fd, HandoverMessage::kPrepare)) {
+    LOG(ERROR) << "hot-upgrade: send kPrepare to old failed, error: "
+               << std::strerror(errno);
+    return false;
+  }
+
+  if (kill(old_pid, SIGHUP) != 0) {
+    LOG(ERROR) << "hot-upgrade: send SIGHUP to old process failed, pid: "
+               << old_pid << ", error: " << std::strerror(errno);
+    return false;
+  }
+
+  HandoverMessage msg;
+  if (!RecvHandoverMessage(comm_fd, &msg)) {
+    LOG(ERROR) << "hot-upgrade: wait old handover message failed, error: "
+               << std::strerror(errno);
+    return false;
+  }
+
+  if (msg == HandoverMessage::kNack) {
+    LOG(ERROR) << "hot-upgrade: old process rejected handover and resumed";
+    return false;
+  }
+
+  if (msg != HandoverMessage::kReadyToExit) {
+    LOG(ERROR) << "hot-upgrade: unexpected old handover message: "
+               << static_cast<uint32_t>(msg);
+    return false;
+  }
+
+  if (!SendHandoverMessage(comm_fd, HandoverMessage::kAck)) {
+    LOG(ERROR) << "hot-upgrade: send handover ACK failed, error: "
+               << std::strerror(errno);
+    return false;
+  }
+
+  LOG(INFO) << "hot-upgrade: old process is ready to exit and ACKed";
+  return true;
+}
+
+int HandoverClient::TakeOver(const std::string& mountpoint,
+                             struct fuse_buf* init_msg) {
+  const std::string stats_file =
+      absl::StrFormat("%s/%s", mountpoint, dingofs::kStatsName);
+
+  int pid = FindOldPid(stats_file);
+  if (pid <= 0) {
+    LOG(ERROR) << "get pid fail, filepath=" << stats_file;
+    return -1;
+  }
+
+  LOG(INFO) << "get pid success, pid=" << pid;
+  UpgradeStateStore::GetInstance().SetOldFusePid(pid);
+
+  const std::string comm_path = GetFdCommFileName(stats_file);
+  CHECK(!comm_path.empty());
+  LOG(INFO) << "get socket success, comm_path=" << comm_path;
+
+  int comm_fd = -1;
+  auto close_comm = MakeScopedCleanup([&]() {
+    if (comm_fd >= 0) close(comm_fd);
+  });
+
+  int fuse_fd = ReceiveFuseFd(comm_path, init_msg, &comm_fd);
+  if (fuse_fd <= 2) {
+    LOG(ERROR) << "recv mount fd fail, comm_path=" << comm_path;
+    return -1;
+  }
+  // The received /dev/fuse fd holds a reference to the kernel mount; close it
+  // on any failure below, and hand it to the caller (cancel) only on success.
+  auto close_fuse_fd = MakeScopedCleanup([&]() { close(fuse_fd); });
+
+  LOG(INFO) << "recv data from " << comm_path << ", mount fd = " << fuse_fd
+            << ", data size = " << init_msg->size;
+
+  if (!Handshake(comm_fd, pid)) return -1;
+
+  close_fuse_fd.cancel();
+  return fuse_fd;
+}
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/fuse/upgrade/handover_client.h
+++ b/src/client/fuse/upgrade/handover_client.h
@@ -27,8 +27,8 @@ namespace fuse {
 
 // New-side handover initiator: connects to the old dingo-client's UDS endpoint,
 // receives the live /dev/fuse fd + saved INIT message, runs the new half of the
-// handshake (kPrepare -> SIGHUP -> wait kReadyToExit -> kAck), and waits for
-// the old process to exit. The counterpart of HandoverServer.
+// handshake (kPrepare -> SIGHUP -> wait kReadyToExit). The counterpart of
+// HandoverServer.
 class HandoverClient {
  public:
   // Take over the mount served by an old dingo-client. On success returns the
@@ -49,8 +49,8 @@ class HandoverClient {
                     int* comm_fd);
 
   // Run the new half of the handshake on the open UDS connection: announce
-  // kPrepare, SIGHUP the old, wait for kReadyToExit, then ACK. Returns false on
-  // any failure or a kNack (old rejected and kept serving).
+  // kPrepare, SIGHUP the old, then wait for kReadyToExit. Returns false on any
+  // failure or a kNack (old rejected and kept serving).
   bool Handshake(int comm_fd, int old_pid);
 };
 

--- a/src/client/fuse/upgrade/handover_client.h
+++ b/src/client/fuse/upgrade/handover_client.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CLIENT_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CLIENT_H_
+
+#include <string>
+
+struct fuse_buf;
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+// New-side handover initiator: connects to the old dingo-client's UDS endpoint,
+// receives the live /dev/fuse fd + saved INIT message, runs the new half of the
+// handshake (kPrepare -> SIGHUP -> wait kReadyToExit -> kAck), and waits for
+// the old process to exit. The counterpart of HandoverServer.
+class HandoverClient {
+ public:
+  // Take over the mount served by an old dingo-client. On success returns the
+  // received /dev/fuse fd (> 2) and fills init_msg with the old's INIT message;
+  // returns -1 on any failure (the caller then aborts the smooth upgrade).
+  int TakeOver(const std::string& mountpoint, struct fuse_buf* init_msg);
+
+ private:
+  // Poll the mount's stats file until the old dingo-client pid appears (bounded
+  // by fuse_fd_get_max_retries). Returns the pid, or <= 0 if not found.
+  int FindOldPid(const std::string& stats_file);
+
+  // Connect the old's UDS and receive the /dev/fuse fd + INIT message, retrying
+  // until a valid fd arrives or the retry budget runs out. On success returns
+  // the fd (> 2) and *comm_fd holds the still-open UDS connection (for the
+  // handshake); otherwise returns <= 2.
+  int ReceiveFuseFd(const std::string& comm_path, struct fuse_buf* init_msg,
+                    int* comm_fd);
+
+  // Run the new half of the handshake on the open UDS connection: announce
+  // kPrepare, SIGHUP the old, wait for kReadyToExit, then ACK. Returns false on
+  // any failure or a kNack (old rejected and kept serving).
+  bool Handshake(int comm_fd, int old_pid);
+};
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CLIENT_H_

--- a/src/client/fuse/upgrade/handover_controller.cc
+++ b/src/client/fuse/upgrade/handover_controller.cc
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/fuse/upgrade/handover_controller.h"
+
+#include <sys/vfs.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+#include "client/fuse/upgrade/state_store.h"
+#include "fmt/format.h"
+#include "glog/logging.h"
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+class HandoverController::HandoverRequestEvent {
+ public:
+  void Notify() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      notified_ = true;
+    }
+    cond_.notify_one();
+  }
+
+  void Wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cond_.wait(lock, [this]() { return notified_; });
+    notified_ = false;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cond_;
+  bool notified_{false};
+};
+
+namespace {
+
+class StatfsWakeupLoop {
+ public:
+  void Start(const std::string& mountpoint, uint32_t interval_ms) {
+    stop_ = std::make_shared<std::atomic<bool>>(false);
+    auto stop = stop_;
+    thread_ = std::thread([stop, mountpoint, interval_ms]() {
+      struct statfs buf;
+      while (!stop->load()) {
+        // Drive a FUSE round-trip to pop a worker blocked in read() back to the
+        // recv_paused check. pause_receive() does not wake a blocked reader.
+        (void)statfs(mountpoint.c_str(), &buf);
+        std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
+      }
+    });
+  }
+
+  void StopAndJoinIfPossible() {
+    Stop();
+    if (thread_.joinable()) thread_.join();
+  }
+
+  void DetachOnCommit() {
+    Stop();
+    if (thread_.joinable()) thread_.detach();
+  }
+
+  ~StatfsWakeupLoop() {
+    Stop();
+    if (thread_.joinable()) thread_.detach();
+  }
+
+ private:
+  void Stop() {
+    if (stop_) stop_->store(true);
+  }
+
+  std::shared_ptr<std::atomic<bool>> stop_;
+  std::thread thread_;
+};
+
+}  // namespace
+
+HandoverController::HandoverController(HandoverOptions options,
+                                       HandoverPeer* peer,
+                                       HandoverSession* session)
+    : options_(std::move(options)),
+      peer_(peer),
+      session_(session),
+      request_event_(std::make_unique<HandoverRequestEvent>()) {
+  CHECK(peer_ != nullptr) << "handover peer must not be null";
+  CHECK(session_ != nullptr) << "handover session must not be null";
+}
+
+HandoverController::~HandoverController() { Stop(); }
+
+void HandoverController::SetCheckpoint(HandoverCheckpoint checkpoint) {
+  std::lock_guard<std::mutex> lock(checkpoint_mutex_);
+  checkpoint_ = std::move(checkpoint);
+}
+
+void HandoverController::Start() {
+  if (started_) return;
+  started_ = true;
+  thread_ = std::thread(&HandoverController::Run, this);
+}
+
+void HandoverController::Stop() {
+  if (!started_) return;
+  shutdown_.store(true);
+  request_event_->Notify();
+  if (thread_.joinable()) thread_.join();
+  started_ = false;
+}
+
+bool HandoverController::RequestHandover() {
+  if (!started_) return false;
+  request_event_->Notify();
+  return true;
+}
+
+bool HandoverController::WaitForRequest() {
+  request_event_->Wait();
+  return !shutdown_.load();
+}
+
+void HandoverController::Run() {
+  while (WaitForRequest()) {
+    // SIGHUP only wakes us; the real trigger is a kPrepare message from the new
+    // process on a live UDS connection. peer_->WaitHandoverPrepare() returns
+    // false for a stray SIGHUP (no connection, or a dead/silent peer), in which
+    // case we
+    // must NOT drain and tear down the VFS -- there would be no peer to hand
+    // off to and no way to resume past the checkpoint. Stay serving instead.
+    if (!peer_->WaitHandoverPrepare()) {
+      LOG(ERROR) << "hot-upgrade: SIGHUP without a valid handover request; "
+                    "ignoring and keep serving";
+      continue;
+    }
+
+    // Do NOT pause IO (drain) if there is nothing to commit yet. The checkpoint
+    // is registered by FuseOpInit during Serve(); a SIGHUP between arming this
+    // controller and that registration -- or after g_vfs->Start() failed and it
+    // is never registered -- would otherwise drain a full round only to abort.
+    // Tell the new to back off and keep serving without ever pausing.
+    bool has_checkpoint;
+    {
+      std::lock_guard<std::mutex> lock(checkpoint_mutex_);
+      has_checkpoint = static_cast<bool>(checkpoint_);
+    }
+
+    if (!has_checkpoint) {
+      LOG(ERROR) << "hot-upgrade: handover checkpoint not registered yet; "
+                    "ignoring SIGHUP, keep serving";
+      peer_->NotifyHandoverAbort();
+      continue;
+    }
+
+    // Mark kFuseUpgradeOld here, in this normal worker thread -- NOT in the
+    // SIGHUP handler. UpdateFuseState takes a mutex and is not
+    // async-signal-safe; running it from the handler risks a self-deadlock if
+    // the interrupted thread already holds that mutex. AbortHandover() reverts
+    // it on failure.
+    UpgradeStateStore::GetInstance().UpdateFuseState(
+        FuseUpgradeState::kFuseUpgradeOld);
+    LOG(INFO) << "hot-upgrade: handover requested, begin controlled drain";
+
+    Status s = DrainSessionForHandover();
+    if (!s.ok()) {
+      AbortHandover(s);
+      continue;
+    }
+
+    // Today the registered checkpoint tears down VFS and dumps state; if that
+    // stop/dump step fails it LOG(FATAL)s because we are already past the clean
+    // rollback point. This non-OK path is still intentional for two cases:
+    // missing/unregistered checkpoint, and the future resumable checkpoint
+    // design where pre-teardown flush/dump can fail and old should resume
+    // serving.
+    s = RunCheckpoint();
+    if (!s.ok()) {
+      AbortHandover(s);
+      continue;
+    }
+
+    CommitHandover();
+    return;
+  }
+}
+
+Status HandoverController::DrainSessionForHandover() {
+  session_->PauseReceive();
+
+  StatfsWakeupLoop wakeup;
+  wakeup.Start(options_.mountpoint, options_.statfs_interval_ms);
+  int rc = session_->WaitDrained(options_.drain_timeout_ms);
+
+  if (rc != 0) {
+    // Leave the session paused; the caller's AbortHandover() does the single
+    // ResumeReceive() (and state rollback). Only the wakeup thread is ours to
+    // clean up here.
+    wakeup.StopAndJoinIfPossible();
+    return Status::Internal(
+        fmt::format("wait_drained failed rc={} (0=ok, -1=timeout)", rc));
+  }
+
+  // Drained: the wakeup thread may be blocked in a statfs the paused session
+  // will no longer serve. Detach it; it holds no FuseServer references and
+  // exits once the new process serves the pending statfs, or with this process
+  // on commit.
+  wakeup.DetachOnCommit();
+  return Status::OK();
+}
+
+Status HandoverController::RunCheckpoint() {
+  HandoverCheckpoint checkpoint;
+  {
+    std::lock_guard<std::mutex> lock(checkpoint_mutex_);
+    checkpoint = checkpoint_;
+  }
+  if (!checkpoint) {
+    return Status::InvalidParam(
+        "hot-upgrade handover checkpoint is not registered");
+  }
+  return checkpoint();
+}
+
+void HandoverController::AbortHandover(const Status& status) {
+  peer_->NotifyHandoverAbort();
+  session_->ResumeReceive();
+  UpgradeStateStore::GetInstance().UpdateFuseState(
+      FuseUpgradeState::kFuseNormal);
+  LOG(ERROR) << "hot-upgrade: abort handover, old process keeps serving, "
+             << "status: " << status.ToString();
+}
+
+void HandoverController::CommitHandover() {
+  // NotifyReadyAndWaitHandoverAck() sends kReadyToExit ONCE and blocks for the
+  // new process's
+  // kAck. We are past the checkpoint here: the VFS is already stopped + dumped
+  // and cannot be resumed, so there is no rollback if the new never ACKs.
+  //
+  // On timeout/failure (new died after kPrepare, or is stuck), log and exit
+  // anyway: hanging forever holding a drained mount is worse than exiting, and
+  // exiting lets the kernel abort the orphaned mount so a remount/restart can
+  // recover. Do NOT loop-retry NotifyReadyAndWaitHandoverAck(): it would
+  // re-send kReadyToExit, which the new reads only once. The true fix
+  // (resumable until ACK) needs the checkpoint to dump-without-teardown; see
+  // handover-ack-handshake-design.md (decision A).
+  if (!peer_->NotifyReadyAndWaitHandoverAck()) {
+    LOG(ERROR) << "hot-upgrade: new did not ACK within timeout after teardown; "
+                  "exiting anyway, mount may be orphaned until remount";
+  } else {
+    LOG(INFO) << "hot-upgrade: new ACKed, exit session for handover";
+  }
+
+  session_->Exit();
+}
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/fuse/upgrade/handover_controller.cc
+++ b/src/client/fuse/upgrade/handover_controller.cc
@@ -254,23 +254,21 @@ void HandoverController::AbortHandover(const Status& status) {
 }
 
 void HandoverController::CommitHandover() {
-  // NotifyReadyAndWaitHandoverAck() sends kReadyToExit ONCE and blocks for the
-  // new process's
-  // kAck. We are past the checkpoint here: the VFS is already stopped + dumped
-  // and cannot be resumed, so there is no rollback if the new never ACKs.
+  // NotifyReadyToExit() sends kReadyToExit ONCE. We are past the checkpoint
+  // here: the VFS is already stopped + dumped and cannot be resumed, so there
+  // is no rollback if the new is gone or cannot receive the notification.
   //
-  // On timeout/failure (new died after kPrepare, or is stuck), log and exit
+  // On notify failure (new died after kPrepare or closed the UDS), log and exit
   // anyway: hanging forever holding a drained mount is worse than exiting, and
   // exiting lets the kernel abort the orphaned mount so a remount/restart can
-  // recover. Do NOT loop-retry NotifyReadyAndWaitHandoverAck(): it would
-  // re-send kReadyToExit, which the new reads only once. The true fix
-  // (resumable until ACK) needs the checkpoint to dump-without-teardown; see
-  // handover-ack-handshake-design.md (decision A).
-  if (!peer_->NotifyReadyAndWaitHandoverAck()) {
-    LOG(ERROR) << "hot-upgrade: new did not ACK within timeout after teardown; "
-                  "exiting anyway, mount may be orphaned until remount";
+  // recover. Do NOT loop-retry NotifyReadyToExit(): it would re-send
+  // kReadyToExit, which the new reads only once. A stronger handover needs the
+  // checkpoint to dump-without-teardown and wait for a post-load ACK.
+  if (!peer_->NotifyReadyToExit()) {
+    LOG(ERROR) << "hot-upgrade: failed to notify new after teardown; exiting "
+                  "anyway, mount may be orphaned until remount";
   } else {
-    LOG(INFO) << "hot-upgrade: new ACKed, exit session for handover";
+    LOG(INFO) << "hot-upgrade: new notified ready, exit session for handover";
   }
 
   session_->Exit();

--- a/src/client/fuse/upgrade/handover_controller.cc
+++ b/src/client/fuse/upgrade/handover_controller.cc
@@ -60,26 +60,30 @@ namespace {
 
 class StatfsWakeupLoop {
  public:
-  void Start(const std::string& mountpoint, uint32_t interval_ms) {
+  void Start(const std::string& mountpoint, uint32_t interval_ms,
+             HandoverOptions::StatfsWakeupFn wakeup_fn) {
+    if (!wakeup_fn) {
+      wakeup_fn = [](const std::string& mountpoint,
+                     const std::atomic<bool>&) {
+        struct statfs buf;
+        (void)statfs(mountpoint.c_str(), &buf);
+      };
+    }
+
     stop_ = std::make_shared<std::atomic<bool>>(false);
     auto stop = stop_;
-    thread_ = std::thread([stop, mountpoint, interval_ms]() {
-      struct statfs buf;
+    thread_ = std::thread([stop, mountpoint, interval_ms,
+                           wakeup_fn = std::move(wakeup_fn)]() {
       while (!stop->load()) {
         // Drive a FUSE round-trip to pop a worker blocked in read() back to the
         // recv_paused check. pause_receive() does not wake a blocked reader.
-        (void)statfs(mountpoint.c_str(), &buf);
+        wakeup_fn(mountpoint, *stop);
         std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
       }
     });
   }
 
-  void StopAndJoinIfPossible() {
-    Stop();
-    if (thread_.joinable()) thread_.join();
-  }
-
-  void DetachOnCommit() {
+  void StopAndDetach() {
     Stop();
     if (thread_.joinable()) thread_.detach();
   }
@@ -211,23 +215,27 @@ Status HandoverController::DrainSessionForHandover() {
   session_->PauseReceive();
 
   StatfsWakeupLoop wakeup;
-  wakeup.Start(options_.mountpoint, options_.statfs_interval_ms);
+  wakeup.Start(options_.mountpoint, options_.statfs_interval_ms,
+               options_.statfs_wakeup_fn);
   int rc = session_->WaitDrained(options_.drain_timeout_ms);
 
   if (rc != 0) {
     // Leave the session paused; the caller's AbortHandover() does the single
-    // ResumeReceive() (and state rollback). Only the wakeup thread is ours to
-    // clean up here.
-    wakeup.StopAndJoinIfPossible();
+    // ResumeReceive() (and state rollback). The statfs wakeup thread may itself
+    // be blocked in a FUSE statfs request queued behind the paused session. Never
+    // join it here: on timeout that can deadlock the controller before it sends
+    // kNack/resumes receive. Stop it and detach; after ResumeReceive() serves the
+    // pending statfs, the thread observes stop_ and exits.
+    wakeup.StopAndDetach();
     return Status::Internal(
         fmt::format("wait_drained failed rc={} (0=ok, -1=timeout)", rc));
   }
 
   // Drained: the wakeup thread may be blocked in a statfs the paused session
-  // will no longer serve. Detach it; it holds no FuseServer references and
-  // exits once the new process serves the pending statfs, or with this process
-  // on commit.
-  wakeup.DetachOnCommit();
+  // will no longer serve. Detach it; it holds no FuseServer references and exits
+  // once the new process serves the pending statfs, or with this process on
+  // commit.
+  wakeup.StopAndDetach();
   return Status::OK();
 }
 

--- a/src/client/fuse/upgrade/handover_controller.h
+++ b/src/client/fuse/upgrade/handover_controller.h
@@ -33,9 +33,13 @@ namespace client {
 namespace fuse {
 
 struct HandoverOptions {
+  using StatfsWakeupFn =
+      std::function<void(const std::string&, const std::atomic<bool>&)>;
+
   std::string mountpoint;
   uint32_t drain_timeout_ms{0};
   uint32_t statfs_interval_ms{0};
+  StatfsWakeupFn statfs_wakeup_fn;
 };
 
 class HandoverController {

--- a/src/client/fuse/upgrade/handover_controller.h
+++ b/src/client/fuse/upgrade/handover_controller.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CONTROLLER_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CONTROLLER_H_
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "client/fuse/upgrade/handover_peer.h"
+#include "client/fuse/upgrade/handover_session.h"
+#include "common/status.h"
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+struct HandoverOptions {
+  std::string mountpoint;
+  uint32_t drain_timeout_ms{0};
+  uint32_t statfs_interval_ms{0};
+};
+
+class HandoverController {
+ public:
+  using HandoverCheckpoint = std::function<Status()>;
+
+  HandoverController(HandoverOptions options, HandoverPeer* peer,
+                     HandoverSession* session);
+  ~HandoverController();
+
+  HandoverController(const HandoverController&) = delete;
+  HandoverController& operator=(const HandoverController&) = delete;
+
+  void Start();
+
+  void Stop();
+
+  void SetCheckpoint(HandoverCheckpoint checkpoint);
+
+  bool RequestHandover();
+
+ private:
+  class HandoverRequestEvent;
+
+  bool WaitForRequest();
+
+  void Run();
+
+  Status DrainSessionForHandover();
+
+  Status RunCheckpoint();
+
+  void AbortHandover(const Status& status);
+
+  void CommitHandover();
+
+  HandoverOptions options_;
+  HandoverPeer* peer_{nullptr};
+  HandoverSession* session_{nullptr};
+
+  std::mutex checkpoint_mutex_;
+  HandoverCheckpoint checkpoint_;
+
+  std::unique_ptr<HandoverRequestEvent> request_event_;
+  std::thread thread_;
+  std::atomic<bool> shutdown_{false};
+  std::atomic<bool> started_{false};
+};
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_CONTROLLER_H_

--- a/src/client/fuse/upgrade/handover_peer.h
+++ b/src/client/fuse/upgrade/handover_peer.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_PEER_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_PEER_H_
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+class HandoverPeer {
+ public:
+  virtual ~HandoverPeer() = default;
+
+  virtual bool WaitHandoverPrepare() = 0;
+  virtual bool NotifyReadyAndWaitHandoverAck() = 0;
+  virtual void NotifyHandoverAbort() = 0;
+};
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_PEER_H_

--- a/src/client/fuse/upgrade/handover_peer.h
+++ b/src/client/fuse/upgrade/handover_peer.h
@@ -26,7 +26,7 @@ class HandoverPeer {
   virtual ~HandoverPeer() = default;
 
   virtual bool WaitHandoverPrepare() = 0;
-  virtual bool NotifyReadyAndWaitHandoverAck() = 0;
+  virtual bool NotifyReadyToExit() = 0;
   virtual void NotifyHandoverAbort() = 0;
 };
 

--- a/src/client/fuse/upgrade/handover_server.cc
+++ b/src/client/fuse/upgrade/handover_server.cc
@@ -19,7 +19,6 @@
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <sys/socket.h>
-#include <sys/time.h>
 #include <sys/un.h>
 #include <unistd.h>
 
@@ -197,8 +196,7 @@ bool HandoverServer::WaitHandoverPrepare() {
   // The new process sends kPrepare over the UDS before raising SIGHUP, so it is
   // already buffered here. poll() bounds the wait so a dead/closed peer
   // (POLLHUP -> recv EOF) or an alive-but-silent peer (timeout) cannot drive a
-  // drain off a stray SIGHUP. poll does not change the fd's blocking mode, so
-  // the later blocking ACK wait is unaffected.
+  // drain off a stray SIGHUP. poll does not change the fd's blocking mode.
   constexpr int kPrepareTimeoutMs = 5000;
   struct pollfd pfd;
   pfd.fd = fd;
@@ -236,11 +234,12 @@ bool HandoverServer::WaitHandoverPrepare() {
   return true;
 }
 
-bool HandoverServer::NotifyReadyAndWaitHandoverAck() {
+bool HandoverServer::NotifyReadyToExit() {
   // Reaching here means the controller is past the checkpoint (VFS torn down)
-  // and WILL exit regardless of the ACK outcome. Mark committed so the accept
-  // loop stops handing the /dev/fuse fd to any further connector, closing the
-  // window where client_fd_ is briefly cleared but the process has not exited.
+  // and WILL exit regardless of the notify outcome. Mark committed so the
+  // accept loop stops handing the /dev/fuse fd to any further connector,
+  // closing the window where client_fd_ is briefly cleared but the process has
+  // not exited.
   committed_.store(true);
 
   int fd = -1;
@@ -252,39 +251,14 @@ bool HandoverServer::NotifyReadyAndWaitHandoverAck() {
   if (fd < 0) {
     // The controller validates the peer via WaitHandoverPrepare() before
     // draining, so reaching here with no fd means the connection was torn down
-    // mid-handover. Fail the ACK wait instead of blocking forever.
-    LOG(ERROR) << "hot-upgrade: no handover client fd when waiting for ACK";
+    // mid-handover.
+    LOG(ERROR) << "hot-upgrade: no handover client fd when notifying ready";
     return false;
   }
 
   if (!SendHandoverMessage(fd, HandoverMessage::kReadyToExit)) {
     LOG(ERROR) << "hot-upgrade: send READY_TO_EXIT failed, error: "
                << std::strerror(errno);
-    return false;
-  }
-
-  // Bound the ACK wait. The new sends kAck immediately after kReadyToExit, so a
-  // 30s ceiling is generous; on timeout the caller exits anyway (we are past
-  // the checkpoint and cannot resume). Without this the recv would block
-  // forever.
-  struct timeval tv;
-  tv.tv_sec = 30;
-  tv.tv_usec = 0;
-  if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0) {
-    LOG(ERROR) << "hot-upgrade: set ACK receive timeout failed, error: "
-               << std::strerror(errno);
-    return false;
-  }
-
-  HandoverMessage msg;
-  if (!RecvHandoverMessage(fd, &msg)) {
-    LOG(ERROR) << "hot-upgrade: wait ACK failed/timed out, error: "
-               << std::strerror(errno);
-    return false;
-  }
-  if (msg != HandoverMessage::kAck) {
-    LOG(ERROR) << "hot-upgrade: unexpected handover reply: "
-               << static_cast<uint32_t>(msg);
     return false;
   }
 

--- a/src/client/fuse/upgrade/handover_server.cc
+++ b/src/client/fuse/upgrade/handover_server.cc
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/fuse/upgrade/handover_server.h"
+
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <utility>
+
+#include "client/fuse/fuse_common.h"
+#include "client/fuse/upgrade/handover_channel.h"
+#include "fuse_lowlevel.h"
+#include "glog/logging.h"
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+HandoverServer::HandoverServer(std::string socket_path,
+                               std::function<int()> get_dev_fd,
+                               const struct fuse_buf* init_msg)
+    : socket_path_(std::move(socket_path)),
+      get_dev_fd_(std::move(get_dev_fd)),
+      init_msg_(init_msg) {}
+
+HandoverServer::~HandoverServer() {
+  Stop();
+  CloseClientFd();
+}
+
+void HandoverServer::Start() {
+  if (running_.load()) {
+    LOG(INFO) << "dingo-client uds server already started.";
+    return;
+  }
+
+  // Create + bind + listen synchronously so server_fd_ is valid before the
+  // thread and before any Stop(). On any failure the endpoint stays down (no
+  // throw): hot-upgrade just won't be available, normal serving continues.
+  server_fd_ = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (server_fd_ == -1) {
+    LOG(ERROR) << "uds server create failed, file: " << socket_path_
+               << ", error: " << std::strerror(errno);
+    return;
+  }
+
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+  unlink(socket_path_.c_str());
+  if (bind(server_fd_, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+    LOG(ERROR) << "uds server bind failed, file: " << socket_path_
+               << ", error: " << std::strerror(errno);
+    close(server_fd_);
+    server_fd_ = -1;
+    return;
+  }
+  if (listen(server_fd_, 1) == -1) {
+    LOG(ERROR) << "uds server listen failed, file: " << socket_path_
+               << ", error: " << std::strerror(errno);
+    close(server_fd_);
+    server_fd_ = -1;
+    unlink(socket_path_.c_str());  // bind() created the socket file; remove it
+    return;
+  }
+
+  stop_event_fd_ = eventfd(0, EFD_CLOEXEC);
+  if (stop_event_fd_ == -1) {
+    LOG(ERROR) << "uds server eventfd failed, error: " << std::strerror(errno);
+    close(server_fd_);
+    server_fd_ = -1;
+    unlink(socket_path_.c_str());  // bind() created the socket file; remove it
+    return;
+  }
+
+  stop_.store(false);
+  committed_.store(false);
+  running_.store(true);
+  thread_ = std::thread(&HandoverServer::AcceptLoop, this);
+
+  LOG(INFO) << "dingo-client uds server started on " << socket_path_;
+}
+
+void HandoverServer::Stop() {
+  if (!running_.load()) return;
+
+  // Wake the accept loop (it polls stop_event_fd_) and join it, then close the
+  // listen socket. This must complete before the object is destroyed so the
+  // thread never touches freed members.
+  stop_.store(true);
+  uint64_t one = 1;
+  bool woke = stop_event_fd_ >= 0 &&
+              write(stop_event_fd_, &one, sizeof(one)) == sizeof(one);
+  if (!woke && server_fd_ >= 0) {
+    // eventfd write failed; fall back to shutting down the listen socket so
+    // poll() returns and the loop sees stop_ -- otherwise join() could hang.
+    shutdown(server_fd_, SHUT_RDWR);
+  }
+  if (thread_.joinable()) thread_.join();
+
+  if (server_fd_ >= 0) {
+    close(server_fd_);
+    server_fd_ = -1;
+  }
+  if (stop_event_fd_ >= 0) {
+    close(stop_event_fd_);
+    stop_event_fd_ = -1;
+  }
+  running_.store(false);
+}
+
+void HandoverServer::SetClientFd(int fd) {
+  // Stores the handover connection, closing any previous one. AcceptLoop
+  // rejects a concurrent connector while a LIVE handover is in flight (see
+  // IsHandoverInFlight), so any previous fd reached here is only ever a STALE
+  // (dead) connection -- closing it is safe and just clears the staleness; it
+  // never pulls an fd out from under the controller mid-handshake.
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (client_fd_ >= 0) {
+    close(client_fd_);
+  }
+  client_fd_ = fd;
+}
+
+bool HandoverServer::IsHandoverInFlight() {
+  // True if a handover connection is established AND the peer is still alive.
+  // Probe with a non-blocking poll under the lock so a concurrent Set/Close
+  // cannot pull the fd mid-probe. POLLHUP/POLLERR => peer gone (stale) => not
+  // in flight, so a dead connection never blocks a fresh upgrade. A live peer
+  // with no event (or buffered kPrepare = POLLIN) counts as in flight.
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (client_fd_ < 0) return false;
+
+  struct pollfd pfd;
+  pfd.fd = client_fd_;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+  int rc;
+  do {
+    rc = poll(&pfd, 1, 0);
+  } while (rc < 0 && errno == EINTR);
+
+  if (rc < 0) {
+    if (errno == EBADF) return false;
+    LOG(ERROR) << "hot-upgrade: probe handover fd failed, conservatively "
+                  "treat as in-flight, error: "
+               << std::strerror(errno);
+    return true;
+  }
+
+  return (pfd.revents & (POLLHUP | POLLERR | POLLNVAL)) == 0;
+}
+
+void HandoverServer::CloseClientFd() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (client_fd_ >= 0) {
+    close(client_fd_);
+    client_fd_ = -1;
+  }
+}
+
+bool HandoverServer::WaitHandoverPrepare() {
+  int fd = -1;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    fd = client_fd_;
+  }
+  if (fd < 0) {
+    LOG(ERROR) << "hot-upgrade: SIGHUP with no handover connection; ignoring";
+    return false;
+  }
+
+  // The new process sends kPrepare over the UDS before raising SIGHUP, so it is
+  // already buffered here. poll() bounds the wait so a dead/closed peer
+  // (POLLHUP -> recv EOF) or an alive-but-silent peer (timeout) cannot drive a
+  // drain off a stray SIGHUP. poll does not change the fd's blocking mode, so
+  // the later blocking ACK wait is unaffected.
+  constexpr int kPrepareTimeoutMs = 5000;
+  struct pollfd pfd;
+  pfd.fd = fd;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(kPrepareTimeoutMs);
+  int poll_ret = 0;
+  do {
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) {
+      poll_ret = 0;
+      break;
+    }
+    auto remaining_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
+            .count();
+    poll_ret = poll(&pfd, 1, static_cast<int>(remaining_ms));
+  } while (poll_ret < 0 && errno == EINTR);
+
+  if (poll_ret <= 0) {
+    LOG(ERROR) << "hot-upgrade: no kPrepare from peer (silent/timeout); "
+                  "ignoring SIGHUP, keep serving";
+    CloseClientFd();
+    return false;
+  }
+
+  HandoverMessage msg;
+  if (!RecvHandoverMessage(fd, &msg) || msg != HandoverMessage::kPrepare) {
+    LOG(ERROR) << "hot-upgrade: invalid handover prepare; ignoring SIGHUP";
+    CloseClientFd();
+    return false;
+  }
+  return true;
+}
+
+bool HandoverServer::NotifyReadyAndWaitHandoverAck() {
+  // Reaching here means the controller is past the checkpoint (VFS torn down)
+  // and WILL exit regardless of the ACK outcome. Mark committed so the accept
+  // loop stops handing the /dev/fuse fd to any further connector, closing the
+  // window where client_fd_ is briefly cleared but the process has not exited.
+  committed_.store(true);
+
+  int fd = -1;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    fd = client_fd_;
+  }
+
+  if (fd < 0) {
+    // The controller validates the peer via WaitHandoverPrepare() before
+    // draining, so reaching here with no fd means the connection was torn down
+    // mid-handover. Fail the ACK wait instead of blocking forever.
+    LOG(ERROR) << "hot-upgrade: no handover client fd when waiting for ACK";
+    return false;
+  }
+
+  if (!SendHandoverMessage(fd, HandoverMessage::kReadyToExit)) {
+    LOG(ERROR) << "hot-upgrade: send READY_TO_EXIT failed, error: "
+               << std::strerror(errno);
+    return false;
+  }
+
+  // Bound the ACK wait. The new sends kAck immediately after kReadyToExit, so a
+  // 30s ceiling is generous; on timeout the caller exits anyway (we are past
+  // the checkpoint and cannot resume). Without this the recv would block
+  // forever.
+  struct timeval tv;
+  tv.tv_sec = 30;
+  tv.tv_usec = 0;
+  if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0) {
+    LOG(ERROR) << "hot-upgrade: set ACK receive timeout failed, error: "
+               << std::strerror(errno);
+    return false;
+  }
+
+  HandoverMessage msg;
+  if (!RecvHandoverMessage(fd, &msg)) {
+    LOG(ERROR) << "hot-upgrade: wait ACK failed/timed out, error: "
+               << std::strerror(errno);
+    return false;
+  }
+  if (msg != HandoverMessage::kAck) {
+    LOG(ERROR) << "hot-upgrade: unexpected handover reply: "
+               << static_cast<uint32_t>(msg);
+    return false;
+  }
+
+  CloseClientFd();
+  return true;
+}
+
+void HandoverServer::NotifyHandoverAbort() {
+  int fd = -1;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    fd = client_fd_;
+  }
+  if (fd >= 0) {
+    (void)SendHandoverMessage(fd, HandoverMessage::kNack);
+    CloseClientFd();
+  }
+}
+
+void HandoverServer::AcceptLoop() {
+  LOG(INFO) << "uds server listening on " << socket_path_;
+
+  while (true) {
+    // Wait for either an incoming connection or a stop request. poll() lets
+    // Stop() wake this loop reliably via the eventfd (a bare accept() could not
+    // be interrupted cleanly).
+    struct pollfd fds[2];
+    fds[0].fd = server_fd_;
+    fds[0].events = POLLIN;
+    fds[0].revents = 0;
+    fds[1].fd = stop_event_fd_;
+    fds[1].events = POLLIN;
+    fds[1].revents = 0;
+
+    int pr = poll(fds, 2, -1);
+    if (pr < 0) {
+      if (errno == EINTR) continue;
+      LOG(ERROR) << "uds server poll failed, error: " << std::strerror(errno);
+      break;
+    }
+    // Stop() may wake us via the eventfd or, as a fallback, by shutting down
+    // the listen socket (POLLHUP/POLLERR on server_fd_). Either way, stop_ is
+    // set.
+    if (stop_.load()) break;
+    if (!(fds[0].revents & POLLIN)) continue;
+
+    struct sockaddr_un addr;
+    socklen_t addrlen = sizeof(addr);
+    int client_fd = accept(server_fd_, (struct sockaddr*)&addr, &addrlen);
+    if (client_fd == -1) {
+      LOG(ERROR) << "uds server accept failed, error: " << std::strerror(errno);
+      continue;
+    }
+
+    // Once committed, the /dev/fuse fd has been (or is being) handed off
+    // exactly once and this process is exiting; reject any further connector
+    // regardless of client_fd_ state, so a late new never receives a duplicate
+    // fd.
+    if (committed_.load()) {
+      LOG(WARNING) << "hot-upgrade: handover already committed; rejecting late "
+                      "connection";
+      close(client_fd);
+      continue;
+    }
+
+    // Fail-closed against concurrent upgrades: if a handover is already in
+    // flight with a live peer, reject this connector instead of replacing it
+    // (which would close the fd the controller is mid-handshake on). A stale
+    // dead peer is not "in flight", so it does not block a fresh upgrade.
+    // Reject BEFORE SendFd so the second new never receives the /dev/fuse fd.
+    if (IsHandoverInFlight()) {
+      LOG(WARNING) << "hot-upgrade: a handover is already in flight; rejecting "
+                      "concurrent upgrade connection (one upgrade per mount)";
+      close(client_fd);
+      continue;
+    }
+
+    // The INIT message must be saved before it is handed off; otherwise the new
+    // process would receive an empty INIT and replay garbage. Start() is only
+    // called after SaveOpInitMsg() fills it, so this is belt-and-suspenders.
+    if (init_msg_->size == 0) {
+      LOG(WARNING) << "hot-upgrade: INIT message not ready yet; rejecting "
+                      "handover connection";
+      close(client_fd);
+      continue;
+    }
+
+    // Store the connection BEFORE sending the fd. Once the new receives the fd
+    // it can race a kPrepare + SIGHUP straight back, and the controller's
+    // WaitHandoverPrepare() must already see client_fd_; otherwise it reads -1
+    // and spuriously rejects the handover. On send failure, clear it.
+    SetClientFd(client_fd);
+    int fuse_fd = get_dev_fd_();
+    int ret = SendFd(client_fd, fuse_fd, init_msg_->mem, init_msg_->size);
+    if (ret == -1) {
+      LOG(ERROR) << "send fuse fd failed, client_id: " << client_fd;
+      CloseClientFd();
+    } else {
+      LOG(INFO) << "fuse fd send to client: " << client_fd
+                << ", fd: " << fuse_fd << ", data size: " << init_msg_->size;
+    }
+  }
+}
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/fuse/upgrade/handover_server.h
+++ b/src/client/fuse/upgrade/handover_server.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SERVER_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SERVER_H_
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "client/fuse/upgrade/handover_peer.h"
+
+struct fuse_buf;
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+// Old-side handover endpoint: a UDS server that hands the live /dev/fuse fd
+// (and the saved INIT message) to a connecting new process, then runs the old
+// half of the handover handshake over that same connection. Implements
+// HandoverPeer so the handover controller can drive it.
+//
+// Dependencies are injected so this stays decoupled from FuseServer:
+//   - get_dev_fd: returns the /dev/fuse fd to hand off (read at connect time).
+//   - init_msg:   the saved INIT message to send alongside the fd; the
+//   pointed-to
+//                 buffer must outlive this server (owned by FuseServer).
+class HandoverServer : public HandoverPeer {
+ public:
+  HandoverServer(std::string socket_path, std::function<int()> get_dev_fd,
+                 const struct fuse_buf* init_msg);
+  ~HandoverServer() override;
+
+  HandoverServer(const HandoverServer&) = delete;
+  HandoverServer& operator=(const HandoverServer&) = delete;
+
+  // Create+bind+listen the UDS socket and run the accept loop on its own
+  // (joinable) thread. No-op on failure (the endpoint is simply unavailable).
+  void Start();
+
+  // Stop the accept loop (wake it via the stop eventfd, then join) and close
+  // the listen socket. Idempotent. Called by the destructor.
+  void Stop();
+
+  // ── HandoverPeer (driven by the handover controller) ──
+  bool WaitHandoverPrepare() override;
+  bool NotifyReadyAndWaitHandoverAck() override;
+  void NotifyHandoverAbort() override;
+
+ private:
+  void AcceptLoop();
+  bool IsHandoverInFlight();
+  void SetClientFd(int fd);
+  void CloseClientFd();
+
+  std::string socket_path_;
+  std::function<int()> get_dev_fd_;
+  const struct fuse_buf* init_msg_;
+
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+  std::atomic<bool> stop_{false};  // set by Stop(), checked by the accept loop
+  // Set once the old is past the point of no return (committing the handover).
+  // After this, AcceptLoop rejects ALL new connectors -- even when client_fd_
+  // is already cleared -- so the /dev/fuse fd is never handed to a second new
+  // while this process is winding down.
+  std::atomic<bool> committed_{false};
+  int server_fd_{-1};      // listen socket (closed by Stop)
+  int stop_event_fd_{-1};  // eventfd to wake the accept loop on Stop
+
+  std::mutex mutex_;
+  int client_fd_{-1};
+};
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SERVER_H_

--- a/src/client/fuse/upgrade/handover_server.h
+++ b/src/client/fuse/upgrade/handover_server.h
@@ -60,7 +60,7 @@ class HandoverServer : public HandoverPeer {
 
   // ── HandoverPeer (driven by the handover controller) ──
   bool WaitHandoverPrepare() override;
-  bool NotifyReadyAndWaitHandoverAck() override;
+  bool NotifyReadyToExit() override;
   void NotifyHandoverAbort() override;
 
  private:

--- a/src/client/fuse/upgrade/handover_session.h
+++ b/src/client/fuse/upgrade/handover_session.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SESSION_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SESSION_H_
+
+#include <cstdint>
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+// The FUSE session operations the handover controller needs, abstracted so the
+// controller does not call libfuse directly (and can be unit-tested with a
+// mock). The production implementation is backed by a real fuse_session.
+class HandoverSession {
+ public:
+  virtual ~HandoverSession() = default;
+
+  // Stop reading new requests off the /dev/fuse fd(s) (reversible).
+  virtual void PauseReceive() = 0;
+  // Resume reading new requests (undo PauseReceive).
+  virtual void ResumeReceive() = 0;
+  // Wait until in-flight requests have been replied. Returns 0 on success,
+  // non-zero on timeout/error.
+  virtual int WaitDrained(uint32_t timeout_ms) = 0;
+  // Exit the session loop (fuse_session_exit).
+  virtual void Exit() = 0;
+};
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SESSION_H_

--- a/src/client/fuse/upgrade/handover_session_impl.cc
+++ b/src/client/fuse/upgrade/handover_session_impl.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/fuse/upgrade/handover_session_impl.h"
+
+#include "client/fuse/fuse_common.h"
+#include "fuse_lowlevel.h"
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+HandoverSessionImpl::HandoverSessionImpl(struct fuse_session* session)
+    : session_(session) {}
+
+void HandoverSessionImpl::PauseReceive() {
+  fuse_session_pause_receive(session_);
+}
+
+void HandoverSessionImpl::ResumeReceive() {
+  fuse_session_resume_receive(session_);
+}
+
+int HandoverSessionImpl::WaitDrained(uint32_t timeout_ms) {
+  return fuse_session_wait_drained(session_, timeout_ms);
+}
+
+void HandoverSessionImpl::Exit() { fuse_session_exit(session_); }
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/fuse/upgrade/handover_session_impl.h
+++ b/src/client/fuse/upgrade/handover_session_impl.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SESSION_IMPL_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SESSION_IMPL_H_
+
+#include <cstdint>
+
+#include "client/fuse/upgrade/handover_session.h"
+
+struct fuse_session;
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+// HandoverSession backed by a real libfuse session. Thin adapter so the
+// handover controller can drive the drain/exit without FuseServer having to
+// inherit the interface, and without the controller touching libfuse.
+class HandoverSessionImpl : public HandoverSession {
+ public:
+  explicit HandoverSessionImpl(struct fuse_session* session);
+
+  void PauseReceive() override;
+  void ResumeReceive() override;
+  int WaitDrained(uint32_t timeout_ms) override;
+  void Exit() override;
+
+ private:
+  struct fuse_session* session_;
+};
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_SESSION_IMPL_H_

--- a/src/client/fuse/upgrade/state_store.h
+++ b/src/client/fuse/upgrade/state_store.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef DINGOFS_SRC_CLIENT_FUSE_FUSE_UPGRADE_MANAGER_H_
-#define DINGOFS_SRC_CLIENT_FUSE_FUSE_UPGRADE_MANAGER_H_
+#ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_STATE_STORE_H_
+#define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_STATE_STORE_H_
 
 #include <mutex>
 
@@ -29,13 +29,13 @@ enum class FuseUpgradeState : uint8_t {
   kFuseUpgradeNew,  // new fuse process during smooth upgrade
 };
 
-class FuseUpgradeManager {
+class UpgradeStateStore {
  public:
-  FuseUpgradeManager(const FuseUpgradeManager&) = delete;
-  FuseUpgradeManager& operator=(const FuseUpgradeManager&) = delete;
+  UpgradeStateStore(const UpgradeStateStore&) = delete;
+  UpgradeStateStore& operator=(const UpgradeStateStore&) = delete;
 
-  static FuseUpgradeManager& GetInstance() {
-    static FuseUpgradeManager instance_;
+  static UpgradeStateStore& GetInstance() {
+    static UpgradeStateStore instance_;
     return instance_;
   }
 
@@ -60,7 +60,7 @@ class FuseUpgradeManager {
   }
 
  private:
-  FuseUpgradeManager() = default;
+  UpgradeStateStore() = default;
 
   int old_pid_{0};  // pid of the old fuse process
   FuseUpgradeState fuse_state_{
@@ -72,4 +72,4 @@ class FuseUpgradeManager {
 }  // namespace client
 }  // namespace dingofs
 
-#endif  // DINGOFS_SRC_CLIENT_FUSE_FUSE_UPGRADE_MANAGER_H_
+#endif  // DINGOFS_SRC_CLIENT_FUSE_UPGRADE_STATE_STORE_H_

--- a/src/client/main.cc
+++ b/src/client/main.cc
@@ -15,16 +15,17 @@
  */
 
 #include <glog/logging.h>
+#include <unistd.h>
 
+#include <atomic>
 #include <csignal>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <thread>
 
 #include "client/fuse/fs_context.h"
 #include "client/fuse/fuse_server.h"
-#include "client/vfs/access_log.h"
-#include "client/vfs/metasystem/meta_log.h"
 #include "common/flag.h"
 #include "common/helper.h"
 #include "common/logging.h"
@@ -44,27 +45,47 @@ using FsContext = dingofs::client::fuse::FsContext;
 
 static FuseServer* fuse_server = nullptr;
 
-// signal handler
-static void HandleSignal(int sig) {
-  printf("received signal %s, exit...\n", strsignal(sig));
-  CHECK(signal(sig, SIG_DFL) != nullptr);
+// SIGSEGV/SIGABRT = fatal synchronous signals (the process is crashing).
+//
+// Do the async-signal-safe minimum: write a short note via write(2), restore
+// the default disposition, and re-raise so the process cores normally. Do NOT
+// unmount, flush logs, or take any lock here -- umount may fork/exec fusermount
+// and grab locks, which can deadlock/hang a crashed process and block the core
+// dump. Mount cleanup is left to an external watchdog / the kernel FUSE abort.
+static void HandleCrashSignal(int sig) {
+  static const char msg[] = "dingo-client: fatal signal, re-raising for core\n";
+  ssize_t n = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+  (void)n;
+  signal(sig, SIG_DFL);
+  raise(sig);
+}
 
-  if (fuse_server == nullptr) {
-    return;
-  }
+static void BlockGracefulSignals(sigset_t* set) {
+  sigemptyset(set);
+  sigaddset(set, SIGHUP);
 
-  if (sig == SIGHUP) {
-    fuse_server->MarkThenShutdown();
-  }
-  if (sig == SIGSEGV || sig == SIGABRT) {
-    fuse_server->SessionUnmount();
-    CHECK(raise(sig) == 0);
-  }
+  // Block SIGHUP in the process before worker threads are created. The signal
+  // thread below consumes it synchronously with sigwait(), so the handover path
+  // runs in a normal thread context instead of an async signal handler.
+  CHECK_EQ(pthread_sigmask(SIG_BLOCK, set, nullptr), 0);
+}
 
-  // flush log
-  dingofs::Logger::FlushLogs();
-  dingofs::client::FlushAccessLog();
-  dingofs::client::vfs::FlushMetaLog();
+static std::thread StartGracefulSignalThread(const sigset_t& set,
+                                             std::atomic<bool>* stopped) {
+  return std::thread([set, stopped]() {
+    while (!stopped->load()) {
+      int sig = 0;
+      // sigwait only fails with EINVAL (an invalid signal in the set), a
+      // programming error here; fail loudly rather than spinning on a tight
+      // retry loop that would peg a CPU and flood the log.
+      CHECK_EQ(sigwait(&set, &sig), 0) << "sigwait failed";
+      if (stopped->load()) break;
+
+      if (sig == SIGHUP && fuse_server != nullptr) {
+        fuse_server->TriggerHandover();
+      }
+    }
+  });
 }
 
 static int InstallSignal(int sig, void (*handler)(int)) {
@@ -102,10 +123,12 @@ int main(int argc, char* argv[]) {
     orig_args.emplace_back(argv[i]);
   }
 
-  // install singal handler
-  InstallSignal(SIGHUP, HandleSignal);
-  InstallSignal(SIGSEGV, HandleSignal);
-  InstallSignal(SIGABRT, HandleSignal);
+  sigset_t graceful_signal_set;
+  BlockGracefulSignals(&graceful_signal_set);
+
+  // install crash signal handlers
+  InstallSignal(SIGSEGV, HandleCrashSignal);
+  InstallSignal(SIGABRT, HandleCrashSignal);
 
   //  parse gflags
   int rc = dingofs::ParseFlags(&argc, &argv, extras);
@@ -188,19 +211,21 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  struct MountOption mount_option{
-      .mount_point = mountpoint,
-      .fs_name = fs_name,
-      .metasystem_type = metasystem_type,
-      .mds_addrs = mds_addrs,
-      .storage_info = storage_info,
-      .meta_url = argv[1],
-      .subdir = dingofs::client::FLAGS_fuse_subdir,
+  struct MountOption mount_option {
+    .mount_point = mountpoint, .fs_name = fs_name,
+    .metasystem_type = metasystem_type, .mds_addrs = mds_addrs,
+    .storage_info = storage_info, .meta_url = argv[1],
+    .subdir = dingofs::client::FLAGS_fuse_subdir,
   };
 
   fuse_server = new FuseServer();
   if (fuse_server == nullptr) return EXIT_FAILURE;
-  auto defer_free = dingofs::MakeScopedCleanup([&]() { delete fuse_server; });
+  // Null the global after delete; the graceful signal thread is joined before
+  // this cleanup runs.
+  auto defer_free = dingofs::MakeScopedCleanup([&]() {
+    delete fuse_server;
+    fuse_server = nullptr;
+  });
 
   // init fuse
   if (fuse_server->Init(argv[0], &mount_option) == 1) return EXIT_FAILURE;
@@ -220,12 +245,25 @@ int main(int argc, char* argv[]) {
   // create fuse session
   if (fuse_server->CreateSession(&fs_context) == 1) return EXIT_FAILURE;
   auto defer_destory =
-      dingofs::MakeScopedCleanup([&]() { fuse_server->DestroySsesion(); });
+      dingofs::MakeScopedCleanup([&]() { fuse_server->DestroySession(); });
 
   // mount filesystem
   if (fuse_server->SessionMount() == 1) return EXIT_FAILURE;
   auto defer_unmount =
       dingofs::MakeScopedCleanup([&]() { fuse_server->SessionUnmount(); });
+
+  fuse_server->ArmHandoverController();
+
+  std::atomic<bool> graceful_signal_thread_stopped{false};
+
+  auto graceful_signal_thread = StartGracefulSignalThread(
+      graceful_signal_set, &graceful_signal_thread_stopped);
+
+  auto defer_signal_thread = dingofs::MakeScopedCleanup([&]() {
+    graceful_signal_thread_stopped.store(true);
+    pthread_kill(graceful_signal_thread.native_handle(), SIGHUP);
+    if (graceful_signal_thread.joinable()) graceful_signal_thread.join();
+  });
 
   if (fuse_server->Serve() == 1) return EXIT_FAILURE;
 

--- a/src/client/vfs/data/reader/file_reader.cc
+++ b/src/client/vfs/data/reader/file_reader.cc
@@ -221,7 +221,7 @@ void FileReader::SchedulePeriodicShrink() {
   }
 
   AcquireRef();
-  vfs_hub_->GetBGExecutor()->Schedule(
+  vfs_hub_->GetReadCleanupExecutor()->Schedule(
       [this] {
         RunPeriodicShrink();
         ReleaseRef();
@@ -351,10 +351,11 @@ ReadRequestSptr FileReader::NewReadRequest(int64_t s, int64_t e) {
   return new_req;
 }
 
-// NOTD: hold req lock
-void FileReader::DeleteReadRequestAsync(ReadRequestSptr req) {
+// NOTE: caller holds req lock. Schedule cleanup outside the completion callback
+// path so request erasure runs in the reader cleanup lane.
+void FileReader::ScheduleReadRequestCleanup(ReadRequestSptr req) {
   AcquireRef();
-  vfs_hub_->GetBGExecutor()->Execute([&, req]() {
+  vfs_hub_->GetReadCleanupExecutor()->Execute([&, req]() {
     DeleteReadRequest(req);
     ReleaseRef();
   });
@@ -369,7 +370,7 @@ void FileReader::DeleteReadRequest(ReadRequestSptr req) {
 //
 // erase() is intentionally idempotent. A request may be reclaimed by several
 // uncoordinated paths that all delete on the same (kInvalid && readers==0)
-// condition: the async DeleteReadRequestAsync scheduled from
+// condition: the scheduled cleanup from ScheduleReadRequestCleanup,
 // OnReadRequestComplete, the per-read CleanUpRequest, the periodic ShrinkMem,
 // and the foreground Read cleanup. The async path decides to delete while
 // holding only req->mutex and erases later under mutex_, so a synchronous path
@@ -435,7 +436,7 @@ void FileReader::OnReadRequestComplete(ReadRequestSptr req, Status s) {
       break;
     case ReadRequestState::kInvalid:
       if (req->readers == 0) {
-        DeleteReadRequestAsync(req);
+        ScheduleReadRequestCleanup(req);
       } else {
         // it's user's responsibility to clean up
         req->cv.notify_all();

--- a/src/client/vfs/data/reader/file_reader.h
+++ b/src/client/vfs/data/reader/file_reader.h
@@ -84,7 +84,7 @@ class FileReader {
   // pretected by mutex_
   void DeleteReadRequestUnlock(ReadRequestSptr req);
   void DeleteReadRequest(ReadRequestSptr req);
-  void DeleteReadRequestAsync(ReadRequestSptr req);
+  void ScheduleReadRequestCleanup(ReadRequestSptr req);
 
   // pretected by mutex_
   void CheckReadahead(ContextSPtr ctx, const FileRange& frange, int64_t flen);

--- a/src/client/vfs/data/slice/slice_writer.cc
+++ b/src/client/vfs/data/slice/slice_writer.cc
@@ -94,10 +94,11 @@ void SliceWriter::DecRef() {
 
 void SliceWriter::StartPrepareSliceId() {
   // Hold a ref for the async work to prevent use-after-free if SliceWriter
-  // is destroyed before BGExecutor picks up the lambda (high load + short
-  // SliceWriter lifetime). Mirrors the pattern in UploadBlockAsync.
+  // is destroyed before write_background_executor picks up the lambda (high
+  // load + short SliceWriter lifetime). Mirrors the pattern in
+  // UploadBlockAsync.
   IncRef();
-  vfs_hub_->GetBGExecutor()->Execute([this]() {
+  vfs_hub_->GetWriteBackgroundExecutor()->Execute([this]() {
     PrepareSliceId();
     DecRef();
   });

--- a/src/client/vfs/data/slice/slice_writer.h
+++ b/src/client/vfs/data/slice/slice_writer.h
@@ -59,7 +59,7 @@ class SliceWriter {
   // Should be called only once (protected by ChunkWriter).
   void FlushAsync(StatusCallback cb);
 
-  // Trigger async slice_id pre-allocation on BGExecutor.
+  // Trigger async slice_id pre-allocation on the write background executor.
   // Called by ChunkWriter after construction.
   void StartPrepareSliceId();
 

--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -384,7 +384,7 @@ void FileWriter::SchedulePeriodicFlush() {
 
   AcquireRef();
 
-  vfs_hub_->GetBGExecutor()->Schedule(
+  vfs_hub_->GetWriteBackgroundExecutor()->Schedule(
       [this] {
         RunPeriodicFlush();
         ReleaseRef();

--- a/src/client/vfs/handle/handle_manager.cc
+++ b/src/client/vfs/handle/handle_manager.cc
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include "client/vfs/data/reader/file_reader.h"
@@ -38,54 +39,99 @@ namespace vfs {
 std::string Handle::ToString() const {
   std::ostringstream oss;
   oss << "Handle{ino: " << ino << ", fh: " << fh << ", flags: " << std::oct
-      << flags << ", has_reader: " << (reader ? "true" : "false")
-      << ", has_writer: " << (writer ? "true" : "false") << "}";
+      << flags << ", has_reader: " << (resources.reader ? "true" : "false")
+      << ", has_writer: " << (resources.writer ? "true" : "false") << "}";
   return oss.str();
 }
 
 HandleManager::~HandleManager() {
   Stop();
-  std::unique_lock<std::mutex> lock(mutex_);
-  for (auto& [fh, handle] : handles_) {
+  std::vector<Handle*> handles;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    handles.reserve(handles_.size());
+    for (auto& [fh, handle] : handles_) {
+      handles.push_back(handle);
+    }
+    handles_.clear();
+  }
+
+  for (auto* handle : handles) {
     ReleaseRefHandle(handle);
   }
-  handles_.clear();
+}
+
+HandleGuard::~HandleGuard() { Reset(); }
+
+HandleGuard::HandleGuard(HandleGuard&& other) noexcept
+    : manager_(std::exchange(other.manager_, nullptr)),
+      handle_(std::exchange(other.handle_, nullptr)) {}
+
+HandleGuard& HandleGuard::operator=(HandleGuard&& other) noexcept {
+  if (this != &other) {
+    Reset();
+    manager_ = std::exchange(other.manager_, nullptr);
+    handle_ = std::exchange(other.handle_, nullptr);
+  }
+  return *this;
+}
+
+void HandleGuard::Reset() {
+  if (manager_ != nullptr && handle_ != nullptr) {
+    manager_->ReleaseGuard(handle_);
+    manager_ = nullptr;
+    handle_ = nullptr;
+  }
 }
 
 void HandleManager::AcquireRefHandle(Handle* h) {
   int64_t orgin = h->refs.fetch_add(1);
-  VLOG(12) << fmt::format("handle-{} AcquireRef origin refs: {}", h->fh,
-                          orgin);
+  VLOG(12) << fmt::format("handle-{} AcquireRef origin refs: {}", h->fh, orgin);
   CHECK_GE(orgin, 0);
 }
 
 void HandleManager::ReleaseRefHandle(Handle* h) {
   int64_t orgin = h->refs.fetch_sub(1);
-  VLOG(12) << fmt::format("handle-{} ReleaseRef origin refs: {}", h->fh,
-                          orgin);
+  VLOG(12) << fmt::format("handle-{} ReleaseRef origin refs: {}", h->fh, orgin);
   CHECK_GT(orgin, 0);
   if (orgin == 1) {
     DestroyHandle(h);
   }
+  cv_.notify_all();
 }
 
 void HandleManager::DestroyHandle(Handle* h) {
-  if (h->reader != nullptr) {
-    h->reader->Close();
-    h->reader->ReleaseRef();
-    h->reader = nullptr;
+  HandleResources resources;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    resources = DetachHandleResourcesLocked(h);
   }
-  if (h->writer != nullptr) {
-    vfs_hub_->GetWriterTable()->ReleaseWriter(h->writer);
-    h->writer = nullptr;
-  }
+  ReleaseHandleResources(resources);
   delete h;
+}
+
+void HandleManager::ReleaseGuard(Handle* h) { ReleaseRefHandle(h); }
+
+HandleResources HandleManager::DetachHandleResourcesLocked(Handle* h) {
+  return std::exchange(h->resources, {});
+}
+
+void HandleManager::ReleaseHandleResources(HandleResources resources) {
+  if (resources.reader != nullptr) {
+    resources.reader->Close();
+    resources.reader->ReleaseRef();
+  }
+
+  if (resources.writer != nullptr) {
+    vfs_hub_->GetWriterTable()->ReleaseWriter(resources.writer);
+  }
 }
 
 Status HandleManager::Start() { return Status::OK(); }
 
 void HandleManager::Stop() {
-  std::vector<Handle*> handles_to_close;
+  std::vector<HandleResources> resources_to_release;
+  std::vector<Handle*> stop_refs;
   {
     std::unique_lock<std::mutex> lock(mutex_);
     if (stopped_) {
@@ -95,22 +141,37 @@ void HandleManager::Stop() {
 
     stopped_ = true;
 
+    cv_.wait(lock, [&]() {
+      for (auto& [fh, handle] : handles_) {
+        if (handle->refs.load(std::memory_order_acquire) != 1) {
+          return false;
+        }
+      }
+      return true;
+    });
+
     for (auto& [fh, handle] : handles_) {
       if (handle->ino == kStatsIno) {
         continue;
       }
       AcquireRefHandle(handle);
-      handles_to_close.push_back(handle);
+      stop_refs.push_back(handle);
+
+      auto resources = DetachHandleResourcesLocked(handle);
+      if (resources.reader != nullptr || resources.writer != nullptr) {
+        resources_to_release.push_back(resources);
+      }
     }
   }
 
-  // Force-close the per-fh reader on each surviving Handle. Writer release
-  // happens via ~Handle when refs hit 0 (i.e. when ReleaseHandler is called
-  // for that fh, or from this manager's destructor).
-  for (auto* handle : handles_to_close) {
-    if (handle->reader != nullptr) {
-      handle->reader->Close();
-    }
+  // Release resources outside mutex_: FileWriter::Close() can synchronously
+  // wait for callbacks that may call back into
+  // HandleManager::InvalidateByIno().
+  for (auto& resources : resources_to_release) {
+    ReleaseHandleResources(resources);
+  }
+
+  for (auto* handle : stop_refs) {
     ReleaseRefHandle(handle);
   }
 }
@@ -122,43 +183,54 @@ Handle* HandleManager::NewHandle(uint64_t fh, Ino ino, int flags) {
   handle->flags = flags;
 
   // Reader is always per-fh.
-  handle->reader = new FileReader(vfs_hub_, fh, ino);
-  handle->reader->AcquireRef();
-  Status s = handle->reader->Open();
+  handle->resources.reader = new FileReader(vfs_hub_, fh, ino);
+  handle->resources.reader->AcquireRef();
+  Status s = handle->resources.reader->Open();
   if (!s.ok()) {
-    LOG(ERROR) << fmt::format("NewHandle: reader Open failed, fh={}, ino={}, "
-                              "status={}",
-                              fh, ino, s.ToString());
+    LOG(ERROR) << fmt::format(
+        "NewHandle: reader Open failed, fh={}, ino={}, "
+        "status={}",
+        fh, ino, s.ToString());
     // Reader holds 1 ref from AcquireRef above; release it (reader will
     // delete-this when refs hit 0). Then drop the bare handle.
-    handle->reader->ReleaseRef();
+    handle->resources.reader->ReleaseRef();
     delete handle;
     return nullptr;
   }
 
   // Writer only for writable opens. Borrowed from WriterTable.
   if ((flags & O_ACCMODE) != O_RDONLY) {
-    handle->writer = vfs_hub_->GetWriterTable()->AcquireWriter(ino);
-    if (handle->writer == nullptr) {
+    handle->resources.writer = vfs_hub_->GetWriterTable()->AcquireWriter(ino);
+    if (handle->resources.writer == nullptr) {
       LOG(ERROR) << fmt::format(
           "NewHandle: AcquireWriter failed, fh={}, ino={}", fh, ino);
-      handle->reader->Close();
-      handle->reader->ReleaseRef();
+      handle->resources.reader->Close();
+      handle->resources.reader->ReleaseRef();
       delete handle;
       return nullptr;
     }
   }
 
-  AddHandle(handle);
+  if (!AddHandle(handle)) {
+    DestroyHandle(handle);
+    return nullptr;
+  }
   return handle;
 }
 
-void HandleManager::AddHandle(Handle* handle) {
+bool HandleManager::AddHandle(Handle* handle) {
   std::lock_guard<std::mutex> lock(mutex_);
+  if (stopped_) {
+    LOG(WARNING) << "AddHandle rejected because HandleManager is stopped, fh: "
+                 << handle->fh;
+    return false;
+  }
+
   AcquireRefHandle(handle);
   handles_[handle->fh] = handle;
 
   total_count_ << 1;
+  return true;
 }
 
 void HandleManager::ReleaseHandler(uint64_t fh) {
@@ -167,7 +239,7 @@ void HandleManager::ReleaseHandler(uint64_t fh) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto iter = handles_.find(fh);
     if (iter == handles_.end()) {
-      LOG(ERROR) << "ReleaseHandler failed, fh not found:" << fh;
+      VLOG(1) << "ReleaseHandler ignored, fh not found: " << fh;
       return;
     }
     h = iter->second;
@@ -179,10 +251,30 @@ void HandleManager::ReleaseHandler(uint64_t fh) {
   ReleaseRefHandle(h);
 }
 
-Handle* HandleManager::FindHandler(uint64_t fh) {
+HandleGuard HandleManager::FindHandlerGuard(uint64_t fh) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (stopped_) {
+    return {};
+  }
+
+  auto it = handles_.find(fh);
+  if (it == handles_.end()) {
+    return {};
+  }
+
+  AcquireRefHandle(it->second);
+  return HandleGuard(this, it->second);
+}
+
+HandleGuard HandleManager::FindHandlerForRelease(uint64_t fh) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = handles_.find(fh);
-  return (it == handles_.end()) ? nullptr : it->second;
+  if (it == handles_.end()) {
+    return {};
+  }
+
+  AcquireRefHandle(it->second);
+  return HandleGuard(this, it->second);
 }
 
 void HandleManager::Invalidate(uint64_t fh, int64_t offset, int64_t size) {
@@ -199,8 +291,8 @@ void HandleManager::Invalidate(uint64_t fh, int64_t offset, int64_t size) {
   }
 
   auto* handle = it->second;
-  if (handle->reader != nullptr) {
-    handle->reader->Invalidate(offset, size);
+  if (handle->resources.reader != nullptr) {
+    handle->resources.reader->Invalidate(offset, size);
   } else {
     LOG(WARNING) << "Invalidate failed, reader is nullptr, fh:" << fh;
   }
@@ -210,7 +302,7 @@ Status HandleManager::FlushByIno(Ino ino) {
   // O(1) hash lookup via WriterTable.
   auto* writer = vfs_hub_->GetWriterTable()->PeekWriter(ino);
   if (writer == nullptr) {
-    return Status::OK();   // no writer for this ino → nothing to flush
+    return Status::OK();  // no writer for this ino → nothing to flush
   }
   Status s = writer->Flush();
   vfs_hub_->GetWriterTable()->ReleaseWriter(writer);
@@ -229,7 +321,7 @@ void HandleManager::InvalidateByIno(Ino ino, int64_t offset, int64_t size) {
       return;
     }
     for (auto& [fh, handle] : handles_) {
-      if (handle->ino == ino && handle->reader != nullptr) {
+      if (handle->ino == ino && handle->resources.reader != nullptr) {
         AcquireRefHandle(handle);
         handles_to_invalidate.push_back(handle);
       }
@@ -237,7 +329,7 @@ void HandleManager::InvalidateByIno(Ino ino, int64_t offset, int64_t size) {
   }
 
   for (auto* handle : handles_to_invalidate) {
-    handle->reader->Invalidate(offset, size);
+    handle->resources.reader->Invalidate(offset, size);
     ReleaseRefHandle(handle);
   }
 }

--- a/src/client/vfs/handle/handle_manager.h
+++ b/src/client/vfs/handle/handle_manager.h
@@ -18,6 +18,7 @@
 #define DINGOFS_CLIENT_VFS_HANDLE_MANAGER_H
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -35,11 +36,17 @@ namespace vfs {
 class VFSHub;
 class FileReader;
 class FileWriter;
+class HandleManager;
 
 // temporary store .stats file data
 struct FileBuffer {
   size_t size{0};
   std::unique_ptr<char[]> data{nullptr};
+};
+
+struct HandleResources {
+  FileReader* reader{nullptr};
+  FileWriter* writer{nullptr};  // nullptr for O_RDONLY
 };
 
 // Handle is a pure-data per-fh value object: identity (fh/ino/flags), the
@@ -52,8 +59,7 @@ struct Handle {
   uint64_t fh{0};
   int32_t flags{0};
 
-  FileReader* reader{nullptr};
-  FileWriter* writer{nullptr};   // nullptr for O_RDONLY
+  HandleResources resources;
 
   std::atomic<int64_t> refs{0};
 
@@ -62,9 +68,36 @@ struct Handle {
   std::string ToString() const;
 };
 
+class HandleGuard {
+ public:
+  HandleGuard() = default;
+  ~HandleGuard();
+
+  HandleGuard(const HandleGuard&) = delete;
+  HandleGuard& operator=(const HandleGuard&) = delete;
+
+  HandleGuard(HandleGuard&& other) noexcept;
+  HandleGuard& operator=(HandleGuard&& other) noexcept;
+
+  Handle* get() const { return handle_; }
+  Handle* operator->() const { return handle_; }
+  explicit operator bool() const { return handle_ != nullptr; }
+
+ private:
+  friend class HandleManager;
+
+  HandleGuard(HandleManager* manager, Handle* handle)
+      : manager_(manager), handle_(handle) {}
+
+  void Reset();
+
+  HandleManager* manager_{nullptr};
+  Handle* handle_{nullptr};
+};
+
 class HandleManager {
  public:
-  HandleManager(VFSHub* hub) : vfs_hub_(hub) {};
+  HandleManager(VFSHub* hub) : vfs_hub_(hub){};
 
   ~HandleManager();
 
@@ -77,10 +110,16 @@ class HandleManager {
   // writable open mode.  Returns nullptr on failure.
   Handle* NewHandle(uint64_t fh, Ino ino, int flags);
 
-  // Used by the .stats path — adds an externally-built (data-only) Handle.
-  void AddHandle(Handle* handle);
+  // Used by NewHandle and the .stats path. Returns false after Stop() starts;
+  // ownership stays with the caller in that case.
+  bool AddHandle(Handle* handle);
 
-  Handle* FindHandler(uint64_t fh);
+  // Data-path lookup: returns empty after Stop() starts.
+  HandleGuard FindHandlerGuard(uint64_t fh);
+
+  // Release-path lookup: FUSE_RELEASE must be allowed after Stop() starts so
+  // the fh identity can be removed from handles_.
+  HandleGuard FindHandlerForRelease(uint64_t fh);
 
   void ReleaseHandler(uint64_t fh);
 
@@ -99,6 +138,8 @@ class HandleManager {
   bool Load(const Json::Value& value);
 
  private:
+  friend class HandleGuard;
+
   // Atomic refs ops on Handle::refs. Caller must use these instead of
   // touching Handle::refs directly.
   void AcquireRefHandle(Handle* h);
@@ -111,9 +152,18 @@ class HandleManager {
   // Called from ReleaseRefHandle when refs hit 0.
   void DestroyHandle(Handle* h);
 
+  void ReleaseGuard(Handle* h);
+
+  // Detach resources from the handle identity. Caller must hold mutex_.
+  HandleResources DetachHandleResourcesLocked(Handle* h);
+
+  // Release detached resources without holding mutex_.
+  void ReleaseHandleResources(HandleResources resources);
+
   VFSHub* vfs_hub_{nullptr};
 
   std::mutex mutex_;
+  std::condition_variable cv_;
   bool stopped_{false};
   std::unordered_map<uint64_t, Handle*> handles_;
 

--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -54,7 +54,8 @@ namespace vfs {
 
 static const std::string kFlushExecutorName = "vfs_flush";
 static const std::string kReadExecutorName = "vfs_read";
-static const std::string kBgExecutorName = "vfs_bg";
+static const std::string kReadCleanupExecutorName = "vfs_read_cleanup";
+static const std::string kWriteBackgroundExecutorName = "vfs_write_bg";
 static const std::string kCBExecutorName = "vfs_callback";
 
 static MetaSystemUPtr BuildMetaSystem(const VFSConfig& vfs_conf,
@@ -85,6 +86,21 @@ WriterTable* VFSHubImpl::GetWriterTable() {
 }
 
 VFSHubImpl::~VFSHubImpl() {
+  // Quiesce before tearing members down. Stop() is idempotent, so this is a
+  // no-op after a normal shutdown that already stopped the hub; but it is the
+  // only thing that stops live components when Start() failed half-way and the
+  // external Stop() path was skipped -- otherwise e.g. ~BatchProcessor would
+  // pthread_cond_destroy a condition variable its worker is still waiting on
+  // and hang the process forever.
+  //
+  // skip_unmount=false: the only case where this actually runs (rather than
+  // no-op) is a dying process whose external Stop() never ran -- it should
+  // deregister its own client_id from the MDS (UnmountFs is per-client_id, it
+  // never touches a peer's mount). A successful handover already ran an
+  // explicit Stop(/*skip_unmount=*/true), so this is a no-op there and does not
+  // override it.
+  Stop(/*skip_unmount=*/false);
+
   if (handle_manager_ != nullptr) {
     handle_manager_.reset();
   }
@@ -97,12 +113,16 @@ VFSHubImpl::~VFSHubImpl() {
     read_executor_.reset();
   }
 
-  if (flush_executor_ != nullptr) {
-    flush_executor_.reset();
+  if (read_cleanup_executor_ != nullptr) {
+    read_cleanup_executor_.reset();
   }
 
-  if (bg_executor_ != nullptr) {
-    bg_executor_.reset();
+  if (write_background_executor_ != nullptr) {
+    write_background_executor_.reset();
+  }
+
+  if (flush_executor_ != nullptr) {
+    flush_executor_.reset();
   }
 
   if (warmup_manager_ != nullptr) {
@@ -137,6 +157,10 @@ VFSHubImpl::~VFSHubImpl() {
 Status VFSHubImpl::Start(bool skip_mount) {
   CHECK(started_.load(std::memory_order_relaxed) == false)
       << "unexpected start";
+
+  // Arm teardown before creating any component: if Start() fails half-way, the
+  // destructor's Stop() must still quiesce whatever came up.
+  stopped_.store(false, std::memory_order_relaxed);
 
   LOG(INFO) << fmt::format("[vfs.hub] vfs hub starting, skip_mount({}).",
                            skip_mount);
@@ -268,10 +292,19 @@ Status VFSHubImpl::Start(bool skip_mount) {
   }
 
   {
-    bg_executor_ = std::make_unique<ExecutorImpl>(kBgExecutorName,
-                                                  FLAGS_vfs_bg_executor_thread);
-    if (!bg_executor_->Start()) {
-      return Status::Internal("bg executor start fail");
+    read_cleanup_executor_ = std::make_unique<ExecutorImpl>(
+        kReadCleanupExecutorName, FLAGS_vfs_read_cleanup_executor_thread);
+    if (!read_cleanup_executor_->Start()) {
+      return Status::Internal("read cleanup executor start fail");
+    }
+  }
+
+  {
+    write_background_executor_ = std::make_unique<ExecutorImpl>(
+        kWriteBackgroundExecutorName,
+        FLAGS_vfs_write_background_executor_thread);
+    if (!write_background_executor_->Start()) {
+      return Status::Internal("write background executor start fail");
     }
   }
 
@@ -378,7 +411,16 @@ Status VFSHubImpl::Start(bool skip_mount) {
 
 // NOTE: the stop sequence is important, please do not change it lightly.
 Status VFSHubImpl::Stop(bool skip_unmount) {
-  if (!started_.load(std::memory_order_relaxed)) {
+  // Teardown-once gate. The first caller runs the full quiescence; later
+  // callers (the destructor after a normal Stop, or a second handover Stop)
+  // no-op. Gated on stopped_ rather than started_ so a half-started hub (e.g.
+  // Start failed after components came up because the brpc dummy server could
+  // not bind) still tears its live components down instead of leaking them into
+  // a destructor that would hang (~BatchProcessor destroying an in-use
+  // condition variable). NOTE: assumes Stop() calls are sequential (they are on
+  // the teardown path); concurrent Stop() would need a wait-for-completion
+  // guard, not exchange.
+  if (stopped_.exchange(true)) {
     return Status::OK();
   }
 
@@ -409,8 +451,10 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
     read_executor_->Stop();
   }
 
-  if (bg_executor_ != nullptr) {
-    bg_executor_->Stop();
+  // Writer-side background tasks may call meta_system/block_store or enqueue
+  // flush work, so drain them while those dependencies are still alive.
+  if (write_background_executor_ != nullptr) {
+    write_background_executor_->Stop();
   }
 
   if (flush_executor_ != nullptr) {
@@ -430,12 +474,27 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
     prefetch_manager_->Stop();
   }
 
-  if (meta_wrapper_ != nullptr) {
-    meta_wrapper_->Stop(skip_unmount);
-  }
-
+  // Block cache read/prefetch completions run in cache-owned bthreads and may
+  // schedule read cleanup work. Keep read_cleanup_executor_ alive until
+  // block_store_->Shutdown() has joined those bthreads.
   if (block_store_ != nullptr) {
     block_store_->Shutdown();
+  }
+
+  // read_cleanup_executor_ is the consumer of read completions (it erases
+  // finished read requests); stop it only after block_store_ has joined every
+  // read bthread, otherwise a straggler completion submits to a dead executor.
+  if (read_cleanup_executor_ != nullptr) {
+    read_cleanup_executor_->Stop();
+  }
+
+  // meta_wrapper_ can stop after block_store_: the metasystem flushes to MDS
+  // via RPC and never pushes data through block_store_, and its only background
+  // producer (write_background_executor_'s slice_id pre-allocation) was already
+  // drained above. Block-store completions firing during Shutdown() touch only
+  // read_cleanup_executor_ / cb_executor_, never meta.
+  if (meta_wrapper_ != nullptr) {
+    meta_wrapper_->Stop(skip_unmount);
   }
 
   if (trace_manager_ != nullptr) {
@@ -453,6 +512,11 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
   LOG(INFO) << fmt::format("[vfs.hub] stopped vfs hub, skip_unmount({}).",
                            skip_unmount);
 
+  // Mark not-serving only after every component is stopped. GetFsInfo() /
+  // GetBlockAccesserOptions() CHECK(started_), and a draining background task
+  // (e.g. an in-flight compaction the compactor is joining) may still call them
+  // while the components are being torn down. Clearing started_ at the top of
+  // Stop() would CHECK-fail (SIGABRT) such a late caller mid-teardown.
   started_.store(false, std::memory_order_relaxed);
 
   return Status::OK();

--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -397,9 +397,9 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
     handle_manager_->Stop();
   }
 
-  // After all Handles are gone, drain residual dirty data and stop the
-  // writer table.  WriterTable::Stop only marks stopped_; FlushAll flushes
-  // any writers that survived (e.g. via lambdas still holding refs).
+  // HandleManager::Stop releases handle-owned reader/writer resources while
+  // preserving handle identities for handover Dump. Drain residual dirty data
+  // and stop the writer table before tearing down executors/meta/block-store.
   if (writer_table_ != nullptr) {
     (void)writer_table_->FlushAll();
     writer_table_->Stop();

--- a/src/client/vfs/hub/vfs_hub.h
+++ b/src/client/vfs/hub/vfs_hub.h
@@ -73,7 +73,9 @@ class VFSHub {
 
   virtual Executor* GetReadExecutor() = 0;
 
-  virtual Executor* GetBGExecutor() = 0;
+  virtual Executor* GetReadCleanupExecutor() = 0;
+
+  virtual Executor* GetWriteBackgroundExecutor() = 0;
 
   virtual Executor* GetFlushExecutor() = 0;
 
@@ -139,9 +141,14 @@ class VFSHubImpl : public VFSHub {
     return read_executor_.get();
   }
 
-  Executor* GetBGExecutor() override {
-    CHECK_NOTNULL(bg_executor_);
-    return bg_executor_.get();
+  Executor* GetReadCleanupExecutor() override {
+    CHECK_NOTNULL(read_cleanup_executor_);
+    return read_cleanup_executor_.get();
+  }
+
+  Executor* GetWriteBackgroundExecutor() override {
+    CHECK_NOTNULL(write_background_executor_);
+    return write_background_executor_.get();
   }
 
   Executor* GetFlushExecutor() override {
@@ -205,7 +212,15 @@ class VFSHubImpl : public VFSHub {
   }
 
  private:
+  // started_ means "serviceable to FUSE ops" (set when Start completes, cleared
+  // when Stop begins). stopped_ is the teardown-needed gate: it starts true (a
+  // freshly constructed, never-started hub owns nothing to tear down), Start()
+  // arms it (false) before creating any component, and Stop() disarms it (back
+  // to true) exactly once. So the destructor's Stop() tears down a half-started
+  // hub yet is a clean no-op for a never-started or already-stopped one,
+  // without relying on the "no Start() after Stop()" invariant.
   std::atomic_bool started_{false};
+  std::atomic_bool stopped_{true};
 
   blockaccess::BlockAccessOptions blockaccess_options_;
 
@@ -223,7 +238,19 @@ class VFSHubImpl : public VFSHub {
   std::unique_ptr<blockaccess::BlockAccesser> block_accesser_;
   std::unique_ptr<BlockStore> block_store_;
   std::unique_ptr<Executor> read_executor_;
-  std::unique_ptr<Executor> bg_executor_;
+
+  // Reader-local cleanup only: periodic shrink and read-request cleanup.
+  // It must not issue block_store I/O.  Keep it alive until after
+  // block_store_->Shutdown(), because cache bthread read completions can still
+  // schedule cleanup work while block_store is draining.
+  std::unique_ptr<Executor> read_cleanup_executor_;
+
+  // Writer-side background work: periodic flush scheduling and slice-id
+  // pre-allocation.  These tasks may touch flush_executor, block_store, and
+  // meta_system, so Stop() must drain this executor before those dependencies
+  // are torn down.
+  std::unique_ptr<Executor> write_background_executor_;
+
   std::unique_ptr<Executor> flush_executor_;
   std::unique_ptr<Executor> cb_executor_;
   std::unique_ptr<WriteMemPool> write_buffer_manager_;

--- a/src/client/vfs/hub/vfs_hub.h
+++ b/src/client/vfs/hub/vfs_hub.h
@@ -22,7 +22,6 @@
 #include <atomic>
 #include <memory>
 
-#include "cache/infiniband/infiniband.h"
 #include "client/vfs/blockstore/block_store.h"
 #include "client/vfs/common/client_id.h"
 #include "client/vfs/compaction/compactor.h"

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -231,7 +231,7 @@ class MDSMetaSystem : public vfs::MetaSystem {
   Status FlushSliceAndFile(ContextSPtr ctx, Ino ino);
   // async flush of single slice
   void AsyncFlushFile(ContextSPtr ctx, Ino ino);
-  // flush slices of all files
+  // flush slices of all files (called internally by Stop)
   void FlushAllFile();
 
   Status CorrectAttr(ContextSPtr ctx, uint64_t time_ns, Attr& attr,

--- a/src/client/vfs/metasystem/meta_wrapper.h
+++ b/src/client/vfs/metasystem/meta_wrapper.h
@@ -19,6 +19,7 @@
 
 #include <glog/logging.h>
 
+#include <atomic>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -36,14 +37,40 @@ namespace vfs {
 class MetaWrapper {
  public:
   MetaWrapper(MetaSystemUPtr target);
-  ~MetaWrapper() = default;
+
+  // Defense in depth: guarantee the underlying metasystem (and its batch
+  // processor worker) is stopped before destruction, even if VFSHubImpl::Stop
+  // never reached meta_wrapper_->Stop(). Stop() is idempotent. skip_unmount is
+  // false so a dying process that never ran an external Stop() still
+  // deregisters its own client_id; a handover already ran an explicit
+  // Stop(true), making this a no-op there (it never overrides the handover's
+  // skipped unmount).
+  ~MetaWrapper() { Stop(/*skip_unmount=*/false); }
 
   Status Init(bool skip_mount) {
     CHECK(target_ != nullptr) << "meta system is null";
-    return target_->Init(skip_mount);
+    Status s = target_->Init(skip_mount);
+    if (s.ok()) {
+      // Arm teardown only after a FULLY successful Init. If the metasystem's
+      // Init() fails half-way, Stop() must NOT run: MDSMetaSystem::Stop()
+      // unconditionally stops sub-components (executor_, compact_processor_,
+      // ...) that a partial Init left uninitialized, which would crash. Leaving
+      // stopped_=true makes the destructor's Stop() a no-op and cleanup falls
+      // to the (uninitialized-safe) member destructors, matching pre-fix
+      // behavior.
+      stopped_.store(false);
+    }
+    return s;
   }
 
-  void Stop(bool skip_unmount) { target_->Stop(skip_unmount); }
+  // Idempotent: shields the underlying (unbounded) FlushAllFile and the batch
+  // processor join from any repeated Stop().
+  void Stop(bool skip_unmount) {
+    if (stopped_.exchange(true)) {
+      return;
+    }
+    target_->Stop(skip_unmount);
+  }
 
   bool Dump(ContextSPtr ctx, Json::Value& value) {
     return target_->Dump(ctx, value);
@@ -214,6 +241,10 @@ class MetaWrapper {
   }
 
  private:
+  // Starts true (a never-Init'd wrapper owns no live worker); Init() arms it
+  // (false) and Stop() disarms it (true) exactly once.
+  std::atomic<bool> stopped_{true};
+
   MetaSystemUPtr target_;
   std::unique_ptr<metrics::client::SliceMetric> slice_metric_;
 };

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -98,7 +98,7 @@ VFSImpl::VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id)
     : client_id_(client_id),
       mount_root_path_(
           vfs_conf.mount_root_path.empty() ? "/" : vfs_conf.mount_root_path),
-      vfs_hub_(std::make_unique<VFSHubImpl>(vfs_conf, client_id_)) {};
+      vfs_hub_(std::make_unique<VFSHubImpl>(vfs_conf, client_id_)){};
 
 VFSImpl::VFSImpl(std::unique_ptr<VFSHub> hub)
     : client_id_(), vfs_hub_(std::move(hub)) {

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -562,10 +562,12 @@ Status VFSImpl::Open(ContextSPtr ctx, Ino ino, int flags, uint64_t* fh) {
     handler->file_buffer.size = len;
     handler->file_buffer.data = std::move(file_data_ptr);
 
+    if (!handle_manager_->AddHandle(handler)) {
+      delete handler;
+      return Status::BadFd("handle manager stopped");
+    }
+
     *fh = handler->fh;
-
-    handle_manager_->AddHandle(handler);
-
     return Status::OK();
   }
 
@@ -614,8 +616,8 @@ Status VFSImpl::Read(ContextSPtr ctx, Ino ino, DataBuffer* data_buffer,
                      uint64_t size, uint64_t offset, uint64_t fh,
                      uint64_t* out_rsize) {
   Status s;
-  auto* handle = handle_manager_->FindHandler(fh);
-  VFS_CHECK_HANDLE(handle, ino, fh);
+  auto handle = handle_manager_->FindHandlerGuard(fh);
+  VFS_CHECK_HANDLE(handle.get(), ino, fh);
   auto span = vfs_hub_->GetTraceManager()->StartChildSpan("VFSImpl::Read",
                                                           ctx->GetTraceSpan());
   // read .stats file data
@@ -632,7 +634,7 @@ Status VFSImpl::Read(ContextSPtr ctx, Ino ino, DataBuffer* data_buffer,
     return Status::OK();
   }
 
-  if (handle->reader == nullptr) {
+  if (handle->resources.reader == nullptr) {
     LOG(ERROR) << "reader is null in handle, ino: " << ino << ", fh: " << fh;
     s = Status::BadFd(fmt::format("bad fh:{}", fh));
     SpanScope::SetStatus(span, s);
@@ -663,8 +665,8 @@ Status VFSImpl::Read(ContextSPtr ctx, Ino ino, DataBuffer* data_buffer,
     }
   }
 
-  s = handle->reader->Read(SpanScope::GetContext(span), data_buffer, size,
-                           offset, out_rsize);
+  s = handle->resources.reader->Read(SpanScope::GetContext(span), data_buffer,
+                                     size, offset, out_rsize);
   SpanScope::SetStatus(span, s);
 
   return s;
@@ -677,21 +679,21 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
   *out_wsize = 0;
 
   Status s;
-  auto* handle = handle_manager_->FindHandler(fh);
-  VFS_CHECK_HANDLE(handle, ino, fh);
+  auto handle = handle_manager_->FindHandlerGuard(fh);
+  VFS_CHECK_HANDLE(handle.get(), ino, fh);
 
   auto span = vfs_hub_->GetTraceManager()->StartChildSpan("VFSImpl::Write",
                                                           ctx->GetTraceSpan());
 
-  if (handle->writer == nullptr) {
+  if (handle->resources.writer == nullptr) {
     LOG(ERROR) << "writer is null (read-only fh), ino: " << ino
                << ", fh: " << fh;
     s = Status::BadFd(fmt::format("read-only fh:{}", fh));
     return s;
   }
 
-  s = handle->writer->Write(SpanScope::GetContext(span), buf, size, offset,
-                            out_wsize);
+  s = handle->resources.writer->Write(SpanScope::GetContext(span), buf, size,
+                                      offset, out_wsize);
   // Use *out_wsize, not size: writer->Write may short-write (OK with
   // *out_wsize < size) when the page pool is exhausted mid-write. Metadata must
   // reflect only what is durable -- MetaSystem::Write extends the inode length
@@ -719,12 +721,12 @@ Status VFSImpl::Flush(ContextSPtr ctx, Ino ino, uint64_t fh) {
   }
 
   Status s;
-  auto* handle = handle_manager_->FindHandler(fh);
-  VFS_CHECK_HANDLE(handle, ino, fh);
+  auto handle = handle_manager_->FindHandlerGuard(fh);
+  VFS_CHECK_HANDLE(handle.get(), ino, fh);
 
   // O_RDONLY fh has no writer — nothing to flush at the data layer.
-  if (handle->writer != nullptr) {
-    s = handle->writer->Flush();
+  if (handle->resources.writer != nullptr) {
+    s = handle->resources.writer->Flush();
     if (!s.ok()) return s;
   }
 
@@ -740,15 +742,28 @@ Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
   }
 
   Status s;
-  auto* handle = handle_manager_->FindHandler(fh);
-  VFS_CHECK_HANDLE(handle, ino, fh);
-
-  // Per-fh reader is closed here; writer release happens via ~Handle when
-  // ReleaseHandler triggers refs→0.
-  if (handle->reader != nullptr) {
-    handle->reader->Close();
+  auto handle = handle_manager_->FindHandlerForRelease(fh);
+  if (!handle) {
+    VLOG(1) << "Release ignored, fh not found, ino: " << ino << ", fh: " << fh;
+    return Status::OK();
   }
-  s = meta_system_->Close(ctx, ino, fh);
+  VFS_CHECK_HANDLE(handle.get(), ino, fh);
+
+  // If Stop() has already detached reader/writer resources, this late release
+  // must only remove the fh identity. The stop/dump path owns the remaining
+  // metadata state; calling meta Close here could race with meta teardown or
+  // erase state needed by hot-upgrade dump.
+  const bool resources_detached = (handle->resources.reader == nullptr &&
+                                   handle->resources.writer == nullptr);
+
+  // Per-fh reader is closed here when resources are still live; writer release
+  // happens via ~Handle when ReleaseHandler triggers refs→0.
+  if (handle->resources.reader != nullptr) {
+    handle->resources.reader->Close();
+  }
+  if (!resources_detached) {
+    s = meta_system_->Close(ctx, ino, fh);
+  }
 
   handle_manager_->ReleaseHandler(fh);
 
@@ -758,11 +773,11 @@ Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
 // TODO: seperate data flush with metadata flush
 Status VFSImpl::Fsync(ContextSPtr ctx, Ino ino, int datasync, uint64_t fh) {
   Status s;
-  auto* handle = handle_manager_->FindHandler(fh);
-  VFS_CHECK_HANDLE(handle, ino, fh);
+  auto handle = handle_manager_->FindHandlerGuard(fh);
+  VFS_CHECK_HANDLE(handle.get(), ino, fh);
 
-  if (handle->writer != nullptr) {
-    s = handle->writer->Flush();
+  if (handle->resources.writer != nullptr) {
+    s = handle->resources.writer->Flush();
   }
 
   if (datasync == 0) {

--- a/src/client/vfs/vfs_impl.h
+++ b/src/client/vfs/vfs_impl.h
@@ -175,8 +175,8 @@ class VFSImpl : public VFS {
   uint32_t LocalGidToHashed(uint32_t gid) const;
 
   // Translate a (uid, gid) outbound pair under a single read lock.
-  void LocalPairToHashed(uint32_t uid, uint32_t gid,
-                         uint32_t& out_uid, uint32_t& out_gid) const;
+  void LocalPairToHashed(uint32_t uid, uint32_t gid, uint32_t& out_uid,
+                         uint32_t& out_gid) const;
 
   // Rewrite an Attr's uid/gid from MDS hashed ids back to host-local, using
   // this mount's UidGidMapper. No-op when uid/gid mapping is disabled.

--- a/src/client/vfs/vfs_wrapper.cc
+++ b/src/client/vfs/vfs_wrapper.cc
@@ -128,7 +128,13 @@ static bool AtomicWriteStateFile(const std::string& dir,
     }
     ok = true;
   } while (false);
-  close(fd);
+  // A close() error after a successful fsync() can still report a deferred
+  // write-back failure; treat it as a failed publish.
+  if (close(fd) != 0 && ok) {
+    LOG(ERROR) << "close temp state file fail, file: " << tmp
+               << ", error: " << std::strerror(errno);
+    ok = false;
+  }
 
   if (!ok) {
     std::remove(tmp.c_str());
@@ -142,10 +148,30 @@ static bool AtomicWriteStateFile(const std::string& dir,
     return false;
   }
 
+  // fsync the directory so the rename is durable. If this cannot be guaranteed,
+  // fail closed AND remove the just-published file: the rename already replaced
+  // the target, so leaving it would expose the new process to a failed
+  // attempt's residue. The new process must not take over a state file whose
+  // rename may not have reached disk.
   int dfd = open(dir.c_str(), O_RDONLY | O_DIRECTORY);
-  if (dfd >= 0) {
-    fsync(dfd);
+  if (dfd < 0) {
+    LOG(ERROR) << "open state dir for fsync fail, dir: " << dir
+               << ", error: " << std::strerror(errno);
+    std::remove(path.c_str());
+    return false;
+  }
+  if (fsync(dfd) != 0) {
+    LOG(ERROR) << "fsync state dir fail, dir: " << dir
+               << ", error: " << std::strerror(errno);
     close(dfd);
+    std::remove(path.c_str());
+    return false;
+  }
+  if (close(dfd) != 0) {
+    LOG(ERROR) << "close state dir fail, dir: " << dir
+               << ", error: " << std::strerror(errno);
+    std::remove(path.c_str());
+    return false;
   }
   return true;
 }
@@ -327,7 +353,20 @@ Status VFSWrapper::Stop(bool handover) {
       [&]() { return absl::StrFormat("stop: %s", s.ToString()); });
   s = vfs_->Stop(/*skip_unmount=*/handover);
 
+  // The VFS teardown has run; mark stopped so a second Stop() (e.g. the
+  // post-exit FuseOpDestroy after a successful handover gate) is a no-op and
+  // does not stop/dump twice.
+  started_.store(false);
+
   LOG(INFO) << fmt::format("stopped vfs, handover({}).", handover);
+
+  // Handover teardown: dump after vfs_->Stop() so the persisted state reflects
+  // the same stop -> dump order used by normal teardown. This is currently past
+  // the clean rollback point; callers treat a non-OK return here as an
+  // unrecoverable handover fault after the pre-teardown flush has succeeded.
+  if (handover && !s.ok()) {
+    return s;
+  }
 
   if (handover && !Dump()) {
     return Status::InvalidParam("dump vfs state fail");

--- a/src/client/vfs/vfs_wrapper.cc
+++ b/src/client/vfs/vfs_wrapper.cc
@@ -16,8 +16,12 @@
 
 #include "client/vfs/vfs_wrapper.h"
 
+#include <fcntl.h>
+#include <unistd.h>
+
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -31,6 +35,7 @@
 #include "client/vfs/vfs_meta.h"
 #include "common/blockaccess/block_access_log.h"
 #include "common/const.h"
+#include "common/directory.h"
 #include "common/helper.h"
 #include "common/logging.h"
 #include "common/metrics/client/client.h"
@@ -50,7 +55,13 @@ DECLARE_string(log_dir);
 namespace dingofs {
 namespace client {
 
-const std::string kFdStatePath = "/tmp/dingo-client-state.json";
+// State file lives under the dingofs runtime data dir (not /tmp), e.g.
+// $DINGOFS_BASE_DIR/data, /var/dingofs/data (root) or $HOME/.dingofs/data.
+// Old (writer) and new (reader) processes resolve the same path as long as
+// they run with the same uid and DINGOFS_BASE_DIR env -- the same assumption
+// already made for the fd-comm socket dir (GetDefaultDir(kSocketDir)).
+const std::string kFdStateDir = GetDefaultDir(kDataDir);
+const std::string kFdStatePath = kFdStateDir + "/dingo-client-state.json";
 
 using metrics::ClientOpMetricGuard;
 using metrics::VFSRWMetricGuard;
@@ -71,6 +82,72 @@ static Status InitLog() {
 
   CHECK(succ) << "init log failed, unexpected!";
   return Status::OK();
+}
+
+// Atomically publish `content` to `path`: write a sibling temp file, fsync it,
+// rename(2) it over the target (atomic on the same filesystem), then fsync the
+// directory so the rename survives a crash. Because the temp sits in the same
+// dir as the target, the reader (new process) never observes a half-written
+// state file -- it sees either the previous file or the fully renamed one.
+// Returns false and removes the temp on any error so the caller can abort the
+// handover instead of letting the new process load a truncated state.
+static bool AtomicWriteStateFile(const std::string& dir,
+                                 const std::string& path,
+                                 const std::string& content) {
+  if (!dingofs::Helper::CreateDirectory(dir)) {
+    LOG(ERROR) << "create state dir fail, dir: " << dir;
+    return false;
+  }
+
+  const std::string tmp = fmt::format("{}.tmp.{}", path, getpid());
+  int fd = open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  if (fd < 0) {
+    LOG(ERROR) << "open temp state file fail, file: " << tmp
+               << ", error: " << std::strerror(errno);
+    return false;
+  }
+
+  bool ok = false;
+  do {
+    size_t off = 0;
+    while (off < content.size()) {
+      ssize_t n = write(fd, content.data() + off, content.size() - off);
+      if (n < 0) {
+        if (errno == EINTR) continue;
+        LOG(ERROR) << "write temp state file fail, file: " << tmp
+                   << ", error: " << std::strerror(errno);
+        break;
+      }
+      off += static_cast<size_t>(n);
+    }
+    if (off != content.size()) break;
+    if (fsync(fd) != 0) {
+      LOG(ERROR) << "fsync temp state file fail, file: " << tmp
+                 << ", error: " << std::strerror(errno);
+      break;
+    }
+    ok = true;
+  } while (false);
+  close(fd);
+
+  if (!ok) {
+    std::remove(tmp.c_str());
+    return false;
+  }
+
+  if (rename(tmp.c_str(), path.c_str()) != 0) {
+    LOG(ERROR) << "rename state file fail, " << tmp << " -> " << path
+               << ", error: " << std::strerror(errno);
+    std::remove(tmp.c_str());
+    return false;
+  }
+
+  int dfd = open(dir.c_str(), O_RDONLY | O_DIRECTORY);
+  if (dfd >= 0) {
+    fsync(dfd);
+    close(dfd);
+  }
+  return true;
 }
 
 static bool LoadStateFile(int pid, Json::Value& root) {
@@ -268,20 +345,19 @@ bool VFSWrapper::Dump() {
     return false;
   }
 
+  // TODO(hotupgrade): write root["schema_version"] here and verify it in
+  // Load() so a new process refuses to consume an incompatible state file.
   root["epch"] = Json::Value::UInt64(ClientState::GetEpoch());
   root["first_start_time_ms"] =
       Json::Value::UInt64(ClientState::GetFirstStartTime());
 
   const std::string path = fmt::format("{}.{}", kFdStatePath, getpid());
-  std::ofstream file(path);
-  if (!file.is_open()) {
-    LOG(ERROR) << "open dingo-client state file fail, file: " << path;
+  Json::StreamWriterBuilder writer;
+  if (!AtomicWriteStateFile(kFdStateDir, path,
+                            Json::writeString(writer, root))) {
+    LOG(ERROR) << "dump vfs state fail, path: " << path;
     return false;
   }
-
-  Json::StreamWriterBuilder writer;
-  file << Json::writeString(writer, root);
-  file.close();
 
   LOG(INFO) << fmt::format("dump vfs state success, path({}).", path);
   return true;
@@ -290,6 +366,9 @@ bool VFSWrapper::Dump() {
 bool VFSWrapper::Load(const Json::Value& value) {
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Load");
 
+  // TODO(hotupgrade): verify value["schema_version"] matches the running
+  // binary's expected version; refuse the handover (return false) on mismatch
+  // instead of loading a state file produced by an incompatible layout.
   if (!value["epch"].isNull()) {
     ClientState::SetEpoch(value["epch"].asUInt64() + 1);
     LOG(INFO) << "load epoch: " << ClientState::GetEpoch();

--- a/src/client/vfs/vfs_wrapper.h
+++ b/src/client/vfs/vfs_wrapper.h
@@ -55,10 +55,9 @@ class VFSWrapper {
   // the old process's persisted state file and skip re-mounting the FS on MDS.
   Status Start(const DingofsConfig& config, int upgrade_from_pid = 0);
 
-  // Normal stop: handover = false.
-  // Graceful-upgrade stop (old process handing off): handover = true.
-  // The old process persists its state for the new process to read and skips
-  // unmounting the FS on MDS so the kernel connection remains intact.
+  // Stop the VFS. With handover=true, skip MDS unmount and persist state for
+  // the new process. It is idempotent after success, so post-exit teardown does
+  // not stop/dump twice.
   Status Stop(bool handover = false);
 
   Status GetInfo(std::string* info);

--- a/src/common/options/client.cc
+++ b/src/common/options/client.cc
@@ -51,26 +51,6 @@ DEFINE_string(fuse_subdir, "/",
 
 DEFINE_bool(fuse_dryrun_bench_mode, false, "enable fuse dryrun bench mode");
 
-// smooth upgrade
-DEFINE_uint32(fuse_fd_get_max_retries, 100,
-              "the max retries that get fuse fd from old dingo-client during "
-              "smooth upgrade");
-DEFINE_validator(fuse_fd_get_max_retries, brpc::PassValidate);
-DEFINE_uint32(
-    fuse_fd_get_retry_interval_ms, 100,
-    "the interval in millseconds that get fuse fd from old dingo-client "
-    "during smooth upgrade");
-DEFINE_validator(fuse_fd_get_retry_interval_ms, brpc::PassValidate);
-DEFINE_uint32(fuse_check_alive_max_retries, 600,
-              "the max retries that check old dingo-client is alive during "
-              "smooth upgrade");
-DEFINE_validator(fuse_check_alive_max_retries, brpc::PassValidate);
-DEFINE_uint32(
-    fuse_check_alive_retry_interval_ms, 1000,
-    "the interval in millseconds that check old dingo-client is alive "
-    "during smooth upgrade");
-DEFINE_validator(fuse_check_alive_retry_interval_ms, brpc::PassValidate);
-
 // vfs meta access log
 DEFINE_bool(vfs_meta_access_logging, true, "enable vfs meta system log");
 DEFINE_validator(vfs_meta_access_logging, brpc::PassValidate);

--- a/src/common/options/client.cc
+++ b/src/common/options/client.cc
@@ -141,8 +141,17 @@ DEFINE_uint32(vfs_prefetch_threads, 8, "number of prefetch threads");
 DEFINE_int32(vfs_warmup_threads, 4, "number of warmup threads");
 
 // vfs handle
-DEFINE_int32(vfs_bg_executor_thread, 4, "number of backgroud threads");
-DEFINE_validator(vfs_bg_executor_thread, brpc::PassValidate);
+// read_cleanup runs only low-frequency reader-side housekeeping (async
+// read-request erasure + periodic mem shrink), so a small pool suffices.
+DEFINE_int32(vfs_read_cleanup_executor_thread, 2,
+             "number of read cleanup executor threads");
+DEFINE_validator(vfs_read_cleanup_executor_thread, brpc::PassValidate);
+
+// write_background runs only low-frequency writer-side housekeeping (slice_id
+// pre-allocation + periodic flush trigger), so a small pool suffices.
+DEFINE_int32(vfs_write_background_executor_thread, 2,
+             "number of write background executor threads");
+DEFINE_validator(vfs_write_background_executor_thread, brpc::PassValidate);
 
 DEFINE_int32(vfs_periodic_flush_interval_ms, 5000,
              "periodic flush interval in milliseconds");

--- a/src/common/options/client.h
+++ b/src/common/options/client.h
@@ -112,7 +112,8 @@ DECLARE_uint32(vfs_meta_warmup_small_file_batch_size);
 DECLARE_uint32(vfs_meta_warmup_small_file_ttl_s);
 
 // vfs handle
-DECLARE_int32(vfs_bg_executor_thread);
+DECLARE_int32(vfs_read_cleanup_executor_thread);
+DECLARE_int32(vfs_write_background_executor_thread);
 DECLARE_int32(vfs_periodic_flush_interval_ms);
 DECLARE_int32(vfs_periodic_trim_mem_ms);
 

--- a/src/common/options/client.h
+++ b/src/common/options/client.h
@@ -60,11 +60,12 @@ DECLARE_uint32(fuse_attr_cache_timeout_s);
 
 DECLARE_bool(fuse_dryrun_bench_mode);
 
-// smooth upgrade
+// hot upgrade (defined at their use sites: drain knobs in fuse_server.cc,
+// fd-get knobs in client/fuse/upgrade/handover_client.cc)
+DECLARE_uint32(fuse_hotupgrade_drain_timeout_ms);
+DECLARE_uint32(fuse_hotupgrade_statfs_interval_ms);
 DECLARE_uint32(fuse_fd_get_max_retries);
 DECLARE_uint32(fuse_fd_get_retry_interval_ms);
-DECLARE_uint32(fuse_check_alive_max_retries);
-DECLARE_uint32(fuse_check_alive_retry_interval_ms);
 
 // vfs meta system log
 DECLARE_bool(vfs_meta_access_logging);

--- a/test/unit/client/CMakeLists.txt
+++ b/test/unit/client/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_subdirectory(vfs)
+add_subdirectory(fuse)
 
 add_executable(test_client
   main.cc

--- a/test/unit/client/fuse/CMakeLists.txt
+++ b/test/unit/client/fuse/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standalone test binary for the FUSE hot-upgrade module -- intentionally NOT
+# folded into test_client. The handover controller is libfuse-free by design
+# (it drives the session via the HandoverSession interface), so it is compiled
+# directly here instead of pulling in fuse_client_lib (+ libfuse).
+file(GLOB TEST_DINGOFS_CLIENT_FUSE_SRCS
+  "*.cc"
+)
+
+add_executable(test_fuse_upgrade
+  ${TEST_DINGOFS_CLIENT_FUSE_SRCS}
+  ${CMAKE_SOURCE_DIR}/src/client/fuse/upgrade/handover_controller.cc
+  ${CMAKE_SOURCE_DIR}/src/client/fuse/upgrade/handover_server.cc
+)
+
+target_link_libraries(test_fuse_upgrade
+  dingofs_common
+
+  ${TEST_DEPS}
+)
+
+set_target_properties(test_fuse_upgrade PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${TEST_EXECUTABLE_OUTPUT_PATH}
+)

--- a/test/unit/client/fuse/test_handover_channel.cc
+++ b/test/unit/client/fuse/test_handover_channel.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/fuse/upgrade/handover_channel.h"
+
+#include <gtest/gtest.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <set>
+#include <string>
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+TEST(HandoverChannelTest, MakeMagicIsBigEndianAscii) {
+  EXPECT_EQ(MakeMagic('A', 'B', 'C', 'D'), 0x41424344u);
+  // High bit set must not sign-extend.
+  EXPECT_EQ(MakeMagic('\xFF', '\x00', '\x00', '\x00'), 0xFF000000u);
+}
+
+TEST(HandoverChannelTest, MessageMagicsAreDistinct) {
+  std::set<uint32_t> magics = {
+      static_cast<uint32_t>(HandoverMessage::kPrepare),
+      static_cast<uint32_t>(HandoverMessage::kReadyToExit),
+      static_cast<uint32_t>(HandoverMessage::kAck),
+      static_cast<uint32_t>(HandoverMessage::kNack),
+  };
+  EXPECT_EQ(magics.size(), 4u) << "handover message magics must be unique";
+}
+
+TEST(HandoverChannelTest, MessageRoundTrip) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+
+  ASSERT_TRUE(SendHandoverMessage(sv[0], HandoverMessage::kReadyToExit));
+  HandoverMessage got;
+  ASSERT_TRUE(RecvHandoverMessage(sv[1], &got));
+  EXPECT_EQ(got, HandoverMessage::kReadyToExit);
+
+  close(sv[0]);
+  close(sv[1]);
+}
+
+TEST(HandoverChannelTest, RecvFromClosedPeerFails) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+  close(sv[0]);  // peer hung up -> EOF on the other end
+
+  HandoverMessage got;
+  EXPECT_FALSE(RecvHandoverMessage(sv[1], &got));
+  close(sv[1]);
+}
+
+// SendFd/GetFd pass a real fd (SCM_RIGHTS) plus an inline data payload; the
+// received fd must refer to the SAME open file description as the sent one.
+TEST(HandoverChannelTest, SendFdPassesFdAndData) {
+  int sv[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+
+  const std::string payload = "INIT-MESSAGE-BYTES";
+  int sent = SendFd(sv[0], pipefd[0], const_cast<char*>(payload.data()),
+                    payload.size());
+  ASSERT_EQ(sent, static_cast<int>(payload.size()));
+
+  char buf[64] = {0};
+  size_t real_size = 0;
+  int recv_fd = GetFd(sv[1], buf, sizeof(buf), &real_size);
+  ASSERT_GT(recv_fd, 2);
+  EXPECT_EQ(real_size, payload.size());
+  EXPECT_EQ(std::string(buf, real_size), payload);
+
+  // Prove recv_fd is a dup of pipefd[0]: write to the pipe, read via recv_fd.
+  ASSERT_EQ(write(pipefd[1], "Z", 1), 1);
+  char z = 0;
+  ASSERT_EQ(read(recv_fd, &z, 1), 1);
+  EXPECT_EQ(z, 'Z');
+
+  close(recv_fd);
+  close(pipefd[0]);
+  close(pipefd[1]);
+  close(sv[0]);
+  close(sv[1]);
+}
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/fuse/test_handover_controller.cc
+++ b/test/unit/client/fuse/test_handover_controller.cc
@@ -64,6 +64,9 @@ class Latch {
   bool Wait() {
     return future_.wait_for(kWaitTimeout) == std::future_status::ready;
   }
+  bool WaitFor(std::chrono::milliseconds timeout) {
+    return future_.wait_for(timeout) == std::future_status::ready;
+  }
 
  private:
   std::promise<void> promise_;
@@ -95,8 +98,8 @@ class HandoverControllerTest : public ::testing::Test {
   MockHandoverSession session_;
 };
 
-// Full success: drain -> checkpoint -> ready/ACK -> exit. No resume/abort, and
-// the state stays kFuseUpgradeOld (the new takes over).
+// Full success: drain -> checkpoint -> ready notification -> exit. No
+// resume/abort, and the state stays kFuseUpgradeOld (the new takes over).
 TEST_F(HandoverControllerTest, HappyPath_DrainCheckpointCommitExits) {
   Latch done;
   std::atomic<bool> checkpoint_ran{false};
@@ -163,6 +166,61 @@ TEST_F(HandoverControllerTest, DrainTimeout_AbortsAndResumes) {
   EXPECT_EQ(State(), FuseUpgradeState::kFuseNormal);
 }
 
+TEST_F(HandoverControllerTest, DrainTimeout_DoesNotJoinBlockedStatfsWakeup) {
+  Latch resumed;
+  std::promise<void> wakeup_entered;
+  auto wakeup_entered_future = wakeup_entered.get_future();
+  std::promise<void> release_wakeup;
+  auto release_wakeup_future = release_wakeup.get_future();
+  std::promise<void> wakeup_returned;
+  auto wakeup_returned_future = wakeup_returned.get_future();
+  std::atomic<bool> wakeup_entered_once{false};
+
+  HandoverOptions options = Options();
+  options.statfs_wakeup_fn =
+      [&](const std::string&, const std::atomic<bool>&) {
+        if (!wakeup_entered_once.exchange(true)) {
+          wakeup_entered.set_value();
+        }
+        release_wakeup_future.wait();
+        wakeup_returned.set_value();
+      };
+
+  {
+    InSequence seq;
+    EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
+    EXPECT_CALL(session_, PauseReceive());
+    EXPECT_CALL(session_, WaitDrained(_)).WillOnce(InvokeWithoutArgs([&] {
+      EXPECT_EQ(wakeup_entered_future.wait_for(kWaitTimeout),
+                std::future_status::ready);
+      return -1;
+    }));
+    EXPECT_CALL(peer_, NotifyHandoverAbort());
+    EXPECT_CALL(session_, ResumeReceive()).WillOnce(InvokeWithoutArgs([&] {
+      resumed.Signal();
+    }));
+  }
+  EXPECT_CALL(session_, Exit()).Times(0);
+  EXPECT_CALL(peer_, NotifyReadyToExit()).Times(0);
+
+  HandoverController controller(options, &peer_, &session_);
+  controller.SetCheckpoint([]() -> Status { return Status::OK(); });
+  controller.Start();
+  controller.RequestHandover();
+
+  const bool resumed_before_wakeup_returns =
+      resumed.WaitFor(std::chrono::milliseconds(500));
+  release_wakeup.set_value();
+  ASSERT_EQ(wakeup_returned_future.wait_for(kWaitTimeout),
+            std::future_status::ready);
+  controller.Stop();
+
+  EXPECT_TRUE(resumed_before_wakeup_returns)
+      << "drain timeout must not join a statfs wakeup blocked behind the "
+         "paused session";
+  EXPECT_EQ(State(), FuseUpgradeState::kFuseNormal);
+}
+
 // M1: a SIGHUP before the checkpoint is registered must NOT pause IO (no drain).
 // It aborts immediately (telling the new to back off) and keeps serving.
 TEST_F(HandoverControllerTest, NoCheckpoint_AbortsWithoutDraining) {
@@ -210,7 +268,7 @@ TEST_F(HandoverControllerTest, InvalidPrepare_KeepsServing) {
 }
 
 // Past the checkpoint the VFS is torn down and cannot be resumed: the session
-// must exit even when the READY notification cannot reach the new process.
+// must exit even when notifying the new fails.
 TEST_F(HandoverControllerTest, CommitExitsEvenIfReadyNotifyFails) {
   Latch done;
   {

--- a/test/unit/client/fuse/test_handover_controller.cc
+++ b/test/unit/client/fuse/test_handover_controller.cc
@@ -44,7 +44,7 @@ constexpr auto kWaitTimeout = std::chrono::seconds(5);
 class MockHandoverPeer : public HandoverPeer {
  public:
   MOCK_METHOD(bool, WaitHandoverPrepare, (), (override));
-  MOCK_METHOD(bool, NotifyReadyAndWaitHandoverAck, (), (override));
+  MOCK_METHOD(bool, NotifyReadyToExit, (), (override));
   MOCK_METHOD(void, NotifyHandoverAbort, (), (override));
 };
 
@@ -106,7 +106,7 @@ TEST_F(HandoverControllerTest, HappyPath_DrainCheckpointCommitExits) {
     EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
     EXPECT_CALL(session_, PauseReceive());
     EXPECT_CALL(session_, WaitDrained(100)).WillOnce(Return(0));
-    EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).WillOnce(Return(true));
+    EXPECT_CALL(peer_, NotifyReadyToExit()).WillOnce(Return(true));
     EXPECT_CALL(session_, Exit()).WillOnce(InvokeWithoutArgs([&] {
       done.Signal();
     }));
@@ -146,7 +146,7 @@ TEST_F(HandoverControllerTest, DrainTimeout_AbortsAndResumes) {
     }));
   }
   EXPECT_CALL(session_, Exit()).Times(0);
-  EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).Times(0);
+  EXPECT_CALL(peer_, NotifyReadyToExit()).Times(0);
 
   HandoverController controller(Options(), &peer_, &session_);
   controller.SetCheckpoint([&]() -> Status {
@@ -210,15 +210,15 @@ TEST_F(HandoverControllerTest, InvalidPrepare_KeepsServing) {
 }
 
 // Past the checkpoint the VFS is torn down and cannot be resumed: the session
-// must exit even when the new never ACKs (NotifyReadyAndWaitHandoverAck false).
-TEST_F(HandoverControllerTest, CommitExitsEvenIfAckTimesOut) {
+// must exit even when the READY notification cannot reach the new process.
+TEST_F(HandoverControllerTest, CommitExitsEvenIfReadyNotifyFails) {
   Latch done;
   {
     InSequence seq;
     EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
     EXPECT_CALL(session_, PauseReceive());
     EXPECT_CALL(session_, WaitDrained(_)).WillOnce(Return(0));
-    EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).WillOnce(Return(false));
+    EXPECT_CALL(peer_, NotifyReadyToExit()).WillOnce(Return(false));
     EXPECT_CALL(session_, Exit()).WillOnce(InvokeWithoutArgs([&] {
       done.Signal();
     }));
@@ -248,7 +248,7 @@ TEST_F(HandoverControllerTest, CheckpointFails_Aborts) {
     }));
   }
   EXPECT_CALL(session_, Exit()).Times(0);
-  EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).Times(0);
+  EXPECT_CALL(peer_, NotifyReadyToExit()).Times(0);
 
   HandoverController controller(Options(), &peer_, &session_);
   controller.SetCheckpoint(

--- a/test/unit/client/fuse/test_handover_controller.cc
+++ b/test/unit/client/fuse/test_handover_controller.cc
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/fuse/upgrade/handover_controller.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+
+#include "client/fuse/upgrade/handover_peer.h"
+#include "client/fuse/upgrade/handover_session.h"
+#include "client/fuse/upgrade/state_store.h"
+#include "common/status.h"
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
+
+namespace {
+constexpr auto kWaitTimeout = std::chrono::seconds(5);
+}  // namespace
+
+class MockHandoverPeer : public HandoverPeer {
+ public:
+  MOCK_METHOD(bool, WaitHandoverPrepare, (), (override));
+  MOCK_METHOD(bool, NotifyReadyAndWaitHandoverAck, (), (override));
+  MOCK_METHOD(void, NotifyHandoverAbort, (), (override));
+};
+
+class MockHandoverSession : public HandoverSession {
+ public:
+  MOCK_METHOD(void, PauseReceive, (), (override));
+  MOCK_METHOD(void, ResumeReceive, (), (override));
+  MOCK_METHOD(int, WaitDrained, (uint32_t), (override));
+  MOCK_METHOD(void, Exit, (), (override));
+};
+
+// A one-shot latch the test waits on; a mock action fulfils it once the
+// controller reaches the expected terminal step.
+class Latch {
+ public:
+  void Signal() { promise_.set_value(); }
+  bool Wait() {
+    return future_.wait_for(kWaitTimeout) == std::future_status::ready;
+  }
+
+ private:
+  std::promise<void> promise_;
+  std::future<void> future_{promise_.get_future()};
+};
+
+class HandoverControllerTest : public ::testing::Test {
+ protected:
+  void SetUp() override { ResetState(); }
+  void TearDown() override { ResetState(); }
+
+  static void ResetState() {
+    UpgradeStateStore::GetInstance().UpdateFuseState(
+        FuseUpgradeState::kFuseNormal);
+  }
+  static FuseUpgradeState State() {
+    return UpgradeStateStore::GetInstance().GetFuseState();
+  }
+
+  HandoverOptions Options() {
+    HandoverOptions o;
+    o.mountpoint = "/tmp/handover-controller-test-no-such-mount";
+    o.drain_timeout_ms = 100;
+    o.statfs_interval_ms = 10;
+    return o;
+  }
+
+  MockHandoverPeer peer_;
+  MockHandoverSession session_;
+};
+
+// Full success: drain -> checkpoint -> ready/ACK -> exit. No resume/abort, and
+// the state stays kFuseUpgradeOld (the new takes over).
+TEST_F(HandoverControllerTest, HappyPath_DrainCheckpointCommitExits) {
+  Latch done;
+  std::atomic<bool> checkpoint_ran{false};
+
+  {
+    InSequence seq;
+    EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
+    EXPECT_CALL(session_, PauseReceive());
+    EXPECT_CALL(session_, WaitDrained(100)).WillOnce(Return(0));
+    EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).WillOnce(Return(true));
+    EXPECT_CALL(session_, Exit()).WillOnce(InvokeWithoutArgs([&] {
+      done.Signal();
+    }));
+  }
+  EXPECT_CALL(session_, ResumeReceive()).Times(0);
+  EXPECT_CALL(peer_, NotifyHandoverAbort()).Times(0);
+
+  HandoverController controller(Options(), &peer_, &session_);
+  controller.SetCheckpoint([&]() -> Status {
+    checkpoint_ran.store(true);
+    return Status::OK();
+  });
+  controller.Start();
+  ASSERT_TRUE(controller.RequestHandover());
+
+  ASSERT_TRUE(done.Wait());
+  controller.Stop();
+
+  EXPECT_TRUE(checkpoint_ran.load());
+  EXPECT_EQ(State(), FuseUpgradeState::kFuseUpgradeOld);
+}
+
+// Drain times out (WaitDrained != 0): abort, resume serving, roll state back.
+// The checkpoint must NOT run and the session must NOT exit.
+TEST_F(HandoverControllerTest, DrainTimeout_AbortsAndResumes) {
+  Latch done;
+  std::atomic<bool> checkpoint_ran{false};
+
+  {
+    InSequence seq;
+    EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
+    EXPECT_CALL(session_, PauseReceive());
+    EXPECT_CALL(session_, WaitDrained(_)).WillOnce(Return(-1));
+    EXPECT_CALL(peer_, NotifyHandoverAbort());
+    EXPECT_CALL(session_, ResumeReceive()).WillOnce(InvokeWithoutArgs([&] {
+      done.Signal();
+    }));
+  }
+  EXPECT_CALL(session_, Exit()).Times(0);
+  EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).Times(0);
+
+  HandoverController controller(Options(), &peer_, &session_);
+  controller.SetCheckpoint([&]() -> Status {
+    checkpoint_ran.store(true);
+    return Status::OK();
+  });
+  controller.Start();
+  controller.RequestHandover();
+
+  ASSERT_TRUE(done.Wait());
+  controller.Stop();
+
+  EXPECT_FALSE(checkpoint_ran.load());
+  EXPECT_EQ(State(), FuseUpgradeState::kFuseNormal);
+}
+
+// M1: a SIGHUP before the checkpoint is registered must NOT pause IO (no drain).
+// It aborts immediately (telling the new to back off) and keeps serving.
+TEST_F(HandoverControllerTest, NoCheckpoint_AbortsWithoutDraining) {
+  Latch done;
+
+  EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
+  EXPECT_CALL(peer_, NotifyHandoverAbort()).WillOnce(InvokeWithoutArgs([&] {
+    done.Signal();
+  }));
+  EXPECT_CALL(session_, PauseReceive()).Times(0);
+  EXPECT_CALL(session_, WaitDrained(_)).Times(0);
+  EXPECT_CALL(session_, ResumeReceive()).Times(0);
+  EXPECT_CALL(session_, Exit()).Times(0);
+
+  HandoverController controller(Options(), &peer_, &session_);
+  // Intentionally no SetCheckpoint().
+  controller.Start();
+  controller.RequestHandover();
+
+  ASSERT_TRUE(done.Wait());
+  controller.Stop();
+
+  EXPECT_EQ(State(), FuseUpgradeState::kFuseNormal);
+}
+
+// A stray/invalid SIGHUP (WaitHandoverPrepare returns false) must not touch the
+// session at all -- keep serving.
+TEST_F(HandoverControllerTest, InvalidPrepare_KeepsServing) {
+  Latch done;
+  EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(InvokeWithoutArgs([&] {
+    done.Signal();
+    return false;
+  }));
+  EXPECT_CALL(session_, PauseReceive()).Times(0);
+  EXPECT_CALL(peer_, NotifyHandoverAbort()).Times(0);
+  EXPECT_CALL(session_, Exit()).Times(0);
+
+  HandoverController controller(Options(), &peer_, &session_);
+  controller.SetCheckpoint([]() -> Status { return Status::OK(); });
+  controller.Start();
+  controller.RequestHandover();
+
+  ASSERT_TRUE(done.Wait());
+  controller.Stop();
+}
+
+// Past the checkpoint the VFS is torn down and cannot be resumed: the session
+// must exit even when the new never ACKs (NotifyReadyAndWaitHandoverAck false).
+TEST_F(HandoverControllerTest, CommitExitsEvenIfAckTimesOut) {
+  Latch done;
+  {
+    InSequence seq;
+    EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
+    EXPECT_CALL(session_, PauseReceive());
+    EXPECT_CALL(session_, WaitDrained(_)).WillOnce(Return(0));
+    EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).WillOnce(Return(false));
+    EXPECT_CALL(session_, Exit()).WillOnce(InvokeWithoutArgs([&] {
+      done.Signal();
+    }));
+  }
+  EXPECT_CALL(session_, ResumeReceive()).Times(0);
+
+  HandoverController controller(Options(), &peer_, &session_);
+  controller.SetCheckpoint([]() -> Status { return Status::OK(); });
+  controller.Start();
+  controller.RequestHandover();
+
+  ASSERT_TRUE(done.Wait());
+  controller.Stop();
+}
+
+// Checkpoint runs but fails: abort (resume + state rollback), do not exit.
+TEST_F(HandoverControllerTest, CheckpointFails_Aborts) {
+  Latch done;
+  {
+    InSequence seq;
+    EXPECT_CALL(peer_, WaitHandoverPrepare()).WillOnce(Return(true));
+    EXPECT_CALL(session_, PauseReceive());
+    EXPECT_CALL(session_, WaitDrained(_)).WillOnce(Return(0));
+    EXPECT_CALL(peer_, NotifyHandoverAbort());
+    EXPECT_CALL(session_, ResumeReceive()).WillOnce(InvokeWithoutArgs([&] {
+      done.Signal();
+    }));
+  }
+  EXPECT_CALL(session_, Exit()).Times(0);
+  EXPECT_CALL(peer_, NotifyReadyAndWaitHandoverAck()).Times(0);
+
+  HandoverController controller(Options(), &peer_, &session_);
+  controller.SetCheckpoint(
+      []() -> Status { return Status::Internal("checkpoint boom"); });
+  controller.Start();
+  controller.RequestHandover();
+
+  ASSERT_TRUE(done.Wait());
+  controller.Stop();
+
+  EXPECT_EQ(State(), FuseUpgradeState::kFuseNormal);
+}
+
+// Lifecycle: RequestHandover before Start is rejected; Stop is idempotent.
+TEST_F(HandoverControllerTest, LifecycleStartStopIdempotent) {
+  HandoverController controller(Options(), &peer_, &session_);
+  EXPECT_FALSE(controller.RequestHandover());  // not started yet
+  controller.Stop();                           // no-op before start
+  controller.Start();
+  controller.Stop();
+  controller.Stop();  // idempotent
+}
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/fuse/test_handover_server.cc
+++ b/test/unit/client/fuse/test_handover_server.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/fuse/upgrade/handover_server.h"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "client/fuse/upgrade/handover_channel.h"
+
+#define FUSE_USE_VERSION 317
+#include "fuse_lowlevel.h"  // struct fuse_buf
+
+namespace dingofs {
+namespace client {
+namespace fuse {
+
+class HandoverServerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    socket_path_ =
+        "/tmp/handover-server-test." + std::to_string(getpid()) + ".sock";
+    unlink(socket_path_.c_str());
+
+    // A stand-in for the /dev/fuse fd to hand off: the read end of a pipe. The
+    // server only passes the int across SCM_RIGHTS; it never calls libfuse on
+    // it, so any real fd works and lets the test prove the handoff.
+    ASSERT_EQ(pipe(pipefd_), 0);
+
+    init_data_ = "FAKE-INIT-MESSAGE";
+    init_buf_.mem = init_data_.data();
+    init_buf_.mem_size = init_data_.size();
+    init_buf_.size = init_data_.size();
+  }
+
+  void TearDown() override {
+    close(pipefd_[0]);
+    close(pipefd_[1]);
+    unlink(socket_path_.c_str());
+  }
+
+  std::unique_ptr<HandoverServer> MakeServer() {
+    return std::make_unique<HandoverServer>(
+        socket_path_, [this]() { return pipefd_[0]; }, &init_buf_);
+  }
+
+  std::string socket_path_;
+  int pipefd_[2];
+  std::string init_data_;
+  struct fuse_buf init_buf_ {};
+};
+
+// A connector receives the /dev/fuse fd and the INIT payload, and the fd refers
+// to the same open file the server handed off.
+TEST_F(HandoverServerTest, TakeoverDeliversFdAndInit) {
+  auto server = MakeServer();
+  server->Start();
+
+  char buf[128] = {0};
+  size_t real_size = 0;
+  int comm_fd = -1;
+  int fuse_fd =
+      GetFuseFd(socket_path_.c_str(), buf, sizeof(buf), &real_size, &comm_fd);
+
+  ASSERT_GT(fuse_fd, 2);
+  EXPECT_EQ(std::string(buf, real_size), init_data_);
+
+  ASSERT_EQ(write(pipefd_[1], "Z", 1), 1);
+  char z = 0;
+  ASSERT_EQ(read(fuse_fd, &z, 1), 1);
+  EXPECT_EQ(z, 'Z');
+
+  close(fuse_fd);
+  if (comm_fd >= 0) close(comm_fd);
+  server->Stop();
+}
+
+// A second connector while the first handover is still live (fail-closed):
+// IsHandoverInFlight() sees a live peer and rejects, so the second gets no fd.
+TEST_F(HandoverServerTest, ConcurrentConnectionRejected) {
+  auto server = MakeServer();
+  server->Start();
+
+  // First connector stays open -> in flight (do not close comm1 yet).
+  char buf1[128] = {0};
+  size_t real1 = 0;
+  int comm1 = -1;
+  int fd1 = GetFuseFd(socket_path_.c_str(), buf1, sizeof(buf1), &real1, &comm1);
+  ASSERT_GT(fd1, 2);
+
+  // Second connector: server rejects (closes without SendFd) -> GetFd EOF -> -1.
+  char buf2[128] = {0};
+  size_t real2 = 0;
+  int comm2 = -1;
+  int fd2 = GetFuseFd(socket_path_.c_str(), buf2, sizeof(buf2), &real2, &comm2);
+  EXPECT_EQ(fd2, -1) << "concurrent upgrade must be rejected";
+
+  close(fd1);
+  if (comm1 >= 0) close(comm1);
+  if (comm2 >= 0) close(comm2);
+  server->Stop();
+}
+
+// H1: once the handover is committed (NotifyReadyAndWaitHandoverAck succeeded),
+// the server rejects ALL further connectors -- even after the committed peer's
+// fd is cleared -- so the /dev/fuse fd is never handed out twice.
+TEST_F(HandoverServerTest, CommittedRejectsLateConnection) {
+  auto server = MakeServer();
+  server->Start();
+
+  // new-side peer: take over, then run the kPrepare -> kReadyToExit -> kAck
+  // handshake. Signal once connected so the controller side reads kPrepare only
+  // after client_fd_ is set.
+  std::promise<void> connected;
+  std::thread peer([&]() {
+    char buf[128] = {0};
+    size_t real = 0;
+    int comm = -1;
+    int fuse_fd =
+        GetFuseFd(socket_path_.c_str(), buf, sizeof(buf), &real, &comm);
+    ASSERT_GT(fuse_fd, 2);
+    connected.set_value();
+
+    ASSERT_TRUE(SendHandoverMessage(comm, HandoverMessage::kPrepare));
+    HandoverMessage msg;
+    ASSERT_TRUE(RecvHandoverMessage(comm, &msg));
+    EXPECT_EQ(msg, HandoverMessage::kReadyToExit);
+    ASSERT_TRUE(SendHandoverMessage(comm, HandoverMessage::kAck));
+
+    close(fuse_fd);
+    close(comm);
+  });
+
+  // Test thread plays the controller's peer-facing calls.
+  connected.get_future().wait();
+  ASSERT_TRUE(server->WaitHandoverPrepare());           // reads kPrepare
+  ASSERT_TRUE(server->NotifyReadyAndWaitHandoverAck());  // commits, waits kAck
+  peer.join();
+
+  // committed_ is now set: a fresh connector is rejected regardless of state.
+  char buf2[128] = {0};
+  size_t real2 = 0;
+  int comm2 = -1;
+  int fd2 = GetFuseFd(socket_path_.c_str(), buf2, sizeof(buf2), &real2, &comm2);
+  EXPECT_EQ(fd2, -1) << "post-commit connection must be rejected";
+
+  if (comm2 >= 0) close(comm2);
+  server->Stop();
+}
+
+}  // namespace fuse
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/fuse/test_handover_server.cc
+++ b/test/unit/client/fuse/test_handover_server.cc
@@ -119,16 +119,16 @@ TEST_F(HandoverServerTest, ConcurrentConnectionRejected) {
   server->Stop();
 }
 
-// H1: once the handover is committed (NotifyReadyAndWaitHandoverAck succeeded),
+// H1: once the handover is committed (NotifyReadyToExit succeeded),
 // the server rejects ALL further connectors -- even after the committed peer's
 // fd is cleared -- so the /dev/fuse fd is never handed out twice.
 TEST_F(HandoverServerTest, CommittedRejectsLateConnection) {
   auto server = MakeServer();
   server->Start();
 
-  // new-side peer: take over, then run the kPrepare -> kReadyToExit -> kAck
-  // handshake. Signal once connected so the controller side reads kPrepare only
-  // after client_fd_ is set.
+  // new-side peer: take over, then run the kPrepare -> kReadyToExit handshake.
+  // Signal once connected so the controller side reads kPrepare only after
+  // client_fd_ is set.
   std::promise<void> connected;
   std::thread peer([&]() {
     char buf[128] = {0};
@@ -143,7 +143,6 @@ TEST_F(HandoverServerTest, CommittedRejectsLateConnection) {
     HandoverMessage msg;
     ASSERT_TRUE(RecvHandoverMessage(comm, &msg));
     EXPECT_EQ(msg, HandoverMessage::kReadyToExit);
-    ASSERT_TRUE(SendHandoverMessage(comm, HandoverMessage::kAck));
 
     close(fuse_fd);
     close(comm);
@@ -151,8 +150,8 @@ TEST_F(HandoverServerTest, CommittedRejectsLateConnection) {
 
   // Test thread plays the controller's peer-facing calls.
   connected.get_future().wait();
-  ASSERT_TRUE(server->WaitHandoverPrepare());           // reads kPrepare
-  ASSERT_TRUE(server->NotifyReadyAndWaitHandoverAck());  // commits, waits kAck
+  ASSERT_TRUE(server->WaitHandoverPrepare());  // reads kPrepare
+  ASSERT_TRUE(server->NotifyReadyToExit());    // commits and sends ready
   peer.join();
 
   // committed_ is now set: a fresh connector is rejected regardless of state.

--- a/test/unit/client/vfs/data/test_slice_writer.cc
+++ b/test/unit/client/vfs/data/test_slice_writer.cc
@@ -730,11 +730,11 @@ class SliceWriterStreamingTest : public test::VFSTestBase {
     return sw;
   }
 
-  // Wait for bg_executor_ to drain (PrepareSliceId runs there).
-  void WaitBGExecutorIdle() {
+  // Wait for write_background_executor_ to drain (PrepareSliceId runs there).
+  void WaitWriteBackgroundExecutorIdle() {
     test::AsyncWaiter w;
     w.Expect(1);
-    bg_executor_->Execute([&w]() { w.Done(); });
+    write_background_executor_->Execute([&w]() { w.Done(); });
     w.Wait();
   }
 
@@ -773,7 +773,7 @@ TEST_F(SliceWriterStreamingTest, UT1_FlushUpTo_OnlyFullBlocks) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();  // slice_id_ = 42
+  WaitWriteBackgroundExecutorIdle();  // slice_id_ = 42
 
   // Write 10MB = 2 full blocks (4MB each) + 2MB partial
   auto buf = MakeBuf(10 * 1024 * 1024);
@@ -834,7 +834,7 @@ TEST_F(SliceWriterStreamingTest, UT2_SliceId_DelayedArrival_CatchUp) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  // Do NOT WaitBGExecutorIdle — PrepareSliceId is blocked
+  // Do NOT WaitWriteBackgroundExecutorIdle — PrepareSliceId is blocked
 
   // Write 8MB = 2 full blocks. slice_id_==0, FlushUpTo skips.
   auto buf1 = MakeBuf(8 * 1024 * 1024);
@@ -847,7 +847,7 @@ TEST_F(SliceWriterStreamingTest, UT2_SliceId_DelayedArrival_CatchUp) {
 
   // Release PrepareSliceId
   proceed.set_value();
-  WaitBGExecutorIdle();  // slice_id_ = 77
+  WaitWriteBackgroundExecutorIdle();  // slice_id_ = 77
 
   // Write 4MB more. FlushUpTo(12MB) catches up: block[0](end=4<=12),
   // block[1](end=8<=12), block[2](end=12<=12) — all uploaded.
@@ -894,7 +894,7 @@ TEST_F(SliceWriterStreamingTest, UT3_UploadError_Propagation) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   // Write 8MB = 2 blocks. block[0] OK, block[1] fails.
   auto buf = MakeBuf(8 * 1024 * 1024);
@@ -927,7 +927,7 @@ TEST_F(SliceWriterStreamingTest, UT4_WaitInflight_Timeout) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   // Write 4MB = 1 full block. PutAsync held → inflight_=1
   auto buf = MakeBuf(4 * 1024 * 1024);
@@ -974,7 +974,7 @@ TEST_F(SliceWriterStreamingTest, UT5_SmallFile_NoStreamingUpload) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   auto buf = MakeBuf(100 * 1024);  // 100KB
   ASSERT_TRUE(sw->Write(ctx_, buf.data(), 100 * 1024, 0).ok());
@@ -1017,7 +1017,7 @@ TEST_F(SliceWriterStreamingTest, UT6_MultipleWrites_StreamingOneByOne) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   const int32_t kBSize = 4 * 1024 * 1024;
   for (int i = 0; i < 4; i++) {
@@ -1068,7 +1068,8 @@ TEST_F(SliceWriterStreamingTest, UT7_SliceId_PreallocFail_SyncFallback) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();  // PrepareSliceId fails, alloc_failed_=true
+  WaitWriteBackgroundExecutorIdle();  // PrepareSliceId fails,
+                                      // alloc_failed_=true
 
   // Write 8MB = 2 blocks. FlushUpTo skips (alloc_failed).
   auto buf = MakeBuf(8 * 1024 * 1024);
@@ -1119,7 +1120,7 @@ TEST_F(SliceWriterStreamingTest, UT8_SingleWrite_MultiBlockFlushUpTo) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   // 10MB = 2 full blocks (4MB each) + 2MB partial
   auto buf = MakeBuf(10 * 1024 * 1024);
@@ -1164,7 +1165,7 @@ TEST_F(SliceWriterStreamingTest, UT9_ConcurrentCallbacks_ThreadSafe) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   // 20MB = 4 full blocks + 4MB partial. FlushUpTo uploads block[0..3].
   auto buf = MakeBuf(20 * 1024 * 1024);
@@ -1227,7 +1228,7 @@ TEST_F(SliceWriterStreamingTest, UT10_MixedStreamAndFlushResidual) {
 
   auto sw = MakeStreamingWriter(0);
   SliceWriterGuard guard(sw);
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   // 6MB = 1 full block (4MB) + 2MB partial
   auto buf = MakeBuf(6 * 1024 * 1024);
@@ -1277,7 +1278,7 @@ TEST_F(SliceWriterStreamingTest, UT11_TimeoutThenLateCallback_NoUAF) {
 
   auto* sw = MakeStreamingWriter(0);
   // No SliceWriterGuard — manually control DecRef to test exact sequence
-  WaitBGExecutorIdle();
+  WaitWriteBackgroundExecutorIdle();
 
   // Write 4MB = 1 full block → IncRef in UploadBlockAsync → refs=2
   auto buf = MakeBuf(4 * 1024 * 1024);

--- a/test/unit/client/vfs/handle/test_handle_manager.cc
+++ b/test/unit/client/vfs/handle/test_handle_manager.cc
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-#include "client/vfs/handle/handle_manager.h"
-
 #include <fcntl.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include "client/vfs/data/writer/file_writer.h"
 #include "client/vfs/data/writer_table.h"
+#include "client/vfs/handle/handle_manager.h"
 #include "test/unit/client/vfs/test_base.h"
 
 namespace dingofs {
@@ -63,8 +66,8 @@ class HandleManagerTest : public VFSTestBase {
 TEST_F(HandleManagerTest, NewHandle_RDONLY_NoWriter) {
   auto* h = handle_manager_->NewHandle(/*fh*/ 1, /*ino*/ 100, O_RDONLY);
   ASSERT_NE(h, nullptr);
-  EXPECT_NE(h->reader, nullptr);
-  EXPECT_EQ(h->writer, nullptr);
+  EXPECT_NE(h->resources.reader, nullptr);
+  EXPECT_EQ(h->resources.writer, nullptr);
   EXPECT_EQ(writer_table_->Size(), 0u);
 
   handle_manager_->ReleaseHandler(1);
@@ -74,8 +77,8 @@ TEST_F(HandleManagerTest, NewHandle_RDONLY_NoWriter) {
 TEST_F(HandleManagerTest, NewHandle_WriteMode_HasWriter) {
   auto* h = handle_manager_->NewHandle(/*fh*/ 2, /*ino*/ 200, O_WRONLY);
   ASSERT_NE(h, nullptr);
-  EXPECT_NE(h->reader, nullptr);
-  EXPECT_NE(h->writer, nullptr);
+  EXPECT_NE(h->resources.reader, nullptr);
+  EXPECT_NE(h->resources.writer, nullptr);
   EXPECT_EQ(writer_table_->Size(), 1u);
 
   handle_manager_->ReleaseHandler(2);
@@ -89,11 +92,12 @@ TEST_F(HandleManagerTest, MultipleWritableFhsShareOneWriter) {
   ASSERT_NE(h1, nullptr);
   ASSERT_NE(h2, nullptr);
 
-  EXPECT_EQ(h1->writer, h2->writer) << "shared per-inode writer expected";
+  EXPECT_EQ(h1->resources.writer, h2->resources.writer)
+      << "shared per-inode writer expected";
   EXPECT_EQ(writer_table_->Size(), 1u);
 
   handle_manager_->ReleaseHandler(3);
-  EXPECT_EQ(writer_table_->Size(), 1u);   // h2 still holds
+  EXPECT_EQ(writer_table_->Size(), 1u);  // h2 still holds
 
   handle_manager_->ReleaseHandler(4);
   EXPECT_EQ(writer_table_->Size(), 0u);
@@ -114,9 +118,9 @@ TEST_F(HandleManagerTest, TwoFhsOnSameInoHaveDistinctReaders) {
   ASSERT_NE(h1, nullptr);
   ASSERT_NE(h2, nullptr);
 
-  ASSERT_NE(h1->reader, nullptr);
-  ASSERT_NE(h2->reader, nullptr);
-  EXPECT_NE(h1->reader, h2->reader)
+  ASSERT_NE(h1->resources.reader, nullptr);
+  ASSERT_NE(h2->resources.reader, nullptr);
+  EXPECT_NE(h1->resources.reader, h2->resources.reader)
       << "per-fh reader: each fh must own a distinct FileReader instance";
 
   handle_manager_->ReleaseHandler(10);
@@ -132,8 +136,9 @@ TEST_F(HandleManagerTest, MixedRdonlyWritable_OnlyOneWriterEntry) {
   ASSERT_NE(hr, nullptr);
   ASSERT_NE(hw, nullptr);
 
-  EXPECT_EQ(hr->writer, nullptr) << "O_RDONLY must not allocate a writer";
-  EXPECT_NE(hw->writer, nullptr);
+  EXPECT_EQ(hr->resources.writer, nullptr)
+      << "O_RDONLY must not allocate a writer";
+  EXPECT_NE(hw->resources.writer, nullptr);
   EXPECT_EQ(writer_table_->Size(), 1u);
 
   // RDONLY release must not touch the writer.
@@ -150,7 +155,7 @@ TEST_F(HandleManagerTest, MixedRdonlyWritable_OnlyOneWriterEntry) {
 TEST_F(HandleManagerTest, WriterEvictedThenRecreatedOnReopen) {
   auto* h1 = handle_manager_->NewHandle(/*fh*/ 30, /*ino*/ 700, O_WRONLY);
   ASSERT_NE(h1, nullptr);
-  ASSERT_NE(h1->writer, nullptr);
+  ASSERT_NE(h1->resources.writer, nullptr);
   EXPECT_EQ(writer_table_->Size(), 1u);
 
   handle_manager_->ReleaseHandler(30);
@@ -160,7 +165,7 @@ TEST_F(HandleManagerTest, WriterEvictedThenRecreatedOnReopen) {
   // Reopen — a fresh writer is allocated.
   auto* h2 = handle_manager_->NewHandle(/*fh*/ 31, /*ino*/ 700, O_WRONLY);
   ASSERT_NE(h2, nullptr);
-  ASSERT_NE(h2->writer, nullptr);
+  ASSERT_NE(h2->resources.writer, nullptr);
   EXPECT_EQ(writer_table_->Size(), 1u);
 
   handle_manager_->ReleaseHandler(31);
@@ -183,18 +188,22 @@ TEST_F(HandleManagerTest, FlushByIno_WithWriter_KeepsTableSize) {
   EXPECT_EQ(writer_table_->Size(), 0u);
 }
 
-// FindHandler returns the live handle for a known fh, nullptr for unknown,
-// and nullptr after release.
-TEST_F(HandleManagerTest, FindHandler_KnownAndUnknown) {
+// FindHandlerGuard returns a live guard for a known fh, an empty guard for an
+// unknown fh, and an empty guard after release.
+TEST_F(HandleManagerTest, FindHandlerGuard_KnownAndUnknown) {
   auto* h = handle_manager_->NewHandle(/*fh*/ 70, /*ino*/ 1100, O_RDONLY);
   ASSERT_NE(h, nullptr);
 
-  EXPECT_EQ(handle_manager_->FindHandler(70), h);
-  EXPECT_EQ(handle_manager_->FindHandler(71), nullptr);
+  {
+    auto g = handle_manager_->FindHandlerGuard(70);
+    EXPECT_TRUE(g);
+    EXPECT_EQ(g.get(), h);
+  }
+  EXPECT_FALSE(handle_manager_->FindHandlerGuard(71));
 
   handle_manager_->ReleaseHandler(70);
-  EXPECT_EQ(handle_manager_->FindHandler(70), nullptr)
-      << "after release, FindHandler must not return the handle";
+  EXPECT_FALSE(handle_manager_->FindHandlerGuard(70))
+      << "after release, FindHandlerGuard must be empty";
 }
 
 // ReleaseHandler on an unknown fh must be a safe no-op — it must not crash
@@ -206,27 +215,183 @@ TEST_F(HandleManagerTest, ReleaseHandler_UnknownFh_NoOp) {
 
   handle_manager_->ReleaseHandler(/*fh*/ 999);  // never created
   EXPECT_EQ(writer_table_->Size(), 1u);
-  EXPECT_EQ(handle_manager_->FindHandler(80), h);
+  EXPECT_EQ(handle_manager_->FindHandlerGuard(80).get(), h);
 
   handle_manager_->ReleaseHandler(80);
   EXPECT_EQ(writer_table_->Size(), 0u);
 }
 
-// Stop() must close the per-fh reader (so in-flight reads drain) but must
-// NOT prematurely return the writer to WriterTable — the writer is still
-// owned by the handle until ReleaseHandler is called.
-TEST_F(HandleManagerTest, Stop_KeepsWriterUntilHandleReleased) {
+// --- teardown lifecycle (N1 fix: writer Close happens in Stop, not in the
+// destructor after executors are gone) ---
+
+// Stop() must release the per-fh reader/writer resources WHILE the data-path
+// executors are still alive, so the writer is returned to the table during
+// Stop (not deferred to ~Handle).  This is the inverse of the pre-fix
+// behavior that kept the writer until ReleaseHandler.
+TEST_F(HandleManagerTest, Stop_ReleasesWriterResources) {
   auto* h = handle_manager_->NewHandle(/*fh*/ 50, /*ino*/ 900, O_WRONLY);
   ASSERT_NE(h, nullptr);
   EXPECT_EQ(writer_table_->Size(), 1u);
 
   handle_manager_->Stop();
-  EXPECT_EQ(writer_table_->Size(), 1u)
-      << "Stop must not return the writer to the table";
-
-  handle_manager_->ReleaseHandler(50);
   EXPECT_EQ(writer_table_->Size(), 0u)
-      << "ReleaseHandler after Stop must still return the writer";
+      << "Stop must release the writer while executors are still alive";
+}
+
+// Stop() detaches resources but keeps the handle identity (fh/ino/flags) so
+// hot-upgrade Dump can still persist open handles.
+TEST_F(HandleManagerTest, Stop_PreservesHandleIdentity) {
+  auto* h = handle_manager_->NewHandle(/*fh*/ 51, /*ino*/ 901, O_WRONLY);
+  ASSERT_NE(h, nullptr);
+  const uint64_t fh = h->fh;
+  const Ino ino = h->ino;
+  const int32_t flags = h->flags;
+
+  handle_manager_->Stop();
+  EXPECT_EQ(writer_table_->Size(), 0u) << "Stop released the writer";
+
+  // Identity survives (release path can still see it), resources are detached.
+  auto g = handle_manager_->FindHandlerForRelease(51);
+  ASSERT_TRUE(g);
+  EXPECT_EQ(g->fh, fh);
+  EXPECT_EQ(g->ino, ino);
+  EXPECT_EQ(g->flags, flags);
+  EXPECT_EQ(g->resources.reader, nullptr) << "reader detached by Stop";
+  EXPECT_EQ(g->resources.writer, nullptr) << "writer detached by Stop";
+}
+
+// After Stop(), the data path must not be able to obtain a handle, but the
+// release path must, so a late FUSE_RELEASE can still drop the fh identity.
+TEST_F(HandleManagerTest, FindHandlerGuard_EmptyAfterStop_ReleasePathWorks) {
+  auto* h = handle_manager_->NewHandle(/*fh*/ 52, /*ino*/ 902, O_RDONLY);
+  ASSERT_NE(h, nullptr);
+
+  handle_manager_->Stop();
+
+  EXPECT_FALSE(handle_manager_->FindHandlerGuard(52))
+      << "data path must be closed after Stop";
+  EXPECT_TRUE(handle_manager_->FindHandlerForRelease(52))
+      << "release path must stay open after Stop";
+}
+
+// NewHandle after Stop() must fail (AddHandle rejected) and must not leak the
+// writer it briefly acquired.
+TEST_F(HandleManagerTest, NewHandle_AfterStop_RejectedNoLeak) {
+  handle_manager_->Stop();
+
+  auto* h = handle_manager_->NewHandle(/*fh*/ 53, /*ino*/ 903, O_WRONLY);
+  EXPECT_EQ(h, nullptr) << "NewHandle must fail once HandleManager is stopped";
+  EXPECT_EQ(writer_table_->Size(), 0u)
+      << "rejected NewHandle must not leak the acquired writer";
+}
+
+// A late FUSE_RELEASE after Stop() already detached resources must be
+// idempotent: no double ReleaseWriter (which would underflow holders) and no
+// crash.
+TEST_F(HandleManagerTest, ReleaseHandler_AfterStop_Idempotent) {
+  auto* h = handle_manager_->NewHandle(/*fh*/ 54, /*ino*/ 904, O_WRONLY);
+  ASSERT_NE(h, nullptr);
+
+  handle_manager_->Stop();
+  EXPECT_EQ(writer_table_->Size(), 0u) << "Stop released the writer";
+
+  // Must not double-release the (already detached) writer.
+  handle_manager_->ReleaseHandler(54);
+  EXPECT_EQ(writer_table_->Size(), 0u);
+  EXPECT_FALSE(handle_manager_->FindHandlerForRelease(54))
+      << "identity removed after late release";
+}
+
+// Core of the N1 fix: Stop() must wait for an outstanding HandleGuard (an
+// in-flight request) to be released before tearing down resources.
+TEST_F(HandleManagerTest, Stop_WaitsForOutstandingGuard) {
+  auto* h = handle_manager_->NewHandle(/*fh*/ 55, /*ino*/ 905, O_WRONLY);
+  ASSERT_NE(h, nullptr);
+  EXPECT_EQ(writer_table_->Size(), 1u);
+
+  // Simulate an in-flight request holding the handle.
+  auto guard = handle_manager_->FindHandlerGuard(55);
+  ASSERT_TRUE(guard);
+
+  std::atomic<bool> stop_returned{false};
+  std::thread stopper([&]() {
+    handle_manager_->Stop();
+    stop_returned.store(true);
+  });
+
+  // Stop must block while the guard is held (writer not yet released).
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_FALSE(stop_returned.load())
+      << "Stop must wait for the outstanding guard to be released";
+  EXPECT_EQ(writer_table_->Size(), 1u)
+      << "writer must not be released while a request still holds the handle";
+
+  // Releasing the guard unblocks Stop, which then releases the writer.
+  guard = HandleGuard{};
+  stopper.join();
+  EXPECT_TRUE(stop_returned.load());
+  EXPECT_EQ(writer_table_->Size(), 0u)
+      << "writer released once the in-flight request drained";
+}
+
+// HandleGuard is move-only and transfers ownership; the moved-from guard must
+// not release, the moved-to guard must, with no double release.
+TEST_F(HandleManagerTest, HandleGuard_MoveTransfersOwnership) {
+  auto* h = handle_manager_->NewHandle(/*fh*/ 56, /*ino*/ 906, O_RDONLY);
+  ASSERT_NE(h, nullptr);
+
+  {
+    auto g1 = handle_manager_->FindHandlerGuard(56);
+    ASSERT_TRUE(g1);
+
+    auto g2 = std::move(g1);
+    EXPECT_FALSE(g1) << "moved-from guard must be empty";
+    ASSERT_TRUE(g2);
+    EXPECT_EQ(g2.get(), h);
+  }  // only g2 releases here; a double release would underflow Handle::refs
+
+  // Handle is still alive (only the transient guard ref was dropped).
+  EXPECT_EQ(handle_manager_->FindHandlerGuard(56).get(), h);
+  handle_manager_->ReleaseHandler(56);
+}
+
+// A late FUSE_RELEASE racing an in-progress Stop() must be safe: no deadlock,
+// no double ReleaseWriter (WriterTable holders underflow), no use-after-free.
+// Stop is forced to block in its cv_.wait by pinning handle A with a guard,
+// then handle B is released concurrently while Stop is parked.
+// Best run under TSAN/ASAN; the race window here is probabilistic.
+TEST_F(HandleManagerTest, Stop_ConcurrentReleaseHandler_Safe) {
+  // A: pinned by a guard so Stop blocks.
+  ASSERT_NE(handle_manager_->NewHandle(/*fh*/ 57, /*ino*/ 907, O_WRONLY),
+            nullptr);
+  // B: dropped by a concurrent FUSE_RELEASE while Stop is parked.
+  ASSERT_NE(handle_manager_->NewHandle(/*fh*/ 58, /*ino*/ 908, O_WRONLY),
+            nullptr);
+  EXPECT_EQ(writer_table_->Size(), 2u);
+
+  auto guard = handle_manager_->FindHandlerGuard(57);  // pin A
+  ASSERT_TRUE(guard);
+
+  std::atomic<bool> stop_returned{false};
+  std::thread stopper([&]() {
+    handle_manager_->Stop();  // blocks on A's outstanding guard
+    stop_returned.store(true);
+  });
+
+  // Let Stop enter its wait, then race a release of B against it.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  handle_manager_->ReleaseHandler(58);  // concurrent with Stop's cv_.wait
+
+  // A is still pinned -> Stop must still be blocked.
+  EXPECT_FALSE(stop_returned.load());
+
+  guard = HandleGuard{};  // release A -> Stop proceeds
+  stopper.join();
+  EXPECT_TRUE(stop_returned.load());
+
+  // Each writer returned exactly once (B by ReleaseHandler, A by Stop); a
+  // double release would have tripped WriterTable's holders CHECK.
+  EXPECT_EQ(writer_table_->Size(), 0u);
 }
 
 // ~HandleManager must release all writers held by surviving handles —

--- a/test/unit/client/vfs/mock/mock_vfs_hub.h
+++ b/test/unit/client/vfs/mock/mock_vfs_hub.h
@@ -37,7 +37,8 @@ class MockVFSHub : public VFSHub {
   MOCK_METHOD(BlockStore*, GetBlockStore, (), (override));
   MOCK_METHOD(blockaccess::BlockAccesser*, GetBlockAccesser, (), (override));
   MOCK_METHOD(Executor*, GetReadExecutor, (), (override));
-  MOCK_METHOD(Executor*, GetBGExecutor, (), (override));
+  MOCK_METHOD(Executor*, GetReadCleanupExecutor, (), (override));
+  MOCK_METHOD(Executor*, GetWriteBackgroundExecutor, (), (override));
   MOCK_METHOD(Executor*, GetFlushExecutor, (), (override));
   MOCK_METHOD(Executor*, GetCBExecutor, (), (override));
   MOCK_METHOD(WriteMemPool*, GetWriteMemPool, (), (override));

--- a/test/unit/client/vfs/test_base.h
+++ b/test/unit/client/vfs/test_base.h
@@ -91,11 +91,15 @@ class VFSTestBase : public ::testing::Test {
     // --- 6. Real thread pools (sdk pattern: don't mock executors) ---
     read_executor_ = std::make_unique<ExecutorImpl>("test_read", 2);
     flush_executor_ = std::make_unique<ExecutorImpl>("test_flush", 2);
-    bg_executor_ = std::make_unique<ExecutorImpl>("test_bg", 1);
+    read_cleanup_executor_ =
+        std::make_unique<ExecutorImpl>("test_read_cleanup", 1);
+    write_background_executor_ =
+        std::make_unique<ExecutorImpl>("test_write_bg", 1);
     cb_executor_ = std::make_unique<ExecutorImpl>("test_cb", 1);
     CHECK(read_executor_->Start());
     CHECK(flush_executor_->Start());
-    CHECK(bg_executor_->Start());
+    CHECK(read_cleanup_executor_->Start());
+    CHECK(write_background_executor_->Start());
     CHECK(cb_executor_->Start());
 
     // --- 7. MockVFSHub defaults (ON_CALL + AnyNumber pattern) ---
@@ -116,8 +120,10 @@ class VFSTestBase : public ::testing::Test {
         .WillByDefault(Return(read_executor_.get()));
     ON_CALL(*mock_hub_, GetFlushExecutor())
         .WillByDefault(Return(flush_executor_.get()));
-    ON_CALL(*mock_hub_, GetBGExecutor())
-        .WillByDefault(Return(bg_executor_.get()));
+    ON_CALL(*mock_hub_, GetReadCleanupExecutor())
+        .WillByDefault(Return(read_cleanup_executor_.get()));
+    ON_CALL(*mock_hub_, GetWriteBackgroundExecutor())
+        .WillByDefault(Return(write_background_executor_.get()));
     ON_CALL(*mock_hub_, GetCBExecutor())
         .WillByDefault(Return(cb_executor_.get()));
     ON_CALL(*mock_hub_, GetFsInfo()).WillByDefault(Return(MakeTestFsInfo()));
@@ -134,7 +140,8 @@ class VFSTestBase : public ::testing::Test {
     EXPECT_CALL(*mock_hub_, GetCompactor()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetReadExecutor()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetFlushExecutor()).Times(AnyNumber());
-    EXPECT_CALL(*mock_hub_, GetBGExecutor()).Times(AnyNumber());
+    EXPECT_CALL(*mock_hub_, GetReadCleanupExecutor()).Times(AnyNumber());
+    EXPECT_CALL(*mock_hub_, GetWriteBackgroundExecutor()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetCBExecutor()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetFsInfo()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetUidGidMapper()).Times(AnyNumber());
@@ -197,10 +204,11 @@ class VFSTestBase : public ::testing::Test {
 
   ~VFSTestBase() override {
     handle_manager_->Stop();
-    cb_executor_->Stop();
+    write_background_executor_->Stop();
     flush_executor_->Stop();
     read_executor_->Stop();
-    bg_executor_->Stop();
+    read_cleanup_executor_->Stop();
+    cb_executor_->Stop();
   }
 
  protected:
@@ -222,7 +230,8 @@ class VFSTestBase : public ::testing::Test {
   // Real executors
   std::unique_ptr<ExecutorImpl> read_executor_;
   std::unique_ptr<ExecutorImpl> flush_executor_;
-  std::unique_ptr<ExecutorImpl> bg_executor_;
+  std::unique_ptr<ExecutorImpl> read_cleanup_executor_;
+  std::unique_ptr<ExecutorImpl> write_background_executor_;
   std::unique_ptr<ExecutorImpl> cb_executor_;
 
   ContextSPtr ctx_;


### PR DESCRIPTION
## Summary

This PR adds graceful hot-upgrade support for the DingoFS FUSE client.

The new process takes over the existing kernel FUSE connection by receiving the old process's `/dev/fuse` fd over UDS, replays the saved FUSE INIT request, and loads the dumped VFS state. The old process uses the libfuse controlled-drain APIs before checkpointing, so requests that have already been read by the old daemon are handled before the fd is handed over.

This is a graceful handover path, not a fully transactional hot-upgrade with rollback at every failure point. Failures before checkpoint can NACK/resume on the old process. After `Stop(true) + Dump`, the old VFS has already been torn down, so a later new-side mount/load failure still requires remount or manual recovery.

## Main Changes

- Free the saved FUSE INIT receive buffer after it is copied and replayed through libfuse.
- Move the VFS handover state file out of `/tmp` and publish it atomically with temp file + fsync + rename + directory fsync.
- Add the hot-upgrade handover path:
  - UDS fd passing for the live `/dev/fuse` fd.
  - saved INIT buffer transfer and replay in the new process.
  - old-side handover controller driven by SIGHUP plus UDS `kPrepare` validation.
  - controlled drain through libfuse pause/resume/wait-drained APIs.
  - checkpoint through `VFSWrapper::Stop(true)` and state dump/load.
  - READY/NACK protocol: checkpoint success sends `kReadyToExit`; drain/checkpoint-precondition failure sends `kNack` and resumes the old process.
- Fix teardown lifecycle issues found during hot-upgrade testing:
  - use `HandleGuard` so Stop waits for active handle users and releases reader/writer resources outside the handle lock.
  - make VFSHub/MetaWrapper Stop idempotent.
  - add dedicated read-cleanup and write-background executors so teardown does not submit cleanup work to already-stopped executors.
- Make `kReadyToExit` a one-way final notification. The new process no longer sends `kAck`, and the old process no longer waits for it after checkpoint.
- Fix the drain-timeout statfs wakeup deadlock: the wakeup thread is stopped and detached on both success and timeout, so a statfs blocked behind a paused FUSE session cannot prevent `kNack`/`ResumeReceive()`.

## Commit Layout

- `free leaked FUSE INIT receive buffer`
- `move VFS state file off /tmp and publish atomically`
- `controlled drain + flush checkpoint + ACK/NACK handover handshake`
- `Release handle resources in Stop() via HandleGuard`
- `Hot-upgrade teardown: dedicated read-cleanup/write-bg executors + idempotent VFSHub/meta Stop`
- `make READY one-way and remove ACK wait`
- `detach statfs wakeup thread on drain timeout`

## Validation

- `cmake --build build --target test_fuse_upgrade -j2`
- `build/bin/test/test_fuse_upgrade`

Current result: 16 tests passed.

## Notes

This PR depends on the libfuse controlled-drain APIs used by `HandoverSessionImpl`:

- `fuse_session_pause_receive`
- `fuse_session_resume_receive`
- `fuse_session_wait_drained`
