### PR TITLE
fix(mds-client): bypass inode cache in info command

### DIFF
--- a/src/tools/mds-cli/mds.cc
+++ b/src/tools/mds-cli/mds.cc
@@ -607,7 +607,7 @@ ListDentryResponse MDSClient::ListDentryPaged(Ino parent,
   return response;
 }
 
-GetInodeResponse MDSClient::GetInode(Ino ino) {
+GetInodeResponse MDSClient::GetInode(Ino ino, bool bypass_cache) {
   CHECK(fs_id_ > 0) << "fs_id_ is zero";
   CHECK(ino > 0) << "ino is zero";
 
@@ -615,6 +615,7 @@ GetInodeResponse MDSClient::GetInode(Ino ino) {
   GetInodeResponse response;
 
   request.mutable_context()->set_epoch(epoch_);
+  request.mutable_context()->set_is_bypass_cache(bypass_cache);
 
   request.set_fs_id(fs_id_);
   request.set_ino(ino);
@@ -2242,7 +2243,10 @@ void HandleInfo(MDSClient& mds_client, uint32_t fs_id,
   const std::string os_path = AbsOsPath(options.path);
   const std::string fs_path = MountRelPath(os_path);
 
-  auto inode_resp = mds_client.GetInode(ino);
+  // Bypass the serving MDS's inode cache: `info` accepts any --mds_addr, and a
+  // non-owner MDS would otherwise serve a stale length forever (writes only
+  // refresh the owner's cache).
+  auto inode_resp = mds_client.GetInode(ino, /*bypass_cache=*/true);
   if (inode_resp.error().errcode() != dingofs::pb::error::Errno::OK) {
     std::cerr << "info: get inode fail, error: "
               << inode_resp.ShortDebugString() << "\n";

--- a/src/tools/mds-cli/mds.h
+++ b/src/tools/mds-cli/mds.h
@@ -253,7 +253,10 @@ class MDSClient {
   // Render-silent, paged variant for the client-side tree walk: returns one page
   // (entries after `last`, up to `limit`) without printing.
   ListDentryResponse ListDentryPaged(Ino parent, const std::string& last, uint32_t limit, bool is_only_dir);
-  GetInodeResponse GetInode(Ino ino);
+  // bypass_cache reads the inode from the store instead of the serving MDS's
+  // local cache, which goes stale on non-owner MDSes (no cross-MDS
+  // invalidation).
+  GetInodeResponse GetInode(Ino ino, bool bypass_cache = false);
   BatchGetInodeResponse BatchGetInode(const std::vector<int64_t>& inos);
   BatchGetXAttrResponse BatchGetXattr(const std::vector<int64_t>& inos);
 


### PR DESCRIPTION
`info <file>` reads the inode via GetInode against whatever --mds_addr the user picked. Each MDS keeps its own lazily-populated inode cache with no cross-MDS invalidation, so once a non-owner MDS caches the inode (e.g. queried while the file was empty), later writes -- which only refresh the owner's cache -- leave that node serving a stale length forever.

Add a bypass_cache parameter to MDSClient::GetInode and set context.is_bypass_cache from it; only the info command passes true, so its header block always reflects the store regardless of which MDS serves the request. The GetInode command keeps the default (false).

Verified live on a 3-MDS setup: poisoning all three caches on an empty file, then writing and truncating, now yields the correct length from every MDS; previously the two non-owner nodes were stuck at 0.

<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
