### PR TITLE
[feat][common] Show proto submodule commit id in dashboard Git section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,20 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# proto/ is the dingofs-proto git submodule; record its commit id so the
+# dashboard Git section can show which proto revision was built against.
+execute_process(
+  COMMAND git -C ${PROJECT_SOURCE_DIR}/proto log -1 --format=%h
+  OUTPUT_VARIABLE PROTO_GIT_COMMIT_ID
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+)
+
+if(NOT PROTO_GIT_COMMIT_ID)
+  set(PROTO_GIT_COMMIT_ID "unknown")
+  message(WARNING "Proto git commit id is unknown")
+endif()
+
 if(NOT GIT_VERSION)
   set(GIT_VERSION "unknown")
   message(WARNING "Git version is unknown")
@@ -147,6 +161,7 @@ message(STATUS "Git commit mail: ${GIT_COMMIT_MAIL}")
 message(STATUS "Git commit time: ${GIT_COMMIT_TIME}")
 message(STATUS "Git last commit id: ${GIT_LAST_COMMIT_ID}")
 message(STATUS "Git branch name: ${GIT_BRANCH_NAME}")
+message(STATUS "Proto git commit id: ${PROTO_GIT_COMMIT_ID}")
 
 add_definitions(-DGIT_VERSION="${GIT_VERSION}")
 add_definitions(-DGIT_TAG_NAME="${GIT_TAG_NAME}")
@@ -155,6 +170,7 @@ add_definitions(-DGIT_COMMIT_MAIL="${GIT_COMMIT_MAIL}")
 add_definitions(-DGIT_COMMIT_TIME="${GIT_COMMIT_TIME}")
 add_definitions(-DGIT_LAST_COMMIT_ID="${GIT_LAST_COMMIT_ID}")
 add_definitions(-DGIT_BRANCH_NAME="${GIT_BRANCH_NAME}")
+add_definitions(-DPROTO_GIT_COMMIT_ID="${PROTO_GIT_COMMIT_ID}")
 add_definitions(-DDINGOFS_BUILD_TYPE="${CMAKE_BUILD_TYPE}")
 
 if(USE_CICD_BUILD)

--- a/src/client/main.cc
+++ b/src/client/main.cc
@@ -211,11 +211,14 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  struct MountOption mount_option {
-    .mount_point = mountpoint, .fs_name = fs_name,
-    .metasystem_type = metasystem_type, .mds_addrs = mds_addrs,
-    .storage_info = storage_info, .meta_url = argv[1],
-    .subdir = dingofs::client::FLAGS_fuse_subdir,
+  struct MountOption mount_option{
+      .mount_point = mountpoint,
+      .fs_name = fs_name,
+      .metasystem_type = metasystem_type,
+      .mds_addrs = mds_addrs,
+      .storage_info = storage_info,
+      .meta_url = argv[1],
+      .subdir = dingofs::client::FLAGS_fuse_subdir,
   };
 
   fuse_server = new FuseServer();
@@ -234,6 +237,7 @@ int main(int argc, char* argv[]) {
   LOG(INFO) << dingofs::GenCurrentFlags();
   // print version
   LOG(INFO) << dingofs::DingoShortVersionString();
+  LOG(INFO) << dingofs::DingoVersionString();
   // print dingo eureka version
   LOG(INFO) << FormatDingoEurekaVersion();
 

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -29,6 +29,7 @@ static const std::string kGitVersion = GIT_VERSION;
 static const std::string kGitTagName = GIT_TAG_NAME;
 static const std::string kGitBranchName = GIT_BRANCH_NAME;
 static const std::string kGitLastCommit = GIT_LAST_COMMIT_ID;
+static const std::string kProtoGitCommit = PROTO_GIT_COMMIT_ID;
 static const std::string kGitCommitUser = GIT_COMMIT_USER;
 static const std::string kGitCommitMail = GIT_COMMIT_MAIL;
 static const std::string kGitCommitTime = GIT_COMMIT_TIME;
@@ -70,6 +71,7 @@ std::string DingoVersionString() {
   oss << fmt::format("DINGOFS GIT_LAST_TAG:[{}]\n", kGitTagName.c_str());
   oss << fmt::format("DINGOFS GIT_BRANCH_NAME:[{}]\n", kGitBranchName.c_str());
   oss << fmt::format("DINGOFS GIT_COMMIT_HASH:[{}]\n", kGitLastCommit.c_str());
+  oss << fmt::format("DINGOFS PROTO_COMMIT_HASH:[{}]\n", kProtoGitCommit.c_str());
   oss << fmt::format("DINGOFS BUILD_TYPE:[{}]\n", kDingoFsBuildType.c_str());
   oss << GetBuildFlag() << "\n";
 
@@ -94,6 +96,7 @@ void DingoLogVersion() {
   LOG(INFO) << "DINGOFS GIT_LAST_TAG:[" << kGitTagName << "]";
   LOG(INFO) << "DINGOFS GIT_BRANCH_NAME:[" << kGitBranchName << "]";
   LOG(INFO) << "DINGOFS GIT_COMMIT_HASH:[" << kGitLastCommit << "]";
+  LOG(INFO) << "DINGOFS PROTO_COMMIT_HASH:[" << kProtoGitCommit << "]";
   LOG(INFO) << "DINGOFS BUILD_TYPE:[" << kDingoFsBuildType << "]";
   LOG(INFO) << GetBuildFlag();
   LOG(INFO) << "PID: " << getpid();
@@ -103,6 +106,7 @@ std::vector<std::pair<std::string, std::string>> DingoVersion() {
   std::vector<std::pair<std::string, std::string>> result;
   result.emplace_back("BRANCH", kGitBranchName);
   result.emplace_back("COMMIT_HASH", kGitLastCommit);
+  result.emplace_back("PROTO_COMMIT_HASH", kProtoGitCommit);
   result.emplace_back("COMMIT_USER", kGitCommitUser);
   result.emplace_back("COMMIT_MAIL", kGitCommitMail);
   result.emplace_back("COMMIT_TIME", kGitCommitTime);
@@ -122,4 +126,6 @@ std::string GetGitVersion() { return kGitVersion; }
 std::string GetGitCommitHash() { return kGitLastCommit; }
 
 std::string GetGitCommitTime() { return kGitCommitTime; }
+
+std::string GetProtoGitCommitHash() { return kProtoGitCommit; }
 }  // namespace dingofs

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -53,6 +53,10 @@ namespace dingofs {
 #define GIT_LAST_COMMIT_ID "unknown"
 #endif
 
+#ifndef PROTO_GIT_COMMIT_ID
+#define PROTO_GIT_COMMIT_ID "unknown"
+#endif
+
 std::string DingoVersionString();
 std::string DingoShortVersionString();
 
@@ -63,6 +67,7 @@ void ExposeDingoVersion();
 std::string GetGitVersion();
 std::string GetGitCommitHash();
 std::string GetGitCommitTime();
+std::string GetProtoGitCommitHash();
 
 }  // namespace dingofs
 


### PR DESCRIPTION
Capture the git commit id of the proto/ submodule (dingofs-proto) at build time and expose it through DingoVersion(), the same helper the MDS and client dashboards already use to render their "Git" panel. This lets operators see which proto revision a running dingo-mds or dingo-client binary was built against, without extra dashboard code.

<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: #xxx <!-- replace xxx with issue number -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

Side effects(Breaking backward compatibility? Performance regression?):

### Check List

- [ ] Relevant documentation/comments is changed or added
- [ ] I acknowledge that all my contributions will be made under the project's license
