### PR TITLE
[fix][client] Fixup chunk set split between file session and chunk cache on truncate open

### DIFF
--- a/src/client/vfs/metasystem/mds/chunk.cc
+++ b/src/client/vfs/metasystem/mds/chunk.cc
@@ -704,6 +704,18 @@ void ChunkCache::CleanExpired(uint64_t expire_s) {
   shard_map_.iterateWLock([&](Map& map) {
     for (auto it = map.begin(); it != map.end();) {
       if (it->second->GetLastActiveTimeS() < expire_s) {
+        if (it->second->HasUncommitedSlice()) {
+          // Data safety guard: do not erase staged/committing slices. A future
+          // cleanup path should force-commit and escalate if the same ChunkSet
+          // stays dirty across repeated expiry rounds.
+          LOG_EVERY_N(WARNING, 100) << fmt::format(
+              "[meta.chunkcache] skip clean expired chunkset ino({}) with "
+              "uncommited slice.",
+              it->first);
+          ++it;
+          continue;
+        }
+
         auto temp = it++;
         map.erase(temp);
         clean_count_ << 1;

--- a/src/client/vfs/metasystem/mds/file_session.cc
+++ b/src/client/vfs/metasystem/mds/file_session.cc
@@ -118,7 +118,8 @@ bool FileSession::Dump(Json::Value& value) {
 
   // dump chunk_set_
   Json::Value chunk_set_value = Json::objectValue;
-  chunk_set_->Dump(chunk_set_value);
+  auto chunk_set = GetChunkSet();
+  chunk_set->Dump(chunk_set_value);
   value["chunk_set"] = chunk_set_value;
 
   return true;

--- a/src/client/vfs/metasystem/mds/file_session.h
+++ b/src/client/vfs/metasystem/mds/file_session.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -59,10 +60,17 @@ class FileSession {
   void SetInode(InodeSPtr inode) { inode_ = inode; }
   InodeSPtr& GetInode() { return inode_; }
 
-  ChunkSetSPtr& GetChunkSet() {
+  ChunkSetSPtr GetChunkSet() {
+    std::lock_guard<std::mutex> guard(chunk_set_mutex_);
     CHECK(chunk_set_ != nullptr)
         << fmt::format("chunk_set is nullptr, ino({}).", ino_);
     return chunk_set_;
+  }
+  void SetChunkSet(ChunkSetSPtr chunk_set) {
+    CHECK(chunk_set != nullptr)
+        << fmt::format("chunk_set is nullptr, ino({}).", ino_);
+    std::lock_guard<std::mutex> guard(chunk_set_mutex_);
+    chunk_set_ = chunk_set;
   }
 
   void AddSession(uint64_t fh, const std::string& session_id, uint32_t flags);
@@ -95,6 +103,10 @@ class FileSession {
   absl::flat_hash_map<uint64_t, SessionInfo> session_id_map_;
 
   InodeSPtr inode_;
+
+  // Guards chunk_set_ rebinding on successful O_TRUNC while other fhs of the
+  // same inode may concurrently flush through the shared FileSession.
+  std::mutex chunk_set_mutex_;
   ChunkSetSPtr chunk_set_;
 
   uint64_t last_keep_alive_time_s_{utils::Timestamp()};

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -704,13 +704,17 @@ Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
   file_session->SetInode(inode);
 
   // truncate file, forget chunk memo and delete chunk cache
+  ChunkSetSPtr chunk_set;
   if (flags & O_TRUNC) {
     chunk_memo_.Forget(ino);
     chunk_cache_.Delete(ino);
+    chunk_set = chunk_cache_.GetOrCreate(ino);
+    file_session->SetChunkSet(chunk_set);
+  } else {
+    chunk_set = file_session->GetChunkSet();
   }
 
   // update chunk cache
-  auto& chunk_set = file_session->GetChunkSet();
   if (!chunks.empty()) chunk_set->Put(chunks, "open");
 
   // update chunk memo
@@ -918,9 +922,27 @@ void MDSMetaSystem::AsyncClose(ContextSPtr ctx, Ino ino, uint64_t fh,
 Status MDSMetaSystem::Close(ContextSPtr ctx, Ino ino, uint64_t fh) {
   AssertStop();
 
-  std::string session_id = file_session_map_.GetSessionID(ino, fh);
+  auto file_session = file_session_map_.GetSession(ino);
+  CHECK(file_session != nullptr)
+      << fmt::format("get file session fail, ino({}) fh({}).", ino, fh);
+
+  std::string session_id = file_session->GetSessionID(fh);
   CHECK(!session_id.empty())
       << fmt::format("get file session fail, ino({}) fh({}).", ino, fh);
+
+  uint32_t flags = file_session->GetFlags(fh);
+  Status flush_status = Status::OK();
+  if ((flags & O_WRONLY) || (flags & O_RDWR)) {
+    // VFS release closes the data writer before meta close, so all slices
+    // produced by this fd have already reached MetaSystem::WriteSlice().  This
+    // barrier turns any remaining staged slice metadata into committed MDS
+    // WriteSlice RPCs before the file session is released.
+    flush_status = FlushSliceAndFile(ctx, ino);
+    if (!flush_status.ok()) {
+      LOG(ERROR) << fmt::format("[meta.fs.{}.{}] close flush fail, error({}).",
+                                ino, fh, flush_status.ToString());
+    }
+  }
 
   file_session_map_.Delete(ino, fh);
 
@@ -929,7 +951,7 @@ Status MDSMetaSystem::Close(ContextSPtr ctx, Ino ino, uint64_t fh) {
 
   AsyncClose(ctx, ino, fh, session_id);
 
-  return Status::OK();
+  return flush_status;
 }
 
 Status MDSMetaSystem::ReadSlice(ContextSPtr ctx, Ino ino, uint64_t index,
@@ -1028,7 +1050,7 @@ Status MDSMetaSystem::Write(ContextSPtr, Ino ino, const char* buf,
   CHECK(file_session != nullptr)
       << fmt::format("file session is nullptr, ino({}) fh({}).", ino, fh);
 
-  auto& chunk_set = file_session->GetChunkSet();
+  auto chunk_set = file_session->GetChunkSet();
   chunk_set->SetLastWriteLength(offset, size);
 
   if (FLAGS_vfs_tiny_file_data_enable) {
@@ -1260,7 +1282,16 @@ Status MDSMetaSystem::Unlink(ContextSPtr ctx, Ino parent,
   PutInodeToCache(parent_attr_entry);
   if (attr_entry.nlink() == 0) {
     DeleteInodeFromCache(attr_entry.ino());
-    chunk_cache_.Delete(attr_entry.ino());
+    if (file_session_map_.GetSession(attr_entry.ino()) == nullptr) {
+      chunk_cache_.Delete(attr_entry.ino());
+    } else {
+      // POSIX permits write/read through an already-open fd after unlink.
+      // Keep its ChunkSet bound to the live FileSession; deleting it here would
+      // split the FileSession view from future WriteSlice's chunk_cache view.
+      LOG(INFO) << fmt::format(
+          "[meta.fs.{}] keep chunk cache for unlinked open file.",
+          attr_entry.ino());
+    }
   }
 
   return Status::OK();
@@ -1591,7 +1622,7 @@ Status MDSMetaSystem::FlushSliceAndFile(ContextSPtr ctx, Ino ino) {
   CHECK(file_session != nullptr)
       << fmt::format("file session is nullptr, ino({}).", ino);
 
-  auto& chunk_set = file_session->GetChunkSet();
+  auto chunk_set = file_session->GetChunkSet();
 
   LOG(INFO) << fmt::format("[meta.fs.{}] flush all slice.", ino);
 
@@ -1635,7 +1666,7 @@ void MDSMetaSystem::AsyncFlushFile(ContextSPtr ctx, Ino ino) {
             if (file_session != nullptr) {
               LOG(INFO) << fmt::format("[meta.fs.{}] async flush file.", ino);
 
-              auto& chunk_set = file_session->GetChunkSet();
+              auto chunk_set = file_session->GetChunkSet();
               self.DoFlushFile(param->ctx, self.GetInode(file_session),
                                chunk_set, false);
               chunk_set->ResetFlush();

--- a/test/unit/client/vfs/CMakeLists.txt
+++ b/test/unit/client/vfs/CMakeLists.txt
@@ -14,3 +14,4 @@
 
 add_subdirectory(compaction)
 add_subdirectory(data)
+add_subdirectory(metasystem)

--- a/test/unit/client/vfs/metasystem/CMakeLists.txt
+++ b/test/unit/client/vfs/metasystem/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# standalone runners: TEST() registration inside static libs linked into the
+# aggregated test_client gets dropped by the linker, so build own binaries.
+
+add_executable(test_chunkset_flush_race
+    test_chunkset_flush_race.cc
+)
+target_link_libraries(test_chunkset_flush_race
+  vfs_metasystem_mds_lib
+  ${TEST_DEPS}
+)
+set_target_properties(test_chunkset_flush_race PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${TEST_EXECUTABLE_OUTPUT_PATH}
+)
+
+add_executable(test_trunc_chunkset_split
+    test_trunc_chunkset_split.cc
+)
+target_link_libraries(test_trunc_chunkset_split
+  vfs_metasystem_mds_lib
+  ${TEST_DEPS}
+)
+set_target_properties(test_trunc_chunkset_split PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${TEST_EXECUTABLE_OUTPUT_PATH}
+)

--- a/test/unit/client/vfs/metasystem/test_chunkset_flush_race.cc
+++ b/test/unit/client/vfs/metasystem/test_chunkset_flush_race.cc
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Deterministic reproduction of a silent data-loss incident (2026-07-04,
+// fs_id=10004 ino=20007683286): a file overwrite committed slices in two
+// batches; the second batch was swallowed by the 1000ms commit throttle
+// (kChunkCommitIntervalMs, chunk.cc) while MDSMetaSystem::WriteSlice had
+// already returned OK (enqueue-only). FlushSlice's drain loop
+// (metasystem.cc, HasStage/HasCommitting/HasCommitTask emptiness check)
+// raced with the late Append of the tail batch, passed while empty, and
+// FlushFile committed length=2390200 although persisted slices only
+// covered [0, 2129920). Result: torn file, no error anywhere.
+//
+// These tests reproduce the mechanism at the ChunkSet layer with the real
+// incident slice geometry. No RPC/mock needed: TryCommitSlice() creating a
+// CommitTask is the exact precondition for a WriteSlice RPC (consumed by
+// batch_processor); "no CommitTask created" == "no RPC will ever be sent".
+
+#include <cstdint>
+#include <vector>
+
+#include "client/vfs/metasystem/mds/chunk.h"
+#include "client/vfs/vfs_meta.h"
+#include "gtest/gtest.h"
+#include "utils/time.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+namespace meta {
+
+namespace {
+
+constexpr Ino kIno = 20007683286;
+constexpr uint32_t kChunkIndex = 0;
+constexpr uint64_t kFileLength = 2390200;
+constexpr uint64_t kBatch1End = 2129920;  // = 0x208000, gen3 first batch end
+
+Slice MakeSlice(uint64_t id, uint64_t offset, uint64_t length) {
+  Slice slice;
+  slice.id = id;
+  slice.offset = offset;
+  slice.length = length;
+  slice.compaction = 0;
+  slice.is_zero = false;
+  slice.size = length;
+  return slice;
+}
+
+// gen3 first batch: slices 890..898 tiling [0, 2129920), real incident ranges
+std::vector<Slice> Batch1() {
+  return {
+      MakeSlice(10032863890, 0, 163840),
+      MakeSlice(10032863891, 163840, 131072),
+      MakeSlice(10032863892, 294912, 131072),
+      MakeSlice(10032863893, 425984, 98304),
+      MakeSlice(10032863894, 524288, 163840),
+      MakeSlice(10032863895, 688128, 131072),
+      MakeSlice(10032863896, 819200, 393216),
+      MakeSlice(10032863897, 1212416, 393216),
+      MakeSlice(10032863898, 1605632, 524288),
+  };
+}
+
+// gen3 second batch: slices 899/900 tiling [2129920, 2390200)
+std::vector<Slice> Batch2() {
+  return {
+      MakeSlice(10032863899, 2129920, 196608),
+      MakeSlice(10032863900, 2326528, 63672),
+  };
+}
+
+// Simulate a successful MDS WriteSlice response for the first batch
+// (equivalent to "writeslice finish, chunk(0,4)" on the MDS side).
+void AckFirstBatch(ChunkSet& chunk_set) {
+  auto tasks = chunk_set.ListCommitTask();
+  ASSERT_EQ(1, tasks.size());
+
+  ChunkEntry entry;
+  entry.set_index(kChunkIndex);
+  entry.set_version(4);
+  entry.set_just_descriptor(true);
+  chunk_set.FinishCommitTask(tasks[0]->TaskID(), {entry});
+
+  ASSERT_FALSE(chunk_set.HasStage());
+  ASSERT_FALSE(chunk_set.HasCommitting());
+  ASSERT_FALSE(chunk_set.HasCommitTask());
+}
+
+}  // namespace
+
+// Incident step 1: the second batch arriving inside the 1000ms commit
+// window is throttled — it stays in stage and NO CommitTask (hence no
+// WriteSlice RPC) is created, although WriteSlice() already returned OK to
+// the data layer at Append time.
+TEST(ChunkSetFlushRaceTest, SecondBatchThrottledInsideCommitWindow) {
+  ChunkSet chunk_set(kIno);
+
+  chunk_set.SetLastWriteLength(0, kBatch1End);
+  chunk_set.Append(kChunkIndex, Batch1());
+  ASSERT_EQ(9, chunk_set.TryCommitSlice(false));  // first commit: no throttle
+  uint64_t first_commit_ms = utils::TimestampMs();
+  AckFirstBatch(chunk_set);
+
+  // incident: +702ms, inside the 1000ms window; here: immediately after
+  chunk_set.SetLastWriteLength(kBatch1End, kFileLength - kBatch1End);
+  chunk_set.Append(kChunkIndex, Batch2());
+  uint32_t committed = chunk_set.TryCommitSlice(false);
+  ASSERT_LT(utils::TimestampMs() - first_commit_ms, 1000)
+      << "test ran too slow to stay inside the throttle window";
+
+  EXPECT_EQ(0, committed);                      // throttled: nothing commits
+  EXPECT_TRUE(chunk_set.HasStage());            // batch2 stranded in stage
+  EXPECT_FALSE(chunk_set.HasCommitTask());      // no task -> no RPC, ever
+  EXPECT_TRUE(chunk_set.HasUncommitedSlice());  // yet upper layer saw OK
+}
+
+// Incident step 2: FlushSlice's drain emptiness check runs BEFORE the tail
+// batch is appended (2ms race in the incident). The drain passes, FlushFile
+// commits full length, then the tail batch arrives and is throttled. Final
+// state violates the durability invariant: committed slice coverage ends at
+// 2129920 while the flushed length says 2390200 — the exact torn-file
+// condition, with no error surfaced anywhere.
+TEST(ChunkSetFlushRaceTest, FlushDrainRaceLeavesLengthSliceInconsistency) {
+  ChunkSet chunk_set(kIno);
+
+  // all 73 fuse writes already accounted: length memo is full size
+  chunk_set.SetLastWriteLength(0, kFileLength);
+
+  chunk_set.Append(kChunkIndex, Batch1());
+  ASSERT_EQ(9, chunk_set.TryCommitSlice(false));
+  uint64_t first_commit_ms = utils::TimestampMs();
+  AckFirstBatch(chunk_set);
+
+  // [T1] FlushSlice drain emptiness check (metasystem.cc FlushSlice loop):
+  // tail batch not yet appended -> loop breaks, FlushFile proceeds
+  bool drain_passes = !chunk_set.HasStage() && !chunk_set.HasCommitting() &&
+                      !chunk_set.HasCommitTask();
+  ASSERT_TRUE(drain_passes);
+  uint64_t flushed_length = chunk_set.GetLastWriteLength();  // -> FlushFile
+  EXPECT_EQ(kFileLength, flushed_length);
+
+  // [T2] tail batch appended just after the check (upload callback was late)
+  chunk_set.Append(kChunkIndex, Batch2());
+  uint32_t committed = chunk_set.TryCommitSlice(false);
+  ASSERT_LT(utils::TimestampMs() - first_commit_ms, 1000)
+      << "test ran too slow to stay inside the throttle window";
+  EXPECT_EQ(0, committed);  // throttled again: still no RPC
+
+  // [T3] torn invariant at the raw ChunkSet layer: flushed length exceeds
+  // committed slice coverage while the covering slices sit in stage with no
+  // commit task.  Production close/expiry paths must add the missing barrier
+  // and must not erase this uncommitted stage silently.
+  EXPECT_GT(flushed_length, kBatch1End);
+  EXPECT_TRUE(chunk_set.HasStage());
+  EXPECT_FALSE(chunk_set.HasCommitTask());
+}
+
+// Control: one forced commit at close would rescue the stranded batch —
+// demonstrates both that the loss needs the exact race (drain check before
+// append) and the fix direction (flush path must force-commit after the
+// last append, or WriteSlice OK must be tied to task completion).
+TEST(ChunkSetFlushRaceTest, ForceCommitRescuesStagedSlices) {
+  ChunkSet chunk_set(kIno);
+
+  chunk_set.SetLastWriteLength(0, kFileLength);
+  chunk_set.Append(kChunkIndex, Batch1());
+  ASSERT_EQ(9, chunk_set.TryCommitSlice(false));
+  AckFirstBatch(chunk_set);
+
+  chunk_set.Append(kChunkIndex, Batch2());
+  ASSERT_EQ(0, chunk_set.TryCommitSlice(false));  // throttled
+
+  EXPECT_EQ(2, chunk_set.TryCommitSlice(true));  // force bypasses throttle
+  EXPECT_FALSE(chunk_set.HasStage());
+  EXPECT_TRUE(chunk_set.HasCommitTask());  // RPC would now be sent
+}
+
+// Problem 2 (out-of-order overwrite family), client-side invariant: an ACK
+// carrying a version <= commited_version_ makes MarkCommited() clear the
+// committing slices WITHOUT moving them to commited (chunk.cc MarkCommited).
+// Combined with FinishCommitTask deleting the task, the batch evaporates:
+// no stage, no committing, no task, not in GetAllSlice — yet every call
+// returned success. This is how a duplicated/stale/epoch-switched MDS reply
+// silently drops a committed-in-flight batch.
+TEST(ChunkSetFlushRaceTest, StaleVersionAckSilentlyDropsCommittingSlices) {
+  ChunkSet chunk_set(kIno);
+
+  // establish commited_version_ = 4 via a normal batch
+  chunk_set.Append(kChunkIndex, Batch1());
+  ASSERT_EQ(9, chunk_set.TryCommitSlice(true));
+  AckFirstBatch(chunk_set);  // version 4
+
+  // next batch goes committing (task created, RPC in flight)
+  chunk_set.Append(kChunkIndex, Batch2());
+  ASSERT_EQ(2, chunk_set.TryCommitSlice(true));
+  auto tasks = chunk_set.ListCommitTask();
+  ASSERT_EQ(1, tasks.size());
+
+  // MDS reply arrives with a NON-advancing version (duplicate/stale reply,
+  // or another instance already at version 4): MarkCommited(4 <= 4)
+  ChunkEntry stale;
+  stale.set_index(kChunkIndex);
+  stale.set_version(4);  // == commited_version_, does not advance
+  stale.set_just_descriptor(true);
+  chunk_set.FinishCommitTask(tasks[0]->TaskID(), {stale});
+
+  // the batch is gone from every queue, and nothing will ever resend it
+  EXPECT_FALSE(chunk_set.HasStage());
+  EXPECT_FALSE(chunk_set.HasCommitting());
+  EXPECT_FALSE(chunk_set.HasCommitTask());
+  EXPECT_FALSE(chunk_set.HasUncommitedSlice());
+
+  // and it is not visible as commited data either: Batch2 slices vanished
+  auto chunk = chunk_set.Get(kChunkIndex);
+  ASSERT_NE(nullptr, chunk);
+  uint64_t version = 0;
+  auto slices = chunk->GetAllSlice(version);
+  bool has_tail = false;
+  for (const auto& slice : slices) {
+    if (slice.id == 10032863899 || slice.id == 10032863900) has_tail = true;
+  }
+  EXPECT_FALSE(has_tail);  // silently dropped, all calls returned success
+}
+
+}  // namespace meta
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/vfs/metasystem/test_trunc_chunkset_split.cc
+++ b/test/unit/client/vfs/metasystem/test_trunc_chunkset_split.cc
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage for the O_TRUNC ChunkSet split behind the torn-write
+// incidents (xn01 2026-07-04, local repro w4r181 2026-07-08).
+//
+// The broken sequence was:
+//   1. Open(): file_session_map_.Put() bound session->chunk_set to A.
+//   2. DoOpen(O_TRUNC): chunk_cache_.Delete(ino) erased A from cache.
+//   3. WriteSlice(): chunk_cache_.GetOrCreate(ino) created B and appended
+//      slices there.
+//   4. Flush(): inspected session->chunk_set A and missed B.
+//
+// The fix is to rebind the file session to the fresh cache ChunkSet after a
+// successful O_TRUNC, so WriteSlice and Flush use the same object again.
+
+#include <fcntl.h>
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "client/vfs/metasystem/mds/chunk.h"
+#include "client/vfs/metasystem/mds/file_session.h"
+#include "client/vfs/metasystem/mds/inode_cache.h"
+#include "client/vfs/vfs_meta.h"
+#include "gtest/gtest.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+namespace meta {
+
+namespace {
+
+constexpr uint32_t kFsId = 10008;
+constexpr Ino kIno = 20000000024;  // w4r181 incident inode
+constexpr uint32_t kChunkIndex = 0;
+constexpr uint64_t kOldHeadEnd = 2063968;
+
+Slice MakeSlice(uint64_t id, uint64_t offset, uint64_t length) {
+  Slice slice;
+  slice.id = id;
+  slice.offset = offset;
+  slice.length = length;
+  slice.compaction = 0;
+  slice.is_zero = false;
+  slice.size = length;
+  return slice;
+}
+
+std::vector<Slice> OldTail() {
+  return {MakeSlice(10140578651, kOldHeadEnd, 260280)};
+}
+
+std::vector<Slice> OldHead() {
+  return {MakeSlice(10140578646, 0, kOldHeadEnd)};
+}
+
+void AckTask(ChunkSet& chunk_set, uint64_t version) {
+  auto tasks = chunk_set.ListCommitTask();
+  ASSERT_EQ(1, tasks.size());
+  ChunkEntry entry;
+  entry.set_index(kChunkIndex);
+  entry.set_version(version);
+  entry.set_just_descriptor(true);
+  chunk_set.FinishCommitTask(tasks[0]->TaskID(), {entry});
+}
+
+ChunkSetSPtr SimulateSuccessfulTruncOpen(FileSessionSPtr session,
+                                         ChunkCache& chunk_cache, Ino ino) {
+  chunk_cache.Delete(ino);
+  auto fresh = chunk_cache.GetOrCreate(ino);
+  session->SetChunkSet(fresh);
+  return fresh;
+}
+
+}  // namespace
+
+TEST(TruncChunkSetSplitTest, TruncOpenRebindsSessionToFreshCacheChunkSet) {
+  InodeCache inode_cache(kFsId);
+  ChunkCache chunk_cache;
+  FileSessionMap session_map(inode_cache, chunk_cache);
+
+  auto session = session_map.Put(kIno, 4296, "sess-4296", O_WRONLY | O_TRUNC);
+  auto old_chunk_set = session->GetChunkSet();
+
+  auto fresh_chunk_set =
+      SimulateSuccessfulTruncOpen(session, chunk_cache, kIno);
+  ASSERT_NE(old_chunk_set.get(), fresh_chunk_set.get());
+  ASSERT_EQ(fresh_chunk_set.get(), session->GetChunkSet().get());
+  ASSERT_EQ(fresh_chunk_set.get(), chunk_cache.GetOrCreate(kIno).get());
+
+  fresh_chunk_set->Append(kChunkIndex, OldTail());
+
+  auto flush_target = session->GetChunkSet();
+  EXPECT_EQ(fresh_chunk_set.get(), flush_target.get());
+  EXPECT_TRUE(flush_target->HasStage());
+  EXPECT_EQ(1, flush_target->TryCommitSlice(true));
+  EXPECT_TRUE(flush_target->HasCommitTask());
+}
+
+TEST(TruncChunkSetSplitTest, ExpiredCacheKeepsUncommittedTail) {
+  ChunkCache chunk_cache;
+  auto chunk_set = chunk_cache.GetOrCreate(kIno);
+  chunk_set->Append(kChunkIndex, OldTail());
+
+  ASSERT_TRUE(chunk_cache.HasUncommitedSlice());
+  chunk_cache.CleanExpired(std::numeric_limits<uint64_t>::max());
+
+  EXPECT_EQ(chunk_set.get(), chunk_cache.Get(kIno).get());
+  EXPECT_TRUE(chunk_cache.HasUncommitedSlice());
+}
+
+TEST(TruncChunkSetSplitTest, NextTruncOpenDoesNotInheritPreviousTail) {
+  InodeCache inode_cache(kFsId);
+  ChunkCache chunk_cache;
+  FileSessionMap session_map(inode_cache, chunk_cache);
+
+  auto session1 = session_map.Put(kIno, 4296, "sess-4296", O_WRONLY | O_TRUNC);
+  auto chunk_set_b = SimulateSuccessfulTruncOpen(session1, chunk_cache, kIno);
+
+  chunk_set_b->Append(kChunkIndex, OldHead());
+  ASSERT_EQ(1, chunk_set_b->TryCommitSlice(true));
+  AckTask(*chunk_set_b, 359);
+
+  chunk_set_b->Append(kChunkIndex, OldTail());
+  auto flush_target = session1->GetChunkSet();
+  ASSERT_EQ(chunk_set_b.get(), flush_target.get());
+  ASSERT_TRUE(flush_target->HasStage());
+  ASSERT_EQ(1, flush_target->TryCommitSlice(true));
+
+  auto tasks = flush_target->ListCommitTask();
+  ASSERT_EQ(1, tasks.size());
+  const auto& delta_slices = tasks[0]->DeltaSlices();
+  ASSERT_EQ(1, delta_slices.size());
+  EXPECT_EQ(359, delta_slices[0].version);
+  ASSERT_EQ(1, delta_slices[0].slices.size());
+  EXPECT_EQ(10140578651, delta_slices[0].slices[0].id);
+
+  AckTask(*chunk_set_b, 360);
+  session_map.Delete(kIno, 4296);
+
+  auto session2 = session_map.Put(kIno, 4320, "sess-4320", O_WRONLY | O_TRUNC);
+  auto chunk_set_c = SimulateSuccessfulTruncOpen(session2, chunk_cache, kIno);
+
+  EXPECT_NE(chunk_set_b.get(), chunk_set_c.get());
+  EXPECT_EQ(chunk_set_c.get(), session2->GetChunkSet().get());
+  EXPECT_FALSE(session2->GetChunkSet()->HasStage());
+  EXPECT_FALSE(session2->GetChunkSet()->HasCommitTask());
+}
+
+TEST(TruncChunkSetSplitTest, NoTruncNoSplitFlushSeesTail) {
+  InodeCache inode_cache(kFsId);
+  ChunkCache chunk_cache;
+  FileSessionMap session_map(inode_cache, chunk_cache);
+
+  auto session = session_map.Put(kIno, 4296, "sess-4296", O_WRONLY);
+  auto chunk_set = chunk_cache.GetOrCreate(kIno);
+  EXPECT_EQ(session->GetChunkSet().get(), chunk_set.get());
+
+  chunk_set->Append(kChunkIndex, OldTail());
+
+  auto flush_target = session->GetChunkSet();
+  EXPECT_TRUE(flush_target->HasStage());
+  EXPECT_EQ(1, flush_target->TryCommitSlice(true));
+  EXPECT_TRUE(flush_target->HasCommitTask());
+}
+
+TEST(TruncChunkSetSplitTest, UnlinkKeepsCacheWhenFileSessionIsActive) {
+  InodeCache inode_cache(kFsId);
+  ChunkCache chunk_cache;
+  FileSessionMap session_map(inode_cache, chunk_cache);
+
+  auto session = session_map.Put(kIno, 4296, "sess-4296", O_WRONLY);
+  auto live_chunk_set = chunk_cache.GetOrCreate(kIno);
+  ASSERT_EQ(live_chunk_set.get(), session->GetChunkSet().get());
+
+  // Fixed unlink(nlink==0) behavior with an active open fd: do not delete the
+  // cache entry.  An open-unlinked file must keep using the same ChunkSet;
+  // deleting here would make later WriteSlice create B while flush still sees
+  // A.
+  ASSERT_NE(nullptr, session_map.GetSession(kIno));
+
+  auto write_target = chunk_cache.GetOrCreate(kIno);
+  EXPECT_EQ(live_chunk_set.get(), write_target.get());
+  EXPECT_EQ(session->GetChunkSet().get(), write_target.get());
+
+  write_target->Append(kChunkIndex, OldTail());
+
+  auto flush_target = session->GetChunkSet();
+  EXPECT_TRUE(flush_target->HasStage());
+  EXPECT_EQ(1, flush_target->TryCommitSlice(true));
+  EXPECT_TRUE(flush_target->HasCommitTask());
+}
+
+// Fix-path regression: replay the FIXED DoOpen sequence
+// (Delete -> GetOrCreate -> SetChunkSet).  Session and cache converge on the
+// same object again, the WriteSlice target IS the flush target, and the
+// drain sees the pending tail -- the split is gone.  This is the assertion
+// that must stay green after the fix (and would have been red before it).
+TEST(TruncChunkSetSplitTest, FixedTruncOpenRebindUnifiesSessionAndCache) {
+  InodeCache inode_cache(kFsId);
+  ChunkCache chunk_cache;
+  FileSessionMap session_map(inode_cache, chunk_cache);
+
+  auto session = session_map.Put(kIno, 4296, "sess-4296", O_WRONLY | O_TRUNC);
+
+  // fixed DoOpen(O_TRUNC) sequence
+  chunk_cache.Delete(kIno);
+  auto rebound = chunk_cache.GetOrCreate(kIno);
+  session->SetChunkSet(rebound);
+
+  // WriteSlice path and flush path now resolve to the same object
+  auto write_target = chunk_cache.GetOrCreate(kIno);
+  EXPECT_EQ(session->GetChunkSet().get(), write_target.get());
+
+  write_target->Append(kChunkIndex, OldTail());
+
+  auto flush_target = session->GetChunkSet();
+  EXPECT_TRUE(flush_target->HasStage());             // drain sees the tail
+  EXPECT_EQ(1, flush_target->TryCommitSlice(true));  // and commits it
+  EXPECT_TRUE(flush_target->HasCommitTask());
+}
+
+}  // namespace meta
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs


### PR DESCRIPTION
# WIP: fix silent torn-write caused by ChunkSet split on O_TRUNC open

## Problem

Overwriting a file with `open(O_TRUNC)` can silently lose the tail write batch, producing a torn file (new head + stale middle + zero tail) with **no error reported anywhere** (client returns OK, MDS logs clean). Reproduced deterministically with a concurrent overwrite workload (4 md5-verified hits, all producing the same torn artifact).

## Root cause

In `MDSMetaSystem::Open()` with `O_TRUNC`, the session and the chunk cache end up bound to **different `ChunkSet` objects**:

1. `file_session_map_.Put()` binds the session to `chunk_cache_.GetOrCreate(ino)` → object **A**
2. `DoOpen()` (truncate path) then calls `chunk_cache_.Delete(ino)` → A is orphaned from the cache
3. Subsequent `WriteSlice()` calls `chunk_cache_.GetOrCreate(ino)` → creates fresh object **B**, slices staged on B
4. `Flush()/Close()` drains the **session's** ChunkSet A → sees nothing to commit, tail slices on B never reach the MDS

This is a deterministic object split, not a timing race. Two damage modes:
- tail batch is never sent (file ends short / zero tail)
- the orphaned old-generation tail is committed **late** with a higher chunk version, overwriting newer data (MDS `UpsertChunk` has no `curr_version` fencing)

## Fix (client side)

- `metasystem.cc` `DoOpen(O_TRUNC)`: after successful truncate, rebind — `chunk_memo_.Forget` + `chunk_cache_.Delete` + `GetOrCreate` + `file_session->SetChunkSet(fresh)`, so WriteSlice and Flush converge on the same object again
- `file_session.h/.cc`: `chunk_set_` now mutex-guarded; add `SetChunkSet()`, `GetChunkSet()` returns by value
- `metasystem.cc` `Close()`: flush barrier for write fds — `FlushSliceAndFile` before deleting the session, so no commit task can be launched after close
- `chunk.cc` `CleanExpired()`: skip (keep) ChunkSets that still hold uncommitted slices instead of expiring them
- `metasystem.cc` `Unlink()`: only delete the chunk cache entry when there is no active file session (open-unlink POSIX semantics)

## Tests

10 new unit tests, all green:
- `test_trunc_chunkset_split.cc` (6 cases): reproduces the split with the real incident geometry, verifies the rebind unifies session/cache, expired-cache keeps uncommitted tail, next trunc-open does not inherit the previous tail, unlink keeps cache while a session is active
- `test_chunkset_flush_race.cc` (4 cases): commit/flush ordering around the 1000 ms commit throttle

## Remaining work (why WIP)

- [ ] e2e validation run of the fixed client (blocked on local storage recovery)
- [ ] MDS-side hardening as follow-up PRs: `UpsertChunk` curr_version CAS fencing; `FlushFile` length vs slice-coverage validation
- [ ] `CleanExpired` terminal disposition for permanently-dirty ChunkSets; metrics
