### PR TITLE
[feat][client] Hot-upgrade: log peer pids on both handover sides.

### DIFF
--- a/src/client/fuse/upgrade/handover_client.cc
+++ b/src/client/fuse/upgrade/handover_client.cc
@@ -84,8 +84,8 @@ bool HandoverClient::Handshake(int comm_fd, int old_pid) {
   // (or a stale connection) never triggers a drain. Send before the signal so
   // the message is already buffered when the old process reads it.
   if (!SendHandoverMessage(comm_fd, HandoverMessage::kPrepare)) {
-    LOG(ERROR) << "hot-upgrade: send kPrepare to old failed, error: "
-               << std::strerror(errno);
+    LOG(ERROR) << "hot-upgrade: send kPrepare to old failed, old_pid: "
+               << old_pid << ", error: " << std::strerror(errno);
     return false;
   }
 
@@ -97,23 +97,26 @@ bool HandoverClient::Handshake(int comm_fd, int old_pid) {
 
   HandoverMessage msg;
   if (!RecvHandoverMessage(comm_fd, &msg)) {
-    LOG(ERROR) << "hot-upgrade: wait old handover message failed, error: "
-               << std::strerror(errno);
+    LOG(ERROR) << "hot-upgrade: wait old handover message failed, old_pid: "
+               << old_pid << ", error: " << std::strerror(errno);
     return false;
   }
 
   if (msg == HandoverMessage::kNack) {
-    LOG(ERROR) << "hot-upgrade: old process rejected handover and resumed";
+    LOG(ERROR) << "hot-upgrade: old process rejected handover and resumed, "
+                  "old_pid: "
+               << old_pid;
     return false;
   }
 
   if (msg != HandoverMessage::kReadyToExit) {
     LOG(ERROR) << "hot-upgrade: unexpected old handover message: "
-               << static_cast<uint32_t>(msg);
+               << static_cast<uint32_t>(msg) << ", old_pid: " << old_pid;
     return false;
   }
 
-  LOG(INFO) << "hot-upgrade: old process is ready to exit";
+  LOG(INFO) << "hot-upgrade: old process is ready to exit, old_pid: "
+            << old_pid;
   return true;
 }
 
@@ -124,16 +127,18 @@ int HandoverClient::TakeOver(const std::string& mountpoint,
 
   int pid = FindOldPid(stats_file);
   if (pid <= 0) {
-    LOG(ERROR) << "get pid fail, filepath=" << stats_file;
+    LOG(ERROR) << "hot-upgrade: find old process pid failed, filepath="
+               << stats_file;
     return -1;
   }
 
-  LOG(INFO) << "get pid success, pid=" << pid;
+  LOG(INFO) << "hot-upgrade: found old process, old_pid: " << pid;
   UpgradeStateStore::GetInstance().SetOldFusePid(pid);
 
   const std::string comm_path = GetFdCommFileName(stats_file);
   CHECK(!comm_path.empty());
-  LOG(INFO) << "get socket success, comm_path=" << comm_path;
+  LOG(INFO) << "hot-upgrade: old process handover socket, comm_path="
+            << comm_path;
 
   int comm_fd = -1;
   auto close_comm = MakeScopedCleanup([&]() {
@@ -142,15 +147,17 @@ int HandoverClient::TakeOver(const std::string& mountpoint,
 
   int fuse_fd = ReceiveFuseFd(comm_path, init_msg, &comm_fd);
   if (fuse_fd <= 2) {
-    LOG(ERROR) << "recv mount fd fail, comm_path=" << comm_path;
+    LOG(ERROR) << "hot-upgrade: recv mount fd from old failed, old_pid: " << pid
+               << ", comm_path=" << comm_path;
     return -1;
   }
   // The received /dev/fuse fd holds a reference to the kernel mount; close it
   // on any failure below, and hand it to the caller (cancel) only on success.
   auto close_fuse_fd = MakeScopedCleanup([&]() { close(fuse_fd); });
 
-  LOG(INFO) << "recv data from " << comm_path << ", mount fd = " << fuse_fd
-            << ", data size = " << init_msg->size;
+  LOG(INFO) << "hot-upgrade: received fuse fd from old process, old_pid: "
+            << pid << ", mount fd: " << fuse_fd
+            << ", data size: " << init_msg->size;
 
   if (!Handshake(comm_fd, pid)) return -1;
 

--- a/src/client/fuse/upgrade/handover_controller.cc
+++ b/src/client/fuse/upgrade/handover_controller.cc
@@ -63,8 +63,7 @@ class StatfsWakeupLoop {
   void Start(const std::string& mountpoint, uint32_t interval_ms,
              HandoverOptions::StatfsWakeupFn wakeup_fn) {
     if (!wakeup_fn) {
-      wakeup_fn = [](const std::string& mountpoint,
-                     const std::atomic<bool>&) {
+      wakeup_fn = [](const std::string& mountpoint, const std::atomic<bool>&) {
         struct statfs buf;
         (void)statfs(mountpoint.c_str(), &buf);
       };
@@ -72,15 +71,16 @@ class StatfsWakeupLoop {
 
     stop_ = std::make_shared<std::atomic<bool>>(false);
     auto stop = stop_;
-    thread_ = std::thread([stop, mountpoint, interval_ms,
-                           wakeup_fn = std::move(wakeup_fn)]() {
-      while (!stop->load()) {
-        // Drive a FUSE round-trip to pop a worker blocked in read() back to the
-        // recv_paused check. pause_receive() does not wake a blocked reader.
-        wakeup_fn(mountpoint, *stop);
-        std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
-      }
-    });
+    thread_ = std::thread(
+        [stop, mountpoint, interval_ms, wakeup_fn = std::move(wakeup_fn)]() {
+          while (!stop->load()) {
+            // Drive a FUSE round-trip to pop a worker blocked in read() back to
+            // the recv_paused check. pause_receive() does not wake a blocked
+            // reader.
+            wakeup_fn(mountpoint, *stop);
+            std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
+          }
+        });
   }
 
   void StopAndDetach() {
@@ -186,7 +186,8 @@ void HandoverController::Run() {
     // it on failure.
     UpgradeStateStore::GetInstance().UpdateFuseState(
         FuseUpgradeState::kFuseUpgradeOld);
-    LOG(INFO) << "hot-upgrade: handover requested, begin controlled drain";
+    LOG(INFO) << "hot-upgrade: handover requested by new process, new_pid: "
+              << peer_->PeerPid() << ", begin controlled drain";
 
     Status s = DrainSessionForHandover();
     if (!s.ok()) {
@@ -222,19 +223,19 @@ Status HandoverController::DrainSessionForHandover() {
   if (rc != 0) {
     // Leave the session paused; the caller's AbortHandover() does the single
     // ResumeReceive() (and state rollback). The statfs wakeup thread may itself
-    // be blocked in a FUSE statfs request queued behind the paused session. Never
-    // join it here: on timeout that can deadlock the controller before it sends
-    // kNack/resumes receive. Stop it and detach; after ResumeReceive() serves the
-    // pending statfs, the thread observes stop_ and exits.
+    // be blocked in a FUSE statfs request queued behind the paused session.
+    // Never join it here: on timeout that can deadlock the controller before it
+    // sends kNack/resumes receive. Stop it and detach; after ResumeReceive()
+    // serves the pending statfs, the thread observes stop_ and exits.
     wakeup.StopAndDetach();
     return Status::Internal(
         fmt::format("wait_drained failed rc={} (0=ok, -1=timeout)", rc));
   }
 
   // Drained: the wakeup thread may be blocked in a statfs the paused session
-  // will no longer serve. Detach it; it holds no FuseServer references and exits
-  // once the new process serves the pending statfs, or with this process on
-  // commit.
+  // will no longer serve. Detach it; it holds no FuseServer references and
+  // exits once the new process serves the pending statfs, or with this process
+  // on commit.
   wakeup.StopAndDetach();
   return Status::OK();
 }
@@ -253,12 +254,13 @@ Status HandoverController::RunCheckpoint() {
 }
 
 void HandoverController::AbortHandover(const Status& status) {
+  const pid_t new_pid = peer_->PeerPid();  // cleared by NotifyHandoverAbort
   peer_->NotifyHandoverAbort();
   session_->ResumeReceive();
   UpgradeStateStore::GetInstance().UpdateFuseState(
       FuseUpgradeState::kFuseNormal);
   LOG(ERROR) << "hot-upgrade: abort handover, old process keeps serving, "
-             << "status: " << status.ToString();
+             << "new_pid: " << new_pid << ", status: " << status.ToString();
 }
 
 void HandoverController::CommitHandover() {
@@ -272,11 +274,15 @@ void HandoverController::CommitHandover() {
   // recover. Do NOT loop-retry NotifyReadyToExit(): it would re-send
   // kReadyToExit, which the new reads only once. A stronger handover needs the
   // checkpoint to dump-without-teardown and wait for a post-load ACK.
+  const pid_t new_pid = peer_->PeerPid();  // cleared by NotifyReadyToExit
   if (!peer_->NotifyReadyToExit()) {
     LOG(ERROR) << "hot-upgrade: failed to notify new after teardown; exiting "
-                  "anyway, mount may be orphaned until remount";
+                  "anyway, mount may be orphaned until remount, new_pid: "
+               << new_pid;
   } else {
-    LOG(INFO) << "hot-upgrade: new notified ready, exit session for handover";
+    LOG(INFO) << "hot-upgrade: new notified ready, exit session for handover, "
+                 "new_pid: "
+              << new_pid;
   }
 
   session_->Exit();

--- a/src/client/fuse/upgrade/handover_peer.h
+++ b/src/client/fuse/upgrade/handover_peer.h
@@ -17,6 +17,8 @@
 #ifndef DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_PEER_H_
 #define DINGOFS_SRC_CLIENT_FUSE_UPGRADE_HANDOVER_PEER_H_
 
+#include <sys/types.h>
+
 namespace dingofs {
 namespace client {
 namespace fuse {
@@ -28,6 +30,9 @@ class HandoverPeer {
   virtual bool WaitHandoverPrepare() = 0;
   virtual bool NotifyReadyToExit() = 0;
   virtual void NotifyHandoverAbort() = 0;
+
+  // Pid of the connected new process, -1 when unknown. Logging only.
+  virtual pid_t PeerPid() { return -1; }
 };
 
 }  // namespace fuse

--- a/src/client/fuse/upgrade/handover_server.cc
+++ b/src/client/fuse/upgrade/handover_server.cc
@@ -131,7 +131,7 @@ void HandoverServer::Stop() {
   running_.store(false);
 }
 
-void HandoverServer::SetClientFd(int fd) {
+void HandoverServer::SetClientFd(int fd, pid_t pid) {
   // Stores the handover connection, closing any previous one. AcceptLoop
   // rejects a concurrent connector while a LIVE handover is in flight (see
   // IsHandoverInFlight), so any previous fd reached here is only ever a STALE
@@ -142,6 +142,12 @@ void HandoverServer::SetClientFd(int fd) {
     close(client_fd_);
   }
   client_fd_ = fd;
+  client_pid_ = pid;
+}
+
+pid_t HandoverServer::PeerPid() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return client_pid_;
 }
 
 bool HandoverServer::IsHandoverInFlight() {
@@ -180,13 +186,16 @@ void HandoverServer::CloseClientFd() {
     close(client_fd_);
     client_fd_ = -1;
   }
+  client_pid_ = -1;
 }
 
 bool HandoverServer::WaitHandoverPrepare() {
   int fd = -1;
+  pid_t new_pid = -1;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     fd = client_fd_;
+    new_pid = client_pid_;
   }
   if (fd < 0) {
     LOG(ERROR) << "hot-upgrade: SIGHUP with no handover connection; ignoring";
@@ -220,14 +229,17 @@ bool HandoverServer::WaitHandoverPrepare() {
 
   if (poll_ret <= 0) {
     LOG(ERROR) << "hot-upgrade: no kPrepare from peer (silent/timeout); "
-                  "ignoring SIGHUP, keep serving";
+                  "ignoring SIGHUP, keep serving, new_pid: "
+               << new_pid;
     CloseClientFd();
     return false;
   }
 
   HandoverMessage msg;
   if (!RecvHandoverMessage(fd, &msg) || msg != HandoverMessage::kPrepare) {
-    LOG(ERROR) << "hot-upgrade: invalid handover prepare; ignoring SIGHUP";
+    LOG(ERROR) << "hot-upgrade: invalid handover prepare; ignoring SIGHUP, "
+                  "new_pid: "
+               << new_pid;
     CloseClientFd();
     return false;
   }
@@ -243,9 +255,11 @@ bool HandoverServer::NotifyReadyToExit() {
   committed_.store(true);
 
   int fd = -1;
+  pid_t new_pid = -1;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     fd = client_fd_;
+    new_pid = client_pid_;
   }
 
   if (fd < 0) {
@@ -257,23 +271,33 @@ bool HandoverServer::NotifyReadyToExit() {
   }
 
   if (!SendHandoverMessage(fd, HandoverMessage::kReadyToExit)) {
-    LOG(ERROR) << "hot-upgrade: send READY_TO_EXIT failed, error: "
-               << std::strerror(errno);
+    LOG(ERROR) << "hot-upgrade: send READY_TO_EXIT failed, new_pid: " << new_pid
+               << ", error: " << std::strerror(errno);
     return false;
   }
 
+  LOG(INFO) << "hot-upgrade: READY_TO_EXIT sent to new process, new_pid: "
+            << new_pid;
   CloseClientFd();
   return true;
 }
 
 void HandoverServer::NotifyHandoverAbort() {
   int fd = -1;
+  pid_t new_pid = -1;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     fd = client_fd_;
+    new_pid = client_pid_;
   }
   if (fd >= 0) {
-    (void)SendHandoverMessage(fd, HandoverMessage::kNack);
+    if (SendHandoverMessage(fd, HandoverMessage::kNack)) {
+      LOG(INFO) << "hot-upgrade: kNack sent to new process, new_pid: "
+                << new_pid;
+    } else {
+      LOG(ERROR) << "hot-upgrade: send kNack to new process failed, new_pid: "
+                 << new_pid << ", error: " << std::strerror(errno);
+    }
     CloseClientFd();
   }
 }
@@ -313,13 +337,27 @@ void HandoverServer::AcceptLoop() {
       continue;
     }
 
+    // Identify the connecting new process for logging; -1 when unavailable.
+    pid_t new_pid = -1;
+    {
+      struct ucred cred;
+      socklen_t cred_len = sizeof(cred);
+      if (getsockopt(client_fd, SOL_SOCKET, SO_PEERCRED, &cred, &cred_len) ==
+          0) {
+        new_pid = cred.pid;
+      }
+    }
+    LOG(INFO) << "hot-upgrade: handover connection from new process, new_pid: "
+              << new_pid;
+
     // Once committed, the /dev/fuse fd has been (or is being) handed off
     // exactly once and this process is exiting; reject any further connector
     // regardless of client_fd_ state, so a late new never receives a duplicate
     // fd.
     if (committed_.load()) {
       LOG(WARNING) << "hot-upgrade: handover already committed; rejecting late "
-                      "connection";
+                      "connection, new_pid: "
+                   << new_pid;
       close(client_fd);
       continue;
     }
@@ -331,7 +369,9 @@ void HandoverServer::AcceptLoop() {
     // Reject BEFORE SendFd so the second new never receives the /dev/fuse fd.
     if (IsHandoverInFlight()) {
       LOG(WARNING) << "hot-upgrade: a handover is already in flight; rejecting "
-                      "concurrent upgrade connection (one upgrade per mount)";
+                      "concurrent upgrade connection (one upgrade per mount), "
+                      "new_pid: "
+                   << new_pid;
       close(client_fd);
       continue;
     }
@@ -341,7 +381,8 @@ void HandoverServer::AcceptLoop() {
     // called after SaveOpInitMsg() fills it, so this is belt-and-suspenders.
     if (init_msg_->size == 0) {
       LOG(WARNING) << "hot-upgrade: INIT message not ready yet; rejecting "
-                      "handover connection";
+                      "handover connection, new_pid: "
+                   << new_pid;
       close(client_fd);
       continue;
     }
@@ -350,15 +391,17 @@ void HandoverServer::AcceptLoop() {
     // it can race a kPrepare + SIGHUP straight back, and the controller's
     // WaitHandoverPrepare() must already see client_fd_; otherwise it reads -1
     // and spuriously rejects the handover. On send failure, clear it.
-    SetClientFd(client_fd);
+    SetClientFd(client_fd, new_pid);
     int fuse_fd = get_dev_fd_();
     int ret = SendFd(client_fd, fuse_fd, init_msg_->mem, init_msg_->size);
     if (ret == -1) {
-      LOG(ERROR) << "send fuse fd failed, client_id: " << client_fd;
+      LOG(ERROR) << "hot-upgrade: send fuse fd to new process failed, new_pid: "
+                 << new_pid << ", client_fd: " << client_fd;
       CloseClientFd();
     } else {
-      LOG(INFO) << "fuse fd send to client: " << client_fd
-                << ", fd: " << fuse_fd << ", data size: " << init_msg_->size;
+      LOG(INFO) << "hot-upgrade: fuse fd sent to new process, new_pid: "
+                << new_pid << ", fuse_fd: " << fuse_fd
+                << ", data size: " << init_msg_->size;
     }
   }
 }

--- a/src/client/fuse/upgrade/handover_server.h
+++ b/src/client/fuse/upgrade/handover_server.h
@@ -62,11 +62,12 @@ class HandoverServer : public HandoverPeer {
   bool WaitHandoverPrepare() override;
   bool NotifyReadyToExit() override;
   void NotifyHandoverAbort() override;
+  pid_t PeerPid() override;
 
  private:
   void AcceptLoop();
   bool IsHandoverInFlight();
-  void SetClientFd(int fd);
+  void SetClientFd(int fd, pid_t pid);
   void CloseClientFd();
 
   std::string socket_path_;
@@ -86,6 +87,7 @@ class HandoverServer : public HandoverPeer {
 
   std::mutex mutex_;
   int client_fd_{-1};
+  pid_t client_pid_{-1};  // pid of the connected new process (SO_PEERCRED)
 };
 
 }  // namespace fuse


### PR DESCRIPTION
## Problem

During a hot-upgrade incident triage the two sides of a handover cannot be paired from logs. The old process never learns who the connecting new process is: its only identifying line is `fuse fd send to client: 88`, where 88 is the accepted socket fd — easily misread as a pid. The new side logs the old pid once at startup (`get pid success, pid=`) but none of the handshake error paths carry it, and the line lacks the `hot-upgrade:` prefix, so reconstructing "old X ↔ new Y" requires timestamp forensics across log directories.

## Change

- **Old side (HandoverServer)**: resolve the connecting peer's pid via `SO_PEERCRED` at accept time and keep it alongside `client_fd_` (cleared together). Every log on the old side now carries `new_pid`: connection accepted, the three rejection paths (committed / in-flight / INIT not ready), kPrepare timeout/invalid, fd send success/failure, READY_TO_EXIT, kNack. The misleading `fuse fd send to client: <socket fd>` becomes `fuse fd sent to new process, new_pid: X, fuse_fd: Y`.
- **HandoverPeer** gains `PeerPid()` (default -1, mock-compatible) so the controller logs `new_pid` at drain start, abort, and commit — captured before the notify call that tears down the connection.
- **New side (HandoverClient)**: unified `hot-upgrade:` prefix; found-old / socket / recv-fd lines and all handshake paths (kPrepare send failure, wait failure, kNack, unexpected message, ready-to-exit) carry `old_pid`.
- `NotifyHandoverAbort` no longer discards the send result: logs `kNack sent` only on success, otherwise an error with errno.

## Validation

- `test_fuse_upgrade` 16/16 (Debug).
- 3 consecutive live hot-upgrade rounds under fsync'd write + read-back md5 load: all handovers clean (~5s each, drain→READY_TO_EXIT ~50ms), zero data errors, zero WARN/ERROR lines.
- Each side now yields the full pairing from a single `grep -a hot-upgrade`:

```
old : handover connection from new process, new_pid: 1450566
old : fuse fd sent to new process, new_pid: 1450566, fuse_fd: 5
old : handover requested by new process, new_pid: 1450566, begin controlled drain
old : READY_TO_EXIT sent to new process, new_pid: 1450566
new : found old process, old_pid: 1448409
new : received fuse fd from old process, old_pid: 1448409, mount fd: 5
new : old process is ready to exit, old_pid: 1448409
```