### PR TITLE
[fix][client] Bound umount-time compaction: close stop admission and optimize skip

### DIFF
--- a/src/client/vfs/compaction/compact_utils.cc
+++ b/src/client/vfs/compaction/compact_utils.cc
@@ -21,15 +21,24 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
+#include <vector>
 
 #include "client/vfs/common/helper.h"
-#include "client/vfs/data/common/data_utils.h"
 #include "client/vfs/vfs_meta.h"
 
 namespace dingofs {
 namespace client {
 namespace vfs {
 namespace compaction {
+
+namespace {
+
+bool IsEquivalentHole(const Slice& lhs, const Slice& rhs) {
+  return lhs.id == 0 && rhs.id == 0 && lhs.pos == rhs.pos && lhs.len == rhs.len;
+}
+
+}  // namespace
 
 FileRange GetSlicesFileRange(int64_t chunk_start,
                              absl::Span<const Slice> slices) {
@@ -47,63 +56,76 @@ FileRange GetSlicesFileRange(int64_t chunk_start,
 
   CHECK_GT(max_end, min_offset);
 
-  return FileRange{.offset = min_offset,
-                   .len = (max_end - min_offset)};
-}
-
-int64_t SliceReadReqsLength(const std::vector<SliceReadReq>& reqs) {
-  int64_t total_len = 0;
-  for (const auto& req : reqs) {
-    total_len += req.len;
-  }
-  return total_len;
+  return FileRange{.offset = min_offset, .len = (max_end - min_offset)};
 }
 
 int32_t Skip(int64_t chunk_start, const std::vector<Slice>& slices) {
+  const int32_t total = static_cast<int32_t>(slices.size());
+  if (total == 0) return 0;
+
+  // Convert2SliceReadReq() partitions the complete suffix file range into
+  // covered and uncovered requests, so the sum of its result lengths is
+  // always exactly (suffix_max_end - suffix_min_offset). Precompute those
+  // suffix bounds once instead of rebuilding the full read plan for every
+  // candidate slice.
+  std::vector<int64_t> suffix_min_offset(total + 1,
+                                         std::numeric_limits<int64_t>::max());
+  std::vector<int64_t> suffix_max_end(total + 1,
+                                      std::numeric_limits<int64_t>::min());
+  for (int32_t i = total - 1; i >= 0; --i) {
+    const int64_t offset = chunk_start + slices[i].pos;
+    suffix_min_offset[i] = std::min(offset, suffix_min_offset[i + 1]);
+    suffix_max_end[i] = std::max(offset + slices[i].len, suffix_max_end[i + 1]);
+  }
+
   int32_t skipped = 0;
-  int32_t total = slices.size();
-
-  absl::Span<const Slice> span_slices(slices);
-
   while (skipped < total) {
-    absl::Span<const Slice> ss = span_slices.subspan(skipped);
-    const Slice& first = ss[0];
+    const Slice& first = slices[skipped];
+    const int64_t first_offset = chunk_start + first.pos;
+    const int64_t first_end = first_offset + first.len;
+    const int64_t readreqs_len =
+        suffix_max_end[skipped] - suffix_min_offset[skipped];
+    CHECK_GT(readreqs_len, 0) << "invalid slice range length for compact";
 
-    FileRange range = GetSlicesFileRange(chunk_start, ss);
-    auto slice_readreqs = Convert2SliceReadReq(ss, range, chunk_start);
-    CHECK(!slice_readreqs.empty())
-        << "invalid slice readreqs for compact, slices count: " << ss.size();
-
-    int64_t readreqs_len = SliceReadReqsLength(slice_readreqs);
-    CHECK_GT(readreqs_len, 0) << "invalid slice readreqs length for compact";
-
-    if (first.len < (1 << 20) || first.len * 5 < readreqs_len) {
-      VLOG(9) << "Can't skip first slice too small, first_slice: "
-              << Slice2Str(first) << ", readreqs_len: " << readreqs_len
-              << ", skip: " << skipped;
+    if (first.len < (1 << 20) ||
+        static_cast<int64_t>(first.len) * 5 < readreqs_len) {
+      VLOG(12) << "Can't skip first slice too small, first_slice: "
+               << Slice2Str(first) << ", readreqs_len: " << readreqs_len
+               << ", skip: " << skipped;
       break;
     }
 
-    const auto& first_req = slice_readreqs[0];
-    int64_t first_file_offset = chunk_start + first.pos;
-
-    bool is_first =
-        (first_req.file_offset == first_file_offset) &&
-        (first_req.slice->id == first.id) && (first_req.len == first.len);
+    // Convert2SliceReadReq() applies slices from newest to oldest. The first
+    // slice of this suffix survives as the first complete read request iff it
+    // starts at the suffix's minimum offset and no newer slice overlaps it.
+    bool is_first = first_offset == suffix_min_offset[skipped];
+    for (int32_t i = skipped + 1; is_first && i < total; ++i) {
+      const int64_t newer_offset = chunk_start + slices[i].pos;
+      const int64_t newer_end = newer_offset + slices[i].len;
+      const bool overlaps =
+          std::max(first_offset, newer_offset) < std::min(first_end, newer_end);
+      // Zero slices are append-only hole markers and may legitimately be
+      // duplicated by repeated PUNCH_HOLE/ZERO_RANGE operations. An identical
+      // newer hole has the same visible value over the complete candidate
+      // range, so it must not force the sparse range through data compaction.
+      if (overlaps && !IsEquivalentHole(first, slices[i])) {
+        is_first = false;
+      }
+    }
 
     if (!is_first) {
-      VLOG(9) << "Can't skip not same as first, first_slice: "
-              << Slice2Str(first) << ", first_req: " << first_req.ToString()
-              << ", skip: " << skipped;
+      VLOG(12) << "Can't skip overwritten or non-leading first slice: "
+               << Slice2Str(first) << ", skip: " << skipped;
       break;
     }
 
     skipped++;
-    VLOG(9) << "Skip slice for compact, slice: " << Slice2Str(first)
-            << ", first_req: " << first_req.ToString()
-            << ", readreqs_len: " << readreqs_len << ", skip: " << skipped;
+    VLOG(12) << "Skip slice for compact, slice: " << Slice2Str(first)
+             << ", readreqs_len: " << readreqs_len << ", skip: " << skipped;
   }
 
+  VLOG(9) << "Compact skip summary, slices: " << slices.size()
+          << ", skipped: " << skipped;
   return skipped;
 }
 

--- a/src/client/vfs/compaction/compact_utils.h
+++ b/src/client/vfs/compaction/compact_utils.h
@@ -21,6 +21,7 @@
 #include <glog/logging.h>
 
 #include <cstdint>
+#include <vector>
 
 #include "client/vfs/data/common/common.h"
 #include "client/vfs/vfs_meta.h"
@@ -32,8 +33,6 @@ namespace compaction {
 
 FileRange GetSlicesFileRange(int64_t chunk_start,
                              absl::Span<const Slice> slices);
-
-int64_t SliceReadReqsLength(const std::vector<SliceReadReq>& reqs);
 
 int32_t Skip(int64_t chunk_start, const std::vector<Slice>& slices);
 

--- a/src/client/vfs/compaction/compactor_impl.cc
+++ b/src/client/vfs/compaction/compactor_impl.cc
@@ -45,12 +45,15 @@ Status CompactorImpl::Stop() {
     return Status::OK();
   }
 
+  // Close admission before draining. Otherwise queued compaction tasks can
+  // keep incrementing inflight_ while Stop() is waiting and make shutdown
+  // depend on the entire pending queue being exhausted.
+  stopped_ = true;
+
   while (inflight_ > 0) {
     LOG(INFO) << "CompactorImpl::Stop wait inflight_=" << inflight_;
     cv_.wait(lg);
   }
-
-  stopped_ = true;
 
   LOG(INFO) << "CompactorImpl stopped";
   return Status::OK();

--- a/src/client/vfs/data/common/data_utils.cc
+++ b/src/client/vfs/data/common/data_utils.cc
@@ -51,12 +51,12 @@ std::vector<SliceReadReq> Convert2SliceReadReq(absl::Span<const Slice> slices,
   // loop from newest slice to oldest slice
   for (auto it = slices.rbegin(); it != slices.rend(); ++it) {
     const auto& slice = *it;
-    VLOG(9) << "Convert2SliceReadReq: slice: " << Slice2Str(slice);
+    VLOG(12) << "Convert2SliceReadReq: slice: " << Slice2Str(slice);
 
     std::vector<FileRange> new_unmatched_ranges;
 
     for (const auto& file_range : unmatched_ranges) {
-      VLOG(9) << "Convert2SliceReadReq: file_range: " << file_range.ToString();
+      VLOG(12) << "Convert2SliceReadReq: file_range: " << file_range.ToString();
 
       // check if the current range overlaps with the slice
       int64_t slice_file_offset = chunk_start + slice.pos;
@@ -64,7 +64,7 @@ std::vector<SliceReadReq> Convert2SliceReadReq(absl::Span<const Slice> slices,
       if (slice_file_end <= file_range.offset ||
           slice_file_offset >= file_range.End()) {
         new_unmatched_ranges.push_back(file_range);
-        VLOG(9)
+        VLOG(12)
             << "Convert2SliceReadReq: file_range_req no overlap with slice_id: "
             << slice.id;
         continue;
@@ -81,8 +81,8 @@ std::vector<SliceReadReq> Convert2SliceReadReq(absl::Span<const Slice> slices,
           .slice = slice,
       };
 
-      VLOG(9) << "Convert2SliceReadReq: slice_read_req: "
-              << slice_read_req.ToString();
+      VLOG(12) << "Convert2SliceReadReq: slice_read_req: "
+               << slice_read_req.ToString();
 
       results.push_back(slice_read_req);
 
@@ -92,8 +92,8 @@ std::vector<SliceReadReq> Convert2SliceReadReq(absl::Span<const Slice> slices,
             .offset = file_range.offset,
             .len = (overlap_start - file_range.offset),
         };
-        VLOG(9) << "Convert2SliceReadReq: left_uncovered_file_range: "
-                << left_uncovered_file_range.ToString();
+        VLOG(12) << "Convert2SliceReadReq: left_uncovered_file_range: "
+                 << left_uncovered_file_range.ToString();
         new_unmatched_ranges.push_back(left_uncovered_file_range);
       }
 
@@ -103,8 +103,8 @@ std::vector<SliceReadReq> Convert2SliceReadReq(absl::Span<const Slice> slices,
             .offset = overlap_end,
             .len = (file_range.End() - overlap_end),
         };
-        VLOG(9) << "Convert2SliceReadReq: right_uncovered_file_range: "
-                << right_uncovered_file_range.ToString();
+        VLOG(12) << "Convert2SliceReadReq: right_uncovered_file_range: "
+                 << right_uncovered_file_range.ToString();
 
         new_unmatched_ranges.push_back(right_uncovered_file_range);
       }
@@ -114,7 +114,7 @@ std::vector<SliceReadReq> Convert2SliceReadReq(absl::Span<const Slice> slices,
     unmatched_ranges = std::move(new_unmatched_ranges);
 
     if (unmatched_ranges.empty()) {
-      VLOG(9) << "Convert2SliceReadReq: unmatched_ranges is empty, break";
+      VLOG(12) << "Convert2SliceReadReq: unmatched_ranges is empty, break";
       break;
     }
   }
@@ -127,8 +127,8 @@ std::vector<SliceReadReq> Convert2SliceReadReq(absl::Span<const Slice> slices,
         range.len,
         std::nullopt,
     };
-    VLOG(9) << "Convert2SliceReadReq: uncovered_slice_read_req: "
-            << uncovered_slice_read_req.ToString();
+    VLOG(12) << "Convert2SliceReadReq: uncovered_slice_read_req: "
+             << uncovered_slice_read_req.ToString();
     results.push_back(uncovered_slice_read_req);
   }
 

--- a/src/client/vfs/metasystem/mds/compact.cc
+++ b/src/client/vfs/metasystem/mds/compact.cc
@@ -64,6 +64,17 @@ Status CompactChunkTask::Compact() {
   status = compactor_.Compact(ctx, ino_, chunk_index, old_slices, new_slices);
   if (!status.ok()) return status;
   if (IsDeleted()) return Status::OK();
+  if (new_slices.empty()) {
+    // All slices were skipped, so there is no valid non-empty replacement for
+    // MDS CompactChunk (the server requires new_slices to be non-empty). Leave
+    // the chunk unchanged instead of sending an invalid request. A chunk made
+    // entirely of skippable slices (for example, repeated equivalent id=0
+    // holes) therefore remains compaction-eligible and may be reconsidered
+    // after the compaction interval. This is intentionally deferred: fixing it
+    // requires either version-scoped NotFit suppression in Chunk or an MDS
+    // metadata-only compaction that preserves sparse holes without SliceWriter.
+    return Status::NotFit("all slices skipped");
+  }
 
   MDSClient::CompactChunkParam param;
   param.version = version;

--- a/src/client/vfs/metasystem/mds/compact.h
+++ b/src/client/vfs/metasystem/mds/compact.h
@@ -22,7 +22,6 @@
 #include "client/vfs/metasystem/mds/executor.h"
 #include "client/vfs/metasystem/mds/inode_cache.h"
 #include "client/vfs/metasystem/mds/mds_client.h"
-#include "client/vfs/vfs_meta.h"
 #include "mds/common/runnable.h"
 
 namespace dingofs {

--- a/test/unit/client/vfs/compaction/test_compact_utils.cc
+++ b/test/unit/client/vfs/compaction/test_compact_utils.cc
@@ -51,14 +51,6 @@ TEST_F(CompactUtilsTest, GetCompactFileRange) {
   EXPECT_EQ(range.len, 250);  // 300 - 50 = 250
 }
 
-TEST_F(CompactUtilsTest, SliceReadReqsLength) {
-  std::vector<SliceReadReq> reqs;
-  reqs.push_back({0, 100, std::nullopt});
-  reqs.push_back({100, 200, std::nullopt});
-
-  EXPECT_EQ(SliceReadReqsLength(reqs), 300);
-}
-
 TEST_F(CompactUtilsTest, SkipEmpty) {
   std::vector<Slice> slices;
   EXPECT_EQ(Skip(0, slices), 0);
@@ -149,6 +141,84 @@ TEST_F(CompactUtilsTest, SkipPartiallyOverwritten) {
   slices.push_back(CreateSlice(2, 4 * 1024 * 1024, 2 * 1024 * 1024));
 
   EXPECT_EQ(Skip(0, slices), 0);
+}
+
+TEST_F(CompactUtilsTest, SkipAdjacentSlicesAreNotOverlapping) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      CreateSlice(1, 0, 2 * kMiB),
+      CreateSlice(2, 2 * kMiB, 2 * kMiB),
+      CreateSlice(3, 4 * kMiB, 2 * kMiB),
+  };
+
+  EXPECT_EQ(Skip(0, slices), 3);
+}
+
+TEST_F(CompactUtilsTest, SkipStopsWhenNewerSliceStartsBeforeCandidate) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      CreateSlice(1, 2 * kMiB, 2 * kMiB),
+      CreateSlice(2, 0, 2 * kMiB),
+  };
+
+  // The first slice is complete but is not the first request after sorting by
+  // file offset, matching the old Convert2SliceReadReq-based behavior.
+  EXPECT_EQ(Skip(0, slices), 0);
+}
+
+TEST_F(CompactUtilsTest, SkipUsesFullSuffixRangeIncludingHoles) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      CreateSlice(1, 0, 2 * kMiB),
+      CreateSlice(2, 20 * kMiB, 2 * kMiB),
+  };
+
+  // Convert2SliceReadReq represented the 18 MiB hole as an uncovered request,
+  // so the old total read-request length was the full 22 MiB suffix range.
+  EXPECT_EQ(Skip(0, slices), 0);
+}
+
+TEST_F(CompactUtilsTest, SkipEquivalentDuplicateHoles) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      CreateSlice(0, 0, 2 * kMiB),
+      CreateSlice(0, 0, 2 * kMiB),
+  };
+
+  // Repeated PUNCH_HOLE/ZERO_RANGE operations may append identical id=0
+  // slices. They are logically equivalent and must remain sparse rather than
+  // being sent through data compaction as a buffer of physical zeroes.
+  EXPECT_EQ(Skip(0, slices), 2);
+}
+
+TEST_F(CompactUtilsTest, SkipStopsForPartiallyOverlappingHoles) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      CreateSlice(0, 0, 4 * kMiB),
+      CreateSlice(0, 2 * kMiB, 4 * kMiB),
+  };
+
+  EXPECT_EQ(Skip(0, slices), 0);
+}
+
+TEST_F(CompactUtilsTest, SkipStopsWhenDataOverwritesHole) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      CreateSlice(0, 0, 2 * kMiB),
+      CreateSlice(8, 0, 2 * kMiB),
+  };
+
+  EXPECT_EQ(Skip(0, slices), 0);
+}
+
+TEST_F(CompactUtilsTest, SkipWorksWithNonZeroChunkStart) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      CreateSlice(1, 0, 2 * kMiB),
+      CreateSlice(2, 2 * kMiB, 2 * kMiB),
+  };
+
+  EXPECT_EQ(Skip(64LL * kMiB, slices), 2);
 }
 
 }  // namespace compaction

--- a/test/unit/client/vfs/compaction/test_compactor.cc
+++ b/test/unit/client/vfs/compaction/test_compactor.cc
@@ -26,9 +26,13 @@
 #include <vector>
 
 #include "client/vfs/compaction/compactor_impl.h"
+#include "client/vfs/metasystem/mds/compact.h"
+#include "client/vfs/metasystem/mds/mds_client.h"
 #include "client/vfs/vfs_meta.h"
 #include "common/status.h"
 #include "common/trace/trace_manager.h"
+#include "mds/filesystem/fs_info.h"
+#include "test/unit/client/vfs/mock/mock_compactor.h"
 #include "test/unit/client/vfs/test_base.h"
 #include "test/unit/client/vfs/test_common.h"
 
@@ -115,6 +119,59 @@ TEST_F(CompactorTest, Compact_SingleLargeZeroSlice_SkippedBySkipLogic) {
   EXPECT_TRUE(s.ok());
   // All slices skipped: out_slices is empty (nothing to compact).
   EXPECT_TRUE(out.empty());
+}
+
+TEST_F(CompactorTest, Compact_DuplicateLargeHoles_RemainSparse) {
+  constexpr int32_t kHoleSize = 2 * 1024 * 1024;
+  std::vector<Slice> slices = {
+      MakeZeroSlice(0, kHoleSize),
+      MakeZeroSlice(0, kHoleSize),
+  };
+  std::vector<Slice> out;
+
+  EXPECT_CALL(*mock_block_store_, RangeAsync).Times(0);
+  EXPECT_CALL(*mock_block_store_, PutAsync).Times(0);
+
+  Status s = compactor_->Compact(ctx_, 100, 0, slices, out);
+
+  EXPECT_TRUE(s.ok()) << s.ToString();
+  EXPECT_TRUE(out.empty());
+}
+
+TEST(CompactChunkTaskTest, EmptyCompactionResultDoesNotCallMDS) {
+  constexpr Ino kIno = 100;
+  constexpr uint32_t kChunkIndex = 0;
+  constexpr int32_t kHoleSize = 2 * 1024 * 1024;
+
+  mds::ChunkEntry chunk_entry;
+  chunk_entry.set_index(kChunkIndex);
+  chunk_entry.set_version(1);
+  for (int i = 0; i < 99; ++i) {
+    auto* slice = chunk_entry.add_slices();
+    slice->set_id(0);
+    slice->set_pos(0);
+    slice->set_len(kHoleSize);
+  }
+  auto chunk = meta::Chunk::New(kIno, chunk_entry, "test");
+  meta::InodeSPtr inode;
+
+  mds::FsInfoEntry fs_info_entry;
+  mds::FsInfo fs_info(fs_info_entry);
+  meta::RPC rpc{butil::EndPoint()};
+  TraceManager trace_manager;
+  meta::MDSClient mds_client(ClientId(), fs_info, std::move(rpc),
+                             trace_manager);
+
+  test::MockCompactor compactor;
+  EXPECT_CALL(compactor, Compact(_, kIno, kChunkIndex, _, _))
+      .WillOnce([](ContextSPtr, Ino, int64_t, const std::vector<Slice>&,
+                   std::vector<Slice>&) { return Status::OK(); });
+
+  auto task =
+      meta::CompactChunkTask::New(kIno, inode, chunk, mds_client, compactor);
+  task->Run();
+
+  EXPECT_TRUE(task->GetStatus().IsNotFit()) << task->GetStatus().ToString();
 }
 
 // 6. Compact_AfterStop returns a Stop error.
@@ -214,7 +271,69 @@ TEST_F(CompactorTest, Stop_WaitsForInflight) {
   compact_thread.join();
 }
 
-// 10. Repeatedly drive compaction through the shared-owned SliceWriter path.
+// 10. Stop closes admission before waiting for existing work to drain.
+TEST_F(CompactorTest, Stop_RejectsNewWorkWhileDraining) {
+  std::mutex m;
+  std::condition_variable cv;
+  bool compact_started = false;
+  bool release_range = false;
+
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault([&](ContextSPtr, RangeReq req, StatusCallback cb) {
+        {
+          std::unique_lock<std::mutex> lk(m);
+          compact_started = true;
+          cv.notify_all();
+          cv.wait(lk, [&] { return release_range; });
+        }
+        if (req.dst.base != nullptr && req.length > 0) {
+          std::memset(req.dst.data(), 0, req.length);
+        }
+        cb(Status::OK());
+      });
+  EXPECT_CALL(*mock_block_store_, RangeAsync).Times(AnyNumber());
+  EXPECT_CALL(*mock_block_store_, PutAsync).Times(AnyNumber());
+
+  std::vector<Slice> inflight_slices = {
+      dingofs::client::vfs::test::MakeSlice(3, 0, 4 * 1024 * 1024)};
+  std::vector<Slice> inflight_out;
+  std::thread compact_thread([&]() {
+    compactor_->ForceCompact(ctx_, 201, 0, inflight_slices, inflight_out);
+  });
+
+  {
+    std::unique_lock<std::mutex> lk(m);
+    cv.wait(lk, [&] { return compact_started; });
+  }
+
+  std::thread stop_thread([&]() { compactor_->Stop(); });
+
+  // A large zero slice is skipped without I/O when admitted, so retrying is
+  // cheap and avoids relying on scheduling sleeps to observe Stop's state.
+  std::vector<Slice> new_slices = {MakeZeroSlice(0, 2 * 1024 * 1024)};
+  Status new_status;
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  do {
+    std::vector<Slice> out;
+    new_status = compactor_->Compact(ctx_, 202, 0, new_slices, out);
+    std::this_thread::yield();
+  } while (new_status.ok() && std::chrono::steady_clock::now() < deadline);
+  const bool rejected_while_draining = new_status.IsStop();
+
+  {
+    std::lock_guard<std::mutex> lk(m);
+    release_range = true;
+  }
+  cv.notify_all();
+
+  compact_thread.join();
+  stop_thread.join();
+
+  EXPECT_TRUE(rejected_while_draining) << new_status.ToString();
+}
+
+// 11. Repeatedly drive compaction through the shared-owned SliceWriter path.
 // This guards its async FlushAsync lifetime and end-to-end commit result.
 TEST_F(CompactorTest, RegressionHeapAllocSliceWriter_RepeatedDoCompact_Stable) {
   for (int i = 0; i < 20; ++i) {


### PR DESCRIPTION
## Problem

umount hung for 95 minutes on a fragmented workload (chunks with 10k+ slices). Root causes found from thread dumps and client logs:

1. `CompactorImpl::Stop()` set `stopped_` only after draining, so tasks already queued in the compact worker set (up to 8096) kept passing `IncInflight()` while Stop was waiting — Stop had to outlive the entire backlog instead of just the in-flight tasks.
2. `compaction::Skip()` rebuilt the full read plan via `Convert2SliceReadReq()` for every candidate slice (O(N^2) work and O(N^2~N^3) VLOG lines on fragmented chunks), freezing all compact workers on the glog/glibc-tz lock when verbose logging was enabled.

## Changes

**[feat][client] Optimize compaction skip without building read plan.**
- `Skip()` now precomputes suffix min-offset / max-end bounds (exactly equal to the old read-plan length by the partition property of `Convert2SliceReadReq`) and decides skippability with a direct overlap check, removing the per-candidate read-plan rebuild.
- Duplicate identical id=0 hole slices (produced by repeated truncate/PUNCH_HOLE — MDS `AppendZeroSlices` appends without coalescing) are treated as read-equivalent so sparse ranges are not forced through data compaction.
- Per-slice / per-range logs in `Convert2SliceReadReq()` demoted VLOG(9) → VLOG(12); `Skip()` emits a single per-call summary at VLOG(9).
- Removed now-unused `SliceReadReqsLength()`.

**[fix][client] Close compact admission on stop and reject empty compaction result.**
- `Stop()` sets `stopped_` before draining, so queued tasks are rejected immediately and Stop only waits for the tasks actually in flight.
- `CompactChunkTask::Compact()` returns `NotFit` when the compactor skipped everything, instead of sending a `CompactChunk` RPC with empty `new_slices` (which the MDS would reject by CHECK).

## Tests

- `CompactUtilsTest`: 7 new cases covering suffix-range semantics (holes counted), ordering, partial/full hole overlap, data-over-hole, non-zero chunk_start.
- `CompactorTest`: `Stop_RejectsNewWorkWhileDraining` (admission closes while draining), `Compact_DuplicateLargeHoles_RemainSparse` (zero I/O for duplicate holes), empty-result-does-not-call-MDS.
- Full client unit suite: 383 passed / 1 skipped (pre-existing skip).
- Local-mode deploy + e2e smoke: 32/32 passed (incl. punch-hole / truncate-readahead regressions).