### PR TITLE
[feat][client] Support segmented block upload payload.

### DIFF
--- a/src/cache/common/storage_client.cc
+++ b/src/cache/common/storage_client.cc
@@ -57,6 +57,18 @@ static int64_t GetQueueSize(void* meta) {
   return queue->Size();
 }
 
+static blockaccess::PutPayload ToPutPayload(const IOBuffer& buffer) {
+  // butil::IOBuf does not expose zero-length backing blocks, so every fetched
+  // iovec satisfies PutPayload's non-empty segment invariant.
+  auto iovs = buffer.Fetch();
+  std::vector<blockaccess::PayloadSegment> segments;
+  segments.reserve(iovs.size());
+  for (const auto& iov : iovs) {
+    segments.push_back({static_cast<const char*>(iov.iov_base), iov.iov_len});
+  }
+  return blockaccess::PutPayload::Build(std::move(segments));
+}
+
 PutBlockTask::PutBlockTask(BlockHandle handle, const IOBuffer& block,
                            blockaccess::BlockAccesser* block_accesser,
                            iutil::TaskExecutionQueueSPtr retry_queue)
@@ -74,11 +86,9 @@ void PutBlockTask::Run() {
 }
 
 blockaccess::PutObjectAsyncContextSPtr PutBlockTask::OnPrepare() {
-  auto ctx =
-      std::make_shared<blockaccess::PutObjectAsyncContext>(handle_.StoreKey());
+  auto ctx = std::make_shared<blockaccess::PutObjectAsyncContext>(
+      handle_.StoreKey(), ToPutPayload(block_));
   ctx->start_time = butil::gettimeofday_us();
-  ctx->buffer = block_.Fetch1();
-  ctx->buffer_size = block_.Size();
   ctx->retry = 0;
   ctx->cb = [this](const blockaccess::PutObjectAsyncContextSPtr& ctx) {
     OnCallback(ctx);

--- a/src/cache/tier/tier_block_cache.cc
+++ b/src/cache/tier/tier_block_cache.cc
@@ -207,8 +207,7 @@ Status TierBlockCache::Put(BlockHandle handle, IOBuffer block,
         });
   }
 
-  IOBuffer contiguous = CopyBlock(block);
-  status = storage_client_->Put(handle, contiguous);
+  status = storage_client_->Put(handle, block);
   if (!status.ok()) {
     LOG(ERROR) << "Fail to put block to storage, key=" << handle.Filename()
                << ", status=" << status.ToString();
@@ -428,15 +427,6 @@ CacheTier TierBlockCache::ResolveTier(const BlockHandle& handle,
     return CacheTier::kLocal;
   }
   return hint;
-}
-
-IOBuffer TierBlockCache::CopyBlock(const IOBuffer& block) {
-  IOBuffer buffer;
-  size_t size = block.Size();
-  char* data = new char[size];
-  block.CopyTo(data);
-  buffer.AppendUserData(data, size, iutil::DeleteBuffer);
-  return buffer;
 }
 
 }  // namespace cache

--- a/src/cache/tier/tier_block_cache.h
+++ b/src/cache/tier/tier_block_cache.h
@@ -89,10 +89,6 @@ class TierBlockCache final : public BlockCache {
   bool EnableRemoteStage() const { return remote_block_cache_->EnableStage(); }
   bool EnableRemoteCache() const { return remote_block_cache_->EnableCache(); }
 
-  // Linearize a possibly multi-block IOBuf into a single contiguous backing
-  // block, required by S3 upload (storage_client → IOBuffer::Fetch1()).
-  IOBuffer CopyBlock(const IOBuffer& block);
-
   // Returns the effective tier for an operation. If the caller already pinned
   // a tier (kLocal or kRemote) it is honored as-is. Otherwise, small blocks
   // are automatically pinned to local when FLAGS_small_block_size_kb > 0

--- a/src/common/blockaccess/accesser.h
+++ b/src/common/blockaccess/accesser.h
@@ -43,8 +43,7 @@ class Accesser {
 
   virtual bool ContainerExist() = 0;
 
-  virtual Status Put(const std::string& key, const char* buffer,
-                     size_t length) = 0;
+  virtual Status Put(const std::string& key, const PutPayload& payload) = 0;
 
   virtual void AsyncPut(const std::string& key,
                         std::shared_ptr<PutObjectAsyncContext> context) = 0;

--- a/src/common/blockaccess/accesser_common.h
+++ b/src/common/blockaccess/accesser_common.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "common/blockaccess/files/file_common.h"
+#include "common/blockaccess/put_payload.h"
 #include "common/blockaccess/rados/rados_common.h"
 #include "common/blockaccess/s3/s3_common.h"
 #include "common/options/blockaccess.h"
@@ -108,13 +109,13 @@ struct PutObjectAsyncContext {
   // accumulate on every retry. The `key` parameter on AsyncPut/AsyncGet is
   // what backends MUST use; this field exists for caller-side correlation
   // and logging only.
-  explicit PutObjectAsyncContext(std::string k) : origin_key(std::move(k)) {}
+  PutObjectAsyncContext(std::string k, PutPayload p)
+      : origin_key(std::move(k)), payload(std::move(p)) {}
 
   uint64_t start_time{0};
 
   const std::string origin_key;
-  const char* buffer{nullptr};
-  size_t buffer_size{0};
+  const PutPayload payload;
 
   Status status;
 

--- a/src/common/blockaccess/bench/block_access_bench.cc
+++ b/src/common/blockaccess/bench/block_access_bench.cc
@@ -308,10 +308,11 @@ Status BlockAccessBench::PrefillDataForGet() {
   threads.reserve(num_threads);
   for (uint32_t t = 0; t < num_threads; ++t) {
     threads.emplace_back([this, t, num_ops_per_thread, &completed]() {
+      const auto& buffer = test_data_pool_[t % options_.threads];
+      auto payload = PutPayload::Build({{buffer.data(), options_.block_size}});
       for (uint32_t i = 0; i < num_ops_per_thread; ++i) {
         auto key = keys_[(t * num_ops_per_thread) + i];
-        const auto& buffer = test_data_pool_[t % options_.threads];
-        auto s = accesser_->Put(key, buffer.data(), options_.block_size);
+        auto s = accesser_->Put(key, payload);
         if (!s.ok()) {
           LOG(ERROR) << "Failed to prefill key " << key << ": " << s.ToString();
           return;
@@ -367,28 +368,30 @@ void BlockAccessBench::RunPutBench() {
 
   threads.reserve(num_threads);
   for (uint32_t t = 0; t < num_threads; ++t) {
-    threads.emplace_back([this, t, num_ops_per_thread, &thread_histograms,
-                          &progress]() {
-      // Set CPU affinity if enabled
-      if (options_.bind_to_cpu) {
-        SetThreadAffinity(t);
-      }
-      auto& histogram = thread_histograms[t];
-      // Use thread-local buffer to avoid false sharing
-      const auto& thread_buffer = test_data_pool_[t];
-      for (uint32_t i = 0; i < num_ops_per_thread; ++i) {
-        auto key = keys_[(t * num_ops_per_thread) + i];
-        auto op_start = Timer::now();
-        auto s = accesser_->Put(key, thread_buffer.data(), options_.block_size);
-        auto op_end = Timer::now();
-        double latency_us =
-            std::chrono::duration_cast<std::chrono::microseconds>(op_end -
-                                                                  op_start)
-                .count();
-        histogram.addLatency(static_cast<uint64_t>(latency_us));
-        progress.Increment();
-      }
-    });
+    threads.emplace_back(
+        [this, t, num_ops_per_thread, &thread_histograms, &progress]() {
+          // Set CPU affinity if enabled
+          if (options_.bind_to_cpu) {
+            SetThreadAffinity(t);
+          }
+          auto& histogram = thread_histograms[t];
+          // Use thread-local buffer to avoid false sharing
+          const auto& thread_buffer = test_data_pool_[t];
+          auto payload =
+              PutPayload::Build({{thread_buffer.data(), options_.block_size}});
+          for (uint32_t i = 0; i < num_ops_per_thread; ++i) {
+            auto key = keys_[(t * num_ops_per_thread) + i];
+            auto op_start = Timer::now();
+            auto s = accesser_->Put(key, payload);
+            auto op_end = Timer::now();
+            double latency_us =
+                std::chrono::duration_cast<std::chrono::microseconds>(op_end -
+                                                                      op_start)
+                    .count();
+            histogram.addLatency(static_cast<uint64_t>(latency_us));
+            progress.Increment();
+          }
+        });
   }
 
   for (auto& t : threads) {
@@ -426,10 +429,9 @@ void BlockAccessBench::RunPutBench() {
 }
 
 void BlockAccessBench::RunAsyncPutBench() {
-  std::vector<LatencyHistogram> thread_histograms(options_.threads);
   uint32_t num_threads = options_.threads;
-  uint32_t num_ops_per_thread = options_.num_ops_per_thread;
   uint32_t total_ops = options_.num_ops;
+  std::vector<uint64_t> latencies(total_ops);
 
   FastSemaphore semaphore(num_threads);
   pending_ops_ = total_ops;
@@ -441,32 +443,32 @@ void BlockAccessBench::RunAsyncPutBench() {
   for (uint32_t i = 0; i < total_ops; ++i) {
     semaphore.acquire();
 
-    uint32_t thread_id = i / num_ops_per_thread;
+    uint32_t thread_id = i % num_threads;
     auto key = keys_[i];
 
     // Use thread-local buffer to avoid false sharing
     const auto& thread_buffer = test_data_pool_[thread_id];
 
-    auto context = std::make_shared<PutObjectAsyncContext>(key);
-    context->buffer = thread_buffer.data();
-    context->buffer_size = options_.block_size;
+    auto context = std::make_shared<PutObjectAsyncContext>(
+        key, PutPayload::Build(
+                 {PayloadSegment{thread_buffer.data(), options_.block_size}}));
     context->start_time = std::chrono::duration_cast<std::chrono::microseconds>(
                               Timer::now().time_since_epoch())
                               .count();
 
-    context->cb = [this, thread_id, &thread_histograms, &semaphore, &progress](
+    context->cb = [this, i, &latencies, &semaphore, &progress](
                       const std::shared_ptr<PutObjectAsyncContext>& ctx) {
       auto end = std::chrono::duration_cast<std::chrono::microseconds>(
                      Timer::now().time_since_epoch())
                      .count();
-      thread_histograms[thread_id].addLatency(
-          static_cast<uint64_t>(end - ctx->start_time));
-      pending_ops_--;
+      latencies[i] = static_cast<uint64_t>(end - ctx->start_time);
       semaphore.release();
       progress.Increment();
-      if (pending_ops_ == 0) {
-        cv_.notify_one();
+      {
+        std::lock_guard<std::mutex> lock(mtx_);
+        pending_ops_--;
       }
+      cv_.notify_one();
     };
 
     accesser_->AsyncPut(key, context);
@@ -481,8 +483,8 @@ void BlockAccessBench::RunAsyncPutBench() {
           .count();
 
   LatencyHistogram combined_histogram;
-  for (auto& histo : thread_histograms) {
-    combined_histogram += histo;
+  for (uint64_t latency : latencies) {
+    combined_histogram.addLatency(latency);
   }
 
   double avg_latency = combined_histogram.getAverageMicroSec() / 1000.0;
@@ -585,10 +587,9 @@ void BlockAccessBench::RunGetBench() {
 }
 
 void BlockAccessBench::RunAsyncGetBench() {
-  std::vector<LatencyHistogram> thread_histograms(options_.threads);
   uint32_t num_threads = options_.threads;
-  uint32_t num_ops_per_thread = options_.num_ops_per_thread;
   uint32_t total_ops = options_.num_ops;
+  std::vector<uint64_t> latencies(total_ops);
 
   FastSemaphore semaphore(num_threads);
   pending_ops_ = total_ops;
@@ -597,6 +598,12 @@ void BlockAccessBench::RunAsyncGetBench() {
   for (auto& buf : read_buffers) {
     buf = new char[options_.block_size];
   }
+  std::vector<uint32_t> available_slots;
+  available_slots.reserve(num_threads);
+  for (uint32_t i = 0; i < num_threads; ++i) {
+    available_slots.push_back(i);
+  }
+  std::mutex slot_mutex;
 
   ProgressTracker progress(total_ops, "ASYNC_GET", options_.block_size);
 
@@ -605,31 +612,42 @@ void BlockAccessBench::RunAsyncGetBench() {
   for (uint32_t i = 0; i < total_ops; ++i) {
     semaphore.acquire();
 
-    uint32_t thread_id = i / num_ops_per_thread;
+    uint32_t slot;
+    {
+      std::lock_guard<std::mutex> lock(slot_mutex);
+      CHECK(!available_slots.empty());
+      slot = available_slots.back();
+      available_slots.pop_back();
+    }
     auto key = keys_[i];
 
     auto context = std::make_shared<GetObjectAsyncContext>(key);
     context->offset = 0;
     context->len = options_.block_size;
-    context->buf = read_buffers[thread_id];
+    context->buf = read_buffers[slot];
     context->start_time = std::chrono::duration_cast<std::chrono::microseconds>(
                               Timer::now().time_since_epoch())
                               .count();
 
-    context->cb = [this, thread_id, &thread_histograms, &semaphore, &progress](
-                      const std::shared_ptr<GetObjectAsyncContext>& ctx) {
-      auto end = std::chrono::duration_cast<std::chrono::microseconds>(
-                     Timer::now().time_since_epoch())
-                     .count();
-      thread_histograms[thread_id].addLatency(
-          static_cast<uint64_t>(end - ctx->start_time));
-      pending_ops_--;
-      semaphore.release();
-      progress.Increment();
-      if (pending_ops_ == 0) {
-        cv_.notify_one();
-      }
-    };
+    context->cb =
+        [this, i, slot, &latencies, &available_slots, &slot_mutex, &semaphore,
+         &progress](const std::shared_ptr<GetObjectAsyncContext>& ctx) {
+          auto end = std::chrono::duration_cast<std::chrono::microseconds>(
+                         Timer::now().time_since_epoch())
+                         .count();
+          latencies[i] = static_cast<uint64_t>(end - ctx->start_time);
+          progress.Increment();
+          {
+            std::lock_guard<std::mutex> lock(slot_mutex);
+            available_slots.push_back(slot);
+          }
+          semaphore.release();
+          {
+            std::lock_guard<std::mutex> lock(mtx_);
+            pending_ops_--;
+          }
+          cv_.notify_one();
+        };
 
     accesser_->AsyncGet(key, context);
   }
@@ -647,8 +665,8 @@ void BlockAccessBench::RunAsyncGetBench() {
           .count();
 
   LatencyHistogram combined_histogram;
-  for (auto& histo : thread_histograms) {
-    combined_histogram += histo;
+  for (uint64_t latency : latencies) {
+    combined_histogram.addLatency(latency);
   }
 
   double avg_latency = combined_histogram.getAverageMicroSec() / 1000.0;

--- a/src/common/blockaccess/bench/block_access_bench_main.cc
+++ b/src/common/blockaccess/bench/block_access_bench_main.cc
@@ -110,6 +110,9 @@ DEFINE_string(rados_key, "", "Rados key");
 DEFINE_uint32(threads, 1, "Number of threads");
 DEFINE_uint32(num_ops, 10000, "Number of operations per thread");
 DEFINE_uint32(block_size, 4194304, "Block size in bytes (default: 4MB)");
+DEFINE_validator(block_size, [](const char* /*name*/, uint32_t value) {
+  return value > 0;
+});
 
 // Performance flags
 DEFINE_bool(bind_to_cpu, false,

--- a/src/common/blockaccess/block_accesser.cc
+++ b/src/common/blockaccess/block_accesser.cc
@@ -120,12 +120,9 @@ bool BlockAccesserImpl::ContainerExist() {
   return ok;
 }
 
-Status BlockAccesserImpl::Put(const std::string& key, const std::string& data) {
-  return Put(key, data.data(), data.size());
-}
-
-Status BlockAccesserImpl::Put(const std::string& key, const char* buffer,
-                              size_t length) {
+Status BlockAccesserImpl::Put(const std::string& key,
+                              const PutPayload& payload) {
+  const size_t length = payload.Size();
   Status s;
   BlockAccessLogGuard log(butil::cpuwide_time_us(), [&]() {
     return fmt::format("put_block ({}, {}) : {}", key, length,
@@ -143,7 +140,7 @@ Status BlockAccesserImpl::Put(const std::string& key, const char* buffer,
     throttle_->Add(false, length);
   }
 
-  s = data_accesser_->Put(key, buffer, length);
+  s = data_accesser_->Put(key, payload);
   return s;
 }
 
@@ -159,31 +156,33 @@ void BlockAccesserImpl::AsyncPut(
   // ctx->origin_key value the caller may have set.
   context->cb = [this, start_us, key, origin = std::move(origin_cb)](
                     const std::shared_ptr<PutObjectAsyncContext>& ctx) {
-    // The inner formatter lambda must capture by VALUE (not [&]) — the
-    // outer closure (which owns `key`) is destroyed by `ctx->cb = origin`
-    // below, but the BlockAccessLogGuard's destructor runs AFTER that,
-    // invoking this formatter. With [&], `key` would dangle.
-    BlockAccessLogGuard log(start_us, [start_us, key, ctx]() {
-      (void)start_us;
-      return fmt::format("async_put_block ({}, {}) : {}", key, ctx->buffer_size,
-                         ctx->status.ToString());
-    });
-    MetricGuard<Status> guard(&ctx->status, &g_block_metric.write_block,
-                              ctx->buffer_size, start_us);
+    // Snapshot this attempt before invoking the caller. The caller may enqueue
+    // a retry immediately, and that retry reuses and rewrites the same context.
+    Status attempt_status = ctx->status;
+    const size_t payload_size = ctx->payload.Size();
+    {
+      BlockAccessLogGuard log(start_us, [key, payload_size, attempt_status]() {
+        return fmt::format("async_put_block ({}, {}) : {}", key, payload_size,
+                           attempt_status.ToString());
+      });
+      MetricGuard<Status> guard(&attempt_status, &g_block_metric.write_block,
+                                payload_size, start_us);
 
-    block_put_async_num << -1;
-    inflight_bytes_throttle_->OnComplete(ctx->buffer_size);
+      block_put_async_num << -1;
+      inflight_bytes_throttle_->OnComplete(payload_size);
+    }
 
     // NOTE: this is necessary because caller reuse context when retry
-    ctx->cb = origin;
-    ctx->cb(ctx);
+    auto callback = origin;
+    ctx->cb = callback;
+    callback(ctx);
   };
 
   if (throttle_) {
-    throttle_->Add(false, context->buffer_size);
+    throttle_->Add(false, context->payload.Size());
   }
 
-  inflight_bytes_throttle_->OnStart(context->buffer_size);
+  inflight_bytes_throttle_->OnStart(context->payload.Size());
 
   data_accesser_->AsyncPut(key, context);
 }
@@ -217,20 +216,26 @@ void BlockAccesserImpl::AsyncGet(
 
   context->cb = [this, start_us, key, origin = std::move(origin_cb)](
                     const std::shared_ptr<GetObjectAsyncContext>& ctx) {
-    // Inner formatter must capture by VALUE — see AsyncPut comment above.
-    BlockAccessLogGuard log(start_us, [key, ctx]() {
-      return fmt::format("async_get_block ({}, {}, {}) : {}", key, ctx->offset,
-                         ctx->len, ctx->status.ToString());
-    });
-    MetricGuard<Status> guard(&ctx->status, &g_block_metric.read_block,
-                              ctx->len, start_us);
+    Status attempt_status = ctx->status;
+    const off_t offset = ctx->offset;
+    const size_t length = ctx->len;
+    {
+      BlockAccessLogGuard log(
+          start_us, [key, offset, length, attempt_status]() {
+            return fmt::format("async_get_block ({}, {}, {}) : {}", key, offset,
+                               length, attempt_status.ToString());
+          });
+      MetricGuard<Status> guard(&attempt_status, &g_block_metric.read_block,
+                                length, start_us);
 
-    block_get_async_num << -1;
-    inflight_bytes_throttle_->OnComplete(ctx->len);
+      block_get_async_num << -1;
+      inflight_bytes_throttle_->OnComplete(length);
+    }
 
     // NOTE: this is necessary because caller reuse context when retry
-    ctx->cb = origin;
-    ctx->cb(ctx);
+    auto callback = origin;
+    ctx->cb = callback;
+    callback(ctx);
   };
 
   if (throttle_) {
@@ -295,16 +300,20 @@ void BlockAccesserImpl::AsyncDelete(
   auto origin_cb = std::move(context->cb);
   context->cb = [start_us, key, origin = std::move(origin_cb)](
                     const std::shared_ptr<DeleteObjectAsyncContext>& ctx) {
-    BlockAccessLogGuard log(start_us, [key, ctx]() {
-      return fmt::format("async_delete_block ({}) : {}", key,
-                         ctx->status.ToString());
-    });
+    Status attempt_status = ctx->status;
+    {
+      BlockAccessLogGuard log(start_us, [key, attempt_status]() {
+        return fmt::format("async_delete_block ({}) : {}", key,
+                           attempt_status.ToString());
+      });
 
-    block_delete_async_num << -1;
+      block_delete_async_num << -1;
+    }
 
     // NOTE: restore origin cb because caller may reuse context on retry.
-    ctx->cb = origin;
-    ctx->cb(ctx);
+    auto callback = origin;
+    ctx->cb = callback;
+    callback(ctx);
   };
 
   data_accesser_->AsyncDelete(key, context);
@@ -331,16 +340,20 @@ void BlockAccesserImpl::AsyncBatchDelete(
   auto origin_cb = std::move(context->cb);
   context->cb = [start_us, count, origin = std::move(origin_cb)](
                     const std::shared_ptr<BatchDeleteObjectAsyncContext>& ctx) {
-    BlockAccessLogGuard log(start_us, [count, ctx]() {
-      return fmt::format("async_delete_objects ({}) : {}", count,
-                         ctx->status.ToString());
-    });
+    Status attempt_status = ctx->status;
+    {
+      BlockAccessLogGuard log(start_us, [count, attempt_status]() {
+        return fmt::format("async_delete_objects ({}) : {}", count,
+                           attempt_status.ToString());
+      });
 
-    block_batch_delete_async_num << -1;
+      block_batch_delete_async_num << -1;
+    }
 
     // NOTE: restore origin cb because caller may reuse context on retry.
-    ctx->cb = origin;
-    ctx->cb(ctx);
+    auto callback = origin;
+    ctx->cb = callback;
+    callback(ctx);
   };
 
   data_accesser_->AsyncBatchDelete(keys, context);

--- a/src/common/blockaccess/block_accesser.h
+++ b/src/common/blockaccess/block_accesser.h
@@ -44,10 +44,7 @@ class BlockAccesser {
 
   virtual bool ContainerExist() = 0;
 
-  virtual Status Put(const std::string& key, const std::string& data) = 0;
-
-  virtual Status Put(const std::string& key, const char* buffer,
-                     size_t length) = 0;
+  virtual Status Put(const std::string& key, const PutPayload& payload) = 0;
 
   // `key` is the storage key for this Put. It is passed as a separate
   // parameter (not via `context->origin_key`) so that wrappers (e.g.
@@ -109,10 +106,7 @@ class BlockAccesserImpl : public BlockAccesser {
 
   bool ContainerExist() override;
 
-  Status Put(const std::string& key, const std::string& data) override;
-
-  Status Put(const std::string& key, const char* buffer,
-             size_t length) override;
+  Status Put(const std::string& key, const PutPayload& payload) override;
 
   void AsyncPut(const std::string& key,
                 std::shared_ptr<PutObjectAsyncContext> context) override;

--- a/src/common/blockaccess/fake/fake_accesser.cc
+++ b/src/common/blockaccess/fake/fake_accesser.cc
@@ -55,23 +55,21 @@ bool FakeAccesser::Destroy() {
 
 bool FakeAccesser::ContainerExist() { return true; }
 
-Status FakeAccesser::Put(const std::string& key, const char* buffer,
-                         size_t length) {
+Status FakeAccesser::Put(const std::string& key, const PutPayload& payload) {
   (void)key;
-  (void)buffer;
-  (void)length;
+  (void)payload;
   return Status::OK();
 }
 
 void FakeAccesser::DoAsyncPut(const std::string& key,
                               PutObjectAsyncContextSPtr context) {
-  context->status = Put(key, context->buffer, context->buffer_size);
+  context->status = Put(key, context->payload);
   context->cb(context);
 }
 
 void FakeAccesser::AsyncPut(const std::string& key,
                             PutObjectAsyncContextSPtr context) {
-  std::thread([&, key, context]() { DoAsyncPut(key, context); }).detach();
+  std::thread([this, key, context]() { DoAsyncPut(key, context); }).detach();
 }
 
 Status FakeAccesser::Get(const std::string& key, std::string* data) {
@@ -109,7 +107,7 @@ void FakeAccesser::DoAsyncGet(const std::string& key,
 
 void FakeAccesser::AsyncGet(const std::string& key,
                             GetObjectAsyncContextSPtr context) {
-  std::thread([&, key, context]() { DoAsyncGet(key, context); }).detach();
+  std::thread([this, key, context]() { DoAsyncGet(key, context); }).detach();
 }
 
 bool FakeAccesser::BlockExist(const std::string& key) {

--- a/src/common/blockaccess/fake/fake_accesser.h
+++ b/src/common/blockaccess/fake/fake_accesser.h
@@ -34,8 +34,7 @@ class FakeAccesser : public Accesser {
 
   bool ContainerExist() override;
 
-  Status Put(const std::string& key, const char* buffer,
-             size_t length) override;
+  Status Put(const std::string& key, const PutPayload& payload) override;
   void AsyncPut(const std::string& key,
                 PutObjectAsyncContextSPtr context) override;
 

--- a/src/common/blockaccess/files/file_accesser.cc
+++ b/src/common/blockaccess/files/file_accesser.cc
@@ -161,9 +161,7 @@ std::string FileAccesser::KeyPath(const std::string& key) {
   }
 }
 
-Status FileAccesser::Put(const std::string& key, const char* buffer,
-                         size_t length) {
-  CHECK_GT(length, 0);
+Status FileAccesser::Put(const std::string& key, const PutPayload& payload) {
   std::string fpath = KeyPath(key);
   std::string tmp = fpath + ".tmp";
 
@@ -180,16 +178,20 @@ Status FileAccesser::Put(const std::string& key, const char* buffer,
     SCOPED_CLEANUP({ Close(tmp, fd); });
     // TOOO: remove tmp file on error
 
-    while (length > 0) {
-      ssize_t res = ::write(fd, buffer, length);
-      if (res < 0) {
-        if (errno == EINTR) {
-          continue;
+    for (const auto& segment : payload.Segments()) {
+      const char* buffer = segment.data;
+      size_t length = segment.size;
+      while (length > 0) {
+        ssize_t res = ::write(fd, buffer, length);
+        if (res < 0) {
+          if (errno == EINTR) {
+            continue;
+          }
+          return PosixError(fpath, errno);
         }
-        return PosixError(fpath, errno);
+        buffer += res;
+        length -= res;
       }
-      buffer += res;
-      length -= res;
     }
   }
 
@@ -199,13 +201,13 @@ Status FileAccesser::Put(const std::string& key, const char* buffer,
 
 void FileAccesser::DoAsyncPut(const std::string& key,
                               PutObjectAsyncContextSPtr context) {
-  context->status = Put(key, context->buffer, context->buffer_size);
+  context->status = Put(key, context->payload);
   context->cb(context);
 }
 
 void FileAccesser::AsyncPut(const std::string& key,
                             PutObjectAsyncContextSPtr context) {
-  std::thread([&, key, context]() { DoAsyncPut(key, context); }).detach();
+  std::thread([this, key, context]() { DoAsyncPut(key, context); }).detach();
 }
 
 Status FileAccesser::Get(const std::string& key, std::string* data) {
@@ -303,7 +305,7 @@ void FileAccesser::DoAsyncGet(const std::string& key,
 
 void FileAccesser::AsyncGet(const std::string& key,
                             GetObjectAsyncContextSPtr context) {
-  std::thread([&, key, context]() { DoAsyncGet(key, context); }).detach();
+  std::thread([this, key, context]() { DoAsyncGet(key, context); }).detach();
 }
 
 bool FileAccesser::BlockExist(const std::string& key) {

--- a/src/common/blockaccess/files/file_accesser.h
+++ b/src/common/blockaccess/files/file_accesser.h
@@ -35,8 +35,7 @@ class FileAccesser : public Accesser {
 
   bool ContainerExist() override;
 
-  Status Put(const std::string& key, const char* buffer,
-             size_t length) override;
+  Status Put(const std::string& key, const PutPayload& payload) override;
   void AsyncPut(const std::string& key,
                 PutObjectAsyncContextSPtr context) override;
 

--- a/src/common/blockaccess/prefix_block_accesser.h
+++ b/src/common/blockaccess/prefix_block_accesser.h
@@ -57,13 +57,8 @@ class PrefixBlockAccesser : public BlockAccesser {
 
   bool ContainerExist() override { return inner_->ContainerExist(); }
 
-  Status Put(const std::string& key, const std::string& data) override {
-    return inner_->Put(PrefixKey(key), data);
-  }
-
-  Status Put(const std::string& key, const char* buffer,
-             size_t length) override {
-    return inner_->Put(PrefixKey(key), buffer, length);
+  Status Put(const std::string& key, const PutPayload& payload) override {
+    return inner_->Put(PrefixKey(key), payload);
   }
 
   void AsyncPut(const std::string& key,

--- a/src/common/blockaccess/put_payload.h
+++ b/src/common/blockaccess/put_payload.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Project: DingoFS
+ * Created Date: 2026-07-16
+ * Author: DingoFS Authors
+ */
+
+#ifndef DINGOFS_COMMON_BLOCK_ACCESS_PUT_PAYLOAD_H_
+#define DINGOFS_COMMON_BLOCK_ACCESS_PUT_PAYLOAD_H_
+
+#include <glog/logging.h>
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace dingofs::blockaccess {
+
+struct PayloadSegment {
+  const char* data;
+  size_t size;
+};
+
+// Immutable, non-owning description of a segmented upload payload. Callers
+// must keep the referenced bytes alive and unchanged until Put returns or the
+// AsyncPut callback starts.
+class PutPayload {
+ public:
+  static PutPayload Build(std::vector<PayloadSegment> segments) {
+    CHECK(!segments.empty()) << "empty block payload is not supported";
+
+    size_t total = 0;
+    for (const auto& segment : segments) {
+      CHECK_NOTNULL(segment.data);
+      CHECK_GT(segment.size, 0) << "block payload has an empty segment";
+      CHECK_LE(segment.size, std::numeric_limits<size_t>::max() - total)
+          << "payload size overflow";
+      total += segment.size;
+    }
+
+    return PutPayload(std::make_shared<const Rep>(std::move(segments), total));
+  }
+
+  const std::vector<PayloadSegment>& Segments() const { return rep_->segments; }
+  size_t Size() const { return rep_->size; }
+  size_t SegmentCount() const { return rep_->segments.size(); }
+
+ private:
+  struct Rep {
+    Rep(std::vector<PayloadSegment> input, size_t total)
+        : segments(std::move(input)), size(total) {}
+
+    const std::vector<PayloadSegment> segments;
+    const size_t size;
+  };
+
+  explicit PutPayload(std::shared_ptr<const Rep> rep) : rep_(std::move(rep)) {
+    CHECK_NOTNULL(rep_.get());
+  }
+
+  std::shared_ptr<const Rep> rep_;
+};
+
+}  // namespace dingofs::blockaccess
+
+#endif  // DINGOFS_COMMON_BLOCK_ACCESS_PUT_PAYLOAD_H_

--- a/src/common/blockaccess/rados/rados_accesser.cc
+++ b/src/common/blockaccess/rados/rados_accesser.cc
@@ -68,6 +68,14 @@ void DestroyIoctx(rados_ioctx_t ioctx) {
     rados_ioctx_destroy(ioctx);
   }
 }
+
+void AppendPayload(rados_write_op_t op, const PutPayload& payload) {
+  uint64_t offset = 0;
+  for (const auto& segment : payload.Segments()) {
+    rados_write_op_write(op, segment.data, segment.size, offset);
+    offset += segment.size;
+  }
+}
 }  // namespace
 
 bool RadosAccesser::Init() {
@@ -239,13 +247,20 @@ bool RadosAccesser::ContainerExist() {
   }
 }
 
-Status RadosAccesser::Put(const std::string& key, const char* buffer,
-                          size_t length) {
+Status RadosAccesser::Put(const std::string& key, const PutPayload& payload) {
   return ExecuteSyncOp(key, [&](rados_ioctx_t ioctx) {
-    int err = rados_write(ioctx, key.c_str(), buffer, length, 0);
+    rados_write_op_t op = rados_create_write_op();
+    if (op == nullptr) {
+      LOG(ERROR) << "Failed to allocate rados write operation, key: " << key;
+      return Status::OutOfMemory("failed to allocate rados write operation");
+    }
+    auto release = MakeScopedCleanup([&]() { rados_release_write_op(op); });
+    AppendPayload(op, payload);
+    int err = rados_write_op_operate(op, ioctx, key.c_str(), nullptr, 0);
     if (err < 0) {
       LOG(ERROR) << "Failed to write object, key: " << key
-                 << ", length: " << length << ", err: " << strerror(-err);
+                 << ", length: " << payload.Size()
+                 << ", err: " << strerror(-err);
       return Status::IoError("Failed to write object");
     }
     return Status::OK();
@@ -496,8 +511,12 @@ static void AsyncPutCallback(RadosAsyncIOUnit* io_unit, int ret_code) {
 
   auto put_context =
       std::get<std::shared_ptr<PutObjectAsyncContext>>(io_unit->async_context);
-  put_context->status =
-      (ret_code < 0) ? Status::IoError(strerror(-ret_code)) : Status::OK();
+  if (ret_code == -ENOMEM) {
+    put_context->status = Status::OutOfMemory("rados put ran out of memory");
+  } else {
+    put_context->status =
+        (ret_code < 0) ? Status::IoError(strerror(-ret_code)) : Status::OK();
+  }
   put_context->cb(put_context);
 }
 
@@ -508,11 +527,18 @@ void RadosAccesser::AsyncPut(const std::string& key,
 
   // transfer ownership of io_unit to the callback
   ExecuteAsyncOperation(io_unit, [this, key, context](RadosAsyncIOUnit* unit) {
-    int err = rados_aio_write(unit->ioctx, key.c_str(), unit->completion,
-                              context->buffer, context->buffer_size, 0);
+    rados_write_op_t op = rados_create_write_op();
+    if (op == nullptr) {
+      LOG(ERROR) << "Failed to allocate rados write operation, key: " << key;
+      return -ENOMEM;
+    }
+    auto release = MakeScopedCleanup([&]() { rados_release_write_op(op); });
+    AppendPayload(op, context->payload);
+    int err = rados_aio_write_op_operate(op, unit->ioctx, unit->completion,
+                                         key.c_str(), nullptr, 0);
     if (err < 0) {
       LOG(ERROR) << "Fail AsyncPut key: " << key
-                 << ", length: " << context->buffer_size
+                 << ", length: " << context->payload.Size()
                  << ", err: " << strerror(-err);
     }
     return err;

--- a/src/common/blockaccess/rados/rados_accesser.h
+++ b/src/common/blockaccess/rados/rados_accesser.h
@@ -74,8 +74,7 @@ class RadosAccesser : public Accesser {
 
   bool ContainerExist() override;
 
-  Status Put(const std::string& key, const char* buffer,
-             size_t length) override;
+  Status Put(const std::string& key, const PutPayload& payload) override;
   void AsyncPut(const std::string& key,
                 std::shared_ptr<PutObjectAsyncContext> context) override;
 

--- a/src/common/blockaccess/s3/aws/aws_crt_s3_client.cc
+++ b/src/common/blockaccess/s3/aws/aws_crt_s3_client.cc
@@ -106,12 +106,11 @@ bool AwsCrtS3Client::BucketExist(const std::string& bucket) {
 }
 
 int AwsCrtS3Client::PutObject(const std::string& bucket, const std::string& key,
-                              const char* buffer, size_t buffer_size) {
+                              const PutPayload& payload) {
   Model::PutObjectRequest request;
   request.SetBucket(bucket);
   request.SetKey(key);
-  request.SetBody(Aws::MakeShared<PreallocatedIOStream>(AWS_ALLOCATE_TAG,
-                                                        buffer, buffer_size));
+  SetPutObjectPayload(&request, payload);
 
   auto response = client_->PutObject(request);
   if (!response.IsSuccess()) {
@@ -136,8 +135,7 @@ void AwsCrtS3Client::AsyncPutObject(const std::string& bucket,
   auto& request = std::any_cast<Model::PutObjectRequest&>(aws_ctx->request);
   request.SetBucket(bucket);
   request.SetKey(key);
-  request.SetBody(Aws::MakeShared<PreallocatedIOStream>(
-      AWS_ALLOCATE_TAG, user_ctx->buffer, user_ctx->buffer_size));
+  SetPutObjectPayload(&request, user_ctx->payload);
 
   PutObjectResponseReceivedHandler handler =
       [this, bucket, key](

--- a/src/common/blockaccess/s3/aws/aws_crt_s3_client.h
+++ b/src/common/blockaccess/s3/aws/aws_crt_s3_client.h
@@ -45,7 +45,7 @@ class AwsCrtS3Client : public AwsS3Client {
   bool BucketExist(const std::string& bucket) override;
 
   int PutObject(const std::string& bucket, const std::string& key,
-                const char* buffer, size_t buffer_size) override;
+                const PutPayload& payload) override;
 
   void AsyncPutObject(const std::string& bucket, const std::string& key,
                       PutObjectAsyncContextSPtr user_ctx) override;

--- a/src/common/blockaccess/s3/aws/aws_legacy_s3_client.cc
+++ b/src/common/blockaccess/s3/aws/aws_legacy_s3_client.cc
@@ -120,13 +120,12 @@ bool AwsLegacyS3Client::BucketExist(const std::string& bucket) {
 }
 
 int AwsLegacyS3Client::PutObject(const std::string& bucket,
-                                 const std::string& key, const char* buffer,
-                                 size_t buffer_size) {
+                                 const std::string& key,
+                                 const PutPayload& payload) {
   Model::PutObjectRequest request;
   request.SetBucket(bucket);
   request.SetKey(key);
-  request.SetBody(Aws::MakeShared<PreallocatedIOStream>(AWS_ALLOCATE_TAG,
-                                                        buffer, buffer_size));
+  SetPutObjectPayload(&request, payload);
 
   auto response = client_->PutObject(request);
 
@@ -152,8 +151,7 @@ void AwsLegacyS3Client::AsyncPutObject(const std::string& bucket,
   auto& request = std::any_cast<Model::PutObjectRequest&>(aws_ctx->request);
   request.SetBucket(bucket);
   request.SetKey(std::string{key.c_str(), key.size()});
-  request.SetBody(Aws::MakeShared<PreallocatedIOStream>(
-      AWS_ALLOCATE_TAG, user_ctx->buffer, user_ctx->buffer_size));
+  SetPutObjectPayload(&request, user_ctx->payload);
 
   PutObjectResponseReceivedHandler handler =
       [aws_ctx, this, bucket, key](

--- a/src/common/blockaccess/s3/aws/aws_legacy_s3_client.h
+++ b/src/common/blockaccess/s3/aws/aws_legacy_s3_client.h
@@ -43,7 +43,7 @@ class AwsLegacyS3Client : public AwsS3Client {
   bool BucketExist(const std::string& bucket) override;
 
   int PutObject(const std::string& bucket, const std::string& key,
-                const char* buffer, size_t buffer_size) override;
+                const PutPayload& payload) override;
 
   void AsyncPutObject(const std::string& bucket, const std::string& key,
                       PutObjectAsyncContextSPtr user_ctx) override;

--- a/src/common/blockaccess/s3/aws/aws_s3_client.h
+++ b/src/common/blockaccess/s3/aws/aws_s3_client.h
@@ -38,7 +38,7 @@ class AwsS3Client {
   virtual bool BucketExist(const std::string& bucket) = 0;
 
   virtual int PutObject(const std::string& bucket, const std::string& key,
-                        const char* buffer, size_t buffer_size) = 0;
+                        const PutPayload& payload) = 0;
 
   virtual void AsyncPutObject(const std::string& bucket, const std::string& key,
                               PutObjectAsyncContextSPtr user_ctx) = 0;

--- a/src/common/blockaccess/s3/aws/aws_s3_common.h
+++ b/src/common/blockaccess/s3/aws/aws_s3_common.h
@@ -17,11 +17,19 @@
 #ifndef DATA_ACCESS_AWS_S3_COMMON_H
 #define DATA_ACCESS_AWS_S3_COMMON_H
 
+#include <glog/logging.h>
+
+#include <algorithm>
 #include <any>
+#include <cstring>
+#include <ios>
+#include <limits>
 #include <memory>
+#include <streambuf>
 #include <string>
 
 #include "aws/core/client/AsyncCallerContext.h"
+#include "aws/core/utils/memory/AWSMemory.h"
 #include "aws/core/utils/memory/stl/AWSStreamFwd.h"
 #include "aws/core/utils/stream/PreallocatedStreamBuf.h"
 #include "common/blockaccess/accesser_common.h"
@@ -74,6 +82,120 @@ class PreallocatedIOStream : public Aws::IOStream {
     delete rdbuf();
   }
 };
+
+class SegmentedStreamBuf : public std::streambuf {
+ public:
+  explicit SegmentedStreamBuf(PutPayload payload)
+      : payload_(std::move(payload)) {
+    CHECK_LE(payload_.Size(),
+             static_cast<size_t>(std::numeric_limits<off_type>::max()));
+  }
+
+ protected:
+  int_type underflow() override {
+    if (position_ >= payload_.Size()) {
+      return traits_type::eof();
+    }
+    auto [segment, offset] = Locate(position_);
+    return traits_type::to_int_type(segment->data[offset]);
+  }
+
+  int_type uflow() override {
+    int_type value = underflow();
+    if (!traits_type::eq_int_type(value, traits_type::eof())) {
+      ++position_;
+    }
+    return value;
+  }
+
+  std::streamsize xsgetn(char* output, std::streamsize count) override {
+    if (count <= 0 || position_ >= payload_.Size()) {
+      return 0;
+    }
+
+    size_t remaining =
+        std::min(static_cast<size_t>(count), payload_.Size() - position_);
+    const size_t requested = remaining;
+    while (remaining > 0) {
+      auto [segment, offset] = Locate(position_);
+      size_t length = std::min(remaining, segment->size - offset);
+      std::memcpy(output, segment->data + offset, length);
+      output += length;
+      position_ += length;
+      remaining -= length;
+    }
+    return static_cast<std::streamsize>(requested);
+  }
+
+  pos_type seekoff(off_type offset, std::ios_base::seekdir direction,
+                   std::ios_base::openmode mode) override {
+    if ((mode & std::ios_base::in) == 0) {
+      return pos_type(off_type(-1));
+    }
+    off_type base = 0;
+    if (direction == std::ios_base::cur) {
+      base = static_cast<off_type>(position_);
+    } else if (direction == std::ios_base::end) {
+      base = static_cast<off_type>(payload_.Size());
+    } else if (direction != std::ios_base::beg) {
+      return pos_type(off_type(-1));
+    }
+    const off_type end = static_cast<off_type>(payload_.Size());
+    if (offset < -base || offset > end - base) {
+      return pos_type(off_type(-1));
+    }
+    off_type next = base + offset;
+    position_ = static_cast<size_t>(next);
+    return pos_type(next);
+  }
+
+  pos_type seekpos(pos_type position, std::ios_base::openmode mode) override {
+    return seekoff(static_cast<off_type>(position), std::ios_base::beg, mode);
+  }
+
+ private:
+  std::pair<const PayloadSegment*, size_t> Locate(size_t position) {
+    if (position < cursor_segment_start_) {
+      cursor_segment_ = 0;
+      cursor_segment_start_ = 0;
+    }
+
+    const auto& segments = payload_.Segments();
+    while (cursor_segment_ < segments.size()) {
+      const auto& segment = segments[cursor_segment_];
+      if (position < cursor_segment_start_ + segment.size) {
+        return {&segment, position - cursor_segment_start_};
+      }
+      cursor_segment_start_ += segment.size;
+      ++cursor_segment_;
+    }
+    LOG(FATAL) << "payload position out of bounds";
+    return {nullptr, 0};
+  }
+
+  PutPayload payload_;
+  size_t position_{0};
+  size_t cursor_segment_{0};
+  size_t cursor_segment_start_{0};
+};
+
+class SegmentedIOStream : public Aws::IOStream {
+ public:
+  explicit SegmentedIOStream(PutPayload payload)
+      : Aws::IOStream(new SegmentedStreamBuf(std::move(payload))) {}
+
+  ~SegmentedIOStream() override { delete rdbuf(); }
+};
+
+template <typename PutObjectRequest>
+void SetPutObjectPayload(PutObjectRequest* request, const PutPayload& payload) {
+  CHECK_NOTNULL(request);
+  CHECK_LE(payload.Size(),
+           static_cast<size_t>(std::numeric_limits<long long>::max()));
+  request->SetContentLength(static_cast<long long>(payload.Size()));
+  request->SetBody(
+      Aws::MakeShared<SegmentedIOStream>(AWS_ALLOCATE_TAG, payload));
+}
 
 // https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Range_requests
 inline Aws::String GetObjectRequestRange(uint64_t offset, uint64_t len) {

--- a/src/common/blockaccess/s3/s3_accesser.cc
+++ b/src/common/blockaccess/s3/s3_accesser.cc
@@ -111,9 +111,8 @@ Aws::String S3Accesser::S3Key(const std::string& key) {
 
 bool S3Accesser::ContainerExist() { return client_->BucketExist(bucket_); }
 
-Status S3Accesser::Put(const std::string& key, const char* buffer,
-                       size_t length) {
-  int rc = client_->PutObject(bucket_, S3Key(key), buffer, length);
+Status S3Accesser::Put(const std::string& key, const PutPayload& payload) {
+  int rc = client_->PutObject(bucket_, S3Key(key), payload);
   if (rc < 0) {
     LOG(ERROR) << fmt::format("[s3_accesser] put object({}) fail, retcode:{}.",
                               key, rc);

--- a/src/common/blockaccess/s3/s3_accesser.h
+++ b/src/common/blockaccess/s3/s3_accesser.h
@@ -38,8 +38,7 @@ class S3Accesser : public Accesser {
 
   bool ContainerExist() override;
 
-  Status Put(const std::string& key, const char* buffer,
-             size_t length) override;
+  Status Put(const std::string& key, const PutPayload& payload) override;
   void AsyncPut(const std::string& key,
                 PutObjectAsyncContextSPtr context) override;
 

--- a/src/tools/mds-cli/br.cc
+++ b/src/tools/mds-cli/br.cc
@@ -204,7 +204,13 @@ class S3Output : public Output {
   }
 
   void Flush() override {
-    auto status = block_accessor_->Put(s3_info_.object_name, data_);
+    if (data_.empty()) {
+      std::cerr << "refuse to upload an empty backup object.\n";
+      return;
+    }
+    auto payload =
+        blockaccess::PutPayload::Build({{data_.data(), data_.size()}});
+    auto status = block_accessor_->Put(s3_info_.object_name, payload);
     if (!status.ok()) {
       std::cerr << fmt::format("upload S3 fail, error({}).", status.ToString());
     }

--- a/test/integration/cache/deploy/client.h
+++ b/test/integration/cache/deploy/client.h
@@ -243,7 +243,8 @@ class CacheClient {
   // Write a block straight into the backend, bypassing the cache, so tests can
   // exercise the storage-reflow / prefetch paths.
   Status SeedStorage(const BlockHandle& h, const std::string& data) {
-    return accesser_->Put(h.StoreKey(), data);
+    return accesser_->Put(h.StoreKey(), blockaccess::PutPayload::Build(
+                                            {{data.data(), data.size()}}));
   }
 
  private:

--- a/test/unit/cache/common/test_storage_client.cc
+++ b/test/unit/cache/common/test_storage_client.cc
@@ -82,6 +82,36 @@ TEST_F(StorageClientTest, PutSuccess) {
   ASSERT_TRUE(client.Shutdown().ok());
 }
 
+TEST_F(StorageClientTest, PutPreservesSegmentedIOBuffer) {
+  StorageClient client(&accesser_);
+  ASSERT_TRUE(client.Start().ok());
+
+  std::string first = "hello ";
+  std::string second = "segments";
+  IOBuffer buffer;
+  buffer.AppendUserData(first.data(), first.size(), [](void*) {});
+  buffer.AppendUserData(second.data(), second.size(), [](void*) {});
+  ASSERT_EQ(buffer.BackingBlockNum(), 2);
+
+  EXPECT_CALL(accesser_, AsyncPut(_, _))
+      .WillOnce(Invoke(
+          [&](const std::string&, std::shared_ptr<PutObjectAsyncContext> ctx) {
+            EXPECT_EQ(ctx->payload.SegmentCount(), 2);
+            EXPECT_EQ(ctx->payload.Size(), first.size() + second.size());
+            EXPECT_EQ(std::string(ctx->payload.Segments()[0].data,
+                                  ctx->payload.Segments()[0].size),
+                      first);
+            EXPECT_EQ(std::string(ctx->payload.Segments()[1].data,
+                                  ctx->payload.Segments()[1].size),
+                      second);
+            ctx->status = Status::OK();
+            ctx->cb(ctx);
+          }));
+
+  EXPECT_TRUE(client.Put(Handle(103), buffer).ok());
+  ASSERT_TRUE(client.Shutdown().ok());
+}
+
 TEST_F(StorageClientTest, PutRetriesThenSucceeds) {
   StorageClient client(&accesser_);
   ASSERT_TRUE(client.Start().ok());
@@ -98,6 +128,27 @@ TEST_F(StorageClientTest, PutRetriesThenSucceeds) {
           }));
 
   EXPECT_TRUE(client.Put(Handle(101), Buf("data")).ok());
+  EXPECT_EQ(calls, 2);
+  ASSERT_TRUE(client.Shutdown().ok());
+}
+
+TEST_F(StorageClientTest, PutRetriesOutOfMemoryThenSucceeds) {
+  StorageClient client(&accesser_);
+  ASSERT_TRUE(client.Start().ok());
+
+  int calls = 0;
+  EXPECT_CALL(accesser_, AsyncPut(_, _))
+      .Times(2)
+      .WillRepeatedly(Invoke([&calls](
+                                 const std::string&,
+                                 std::shared_ptr<PutObjectAsyncContext> ctx) {
+        ctx->status = (++calls == 1)
+                          ? Status::OutOfMemory("transient allocation failure")
+                          : Status::OK();
+        ctx->cb(ctx);
+      }));
+
+  EXPECT_TRUE(client.Put(Handle(104), Buf("data")).ok());
   EXPECT_EQ(calls, 2);
   ASSERT_TRUE(client.Shutdown().ok());
 }
@@ -135,12 +186,12 @@ TEST_F(StorageClientTest, PutRetryAfterShutdownReturnsIoError) {
   std::condition_variable cv;
   std::shared_ptr<PutObjectAsyncContext> inflight;
   EXPECT_CALL(accesser_, AsyncPut(_, _))
-      .WillOnce(Invoke([&](const std::string&,
-                           std::shared_ptr<PutObjectAsyncContext> ctx) {
-        std::lock_guard<std::mutex> lk(mu);
-        inflight = ctx;
-        cv.notify_one();
-      }));
+      .WillOnce(Invoke(
+          [&](const std::string&, std::shared_ptr<PutObjectAsyncContext> ctx) {
+            std::lock_guard<std::mutex> lk(mu);
+            inflight = ctx;
+            cv.notify_one();
+          }));
 
   // Put blocks until the task completes, so drive it from a separate thread.
   Status put_status;
@@ -235,12 +286,12 @@ TEST_F(StorageClientTest, RangeRetryAfterShutdownReturnsIoError) {
   std::condition_variable cv;
   std::shared_ptr<GetObjectAsyncContext> inflight;
   EXPECT_CALL(accesser_, AsyncGet(_, _))
-      .WillOnce(Invoke([&](const std::string&,
-                           std::shared_ptr<GetObjectAsyncContext> ctx) {
-        std::lock_guard<std::mutex> lk(mu);
-        inflight = ctx;
-        cv.notify_one();
-      }));
+      .WillOnce(Invoke(
+          [&](const std::string&, std::shared_ptr<GetObjectAsyncContext> ctx) {
+            std::lock_guard<std::mutex> lk(mu);
+            inflight = ctx;
+            cv.notify_one();
+          }));
 
   const size_t length = 5;
   std::string storage(length, '\0');

--- a/test/unit/common/blockaccess/files/test_file_accesser.cc
+++ b/test/unit/common/blockaccess/files/test_file_accesser.cc
@@ -37,6 +37,16 @@ namespace dingofs {
 namespace blockaccess {
 namespace unit_test {
 
+struct AsyncTestState {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool called{false};
+  int completed{0};
+  Status status;
+  std::vector<Status> statuses;
+  std::vector<char> buffer;
+};
+
 class FileAccesserTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -65,6 +75,11 @@ class FileAccesserTest : public ::testing::Test {
     return data;
   }
 
+  Status Put(const std::string& key, const std::string& data) {
+    return accesser_->Put(
+        key, PutPayload::Build({PayloadSegment{data.data(), data.size()}}));
+  }
+
   std::string root_;
   std::unique_ptr<FileAccesser> accesser_;
 };
@@ -75,7 +90,7 @@ TEST_F(FileAccesserTest, PutAndGet) {
   const std::string data = "Hello, DingoFS!";
 
   // Put data
-  Status s = accesser_->Put(key, data.data(), data.size());
+  Status s = Put(key, data);
   ASSERT_TRUE(s.ok()) << "Put failed: " << s.ToString();
 
   // Get data back
@@ -90,7 +105,7 @@ TEST_F(FileAccesserTest, PutLargeData) {
   const size_t data_size = 4 * 1024 * 1024;
   std::string data = GenerateRandomData(data_size);
 
-  Status s = accesser_->Put(key, data.data(), data.size());
+  Status s = Put(key, data);
   ASSERT_TRUE(s.ok()) << "Put large data failed: " << s.ToString();
 
   std::string retrieved_data;
@@ -116,7 +131,7 @@ TEST_F(FileAccesserTest, Range) {
   const std::string data = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   // Put data first
-  Status s = accesser_->Put(key, data.data(), data.size());
+  Status s = Put(key, data);
   ASSERT_TRUE(s.ok()) << "Put failed: " << s.ToString();
 
   // Test range read
@@ -142,7 +157,7 @@ TEST_F(FileAccesserTest, RangeInvalidOffset) {
   const std::string key = "range_key_invalid";
   const std::string data = "Short data";
 
-  Status s = accesser_->Put(key, data.data(), data.size());
+  Status s = Put(key, data);
   ASSERT_TRUE(s.ok()) << "Put failed: " << s.ToString();
 
   char buffer[100];
@@ -157,7 +172,7 @@ TEST_F(FileAccesserTest, BlockExistAndDelete) {
   const std::string data = "To be deleted";
 
   // Put and verify
-  Status s = accesser_->Put(key, data.data(), data.size());
+  Status s = Put(key, data);
   ASSERT_TRUE(s.ok()) << "Put failed: " << s.ToString();
   ASSERT_TRUE(accesser_->BlockExist(key)) << "Key should exist";
 
@@ -189,7 +204,7 @@ TEST_F(FileAccesserTest, BatchDelete) {
 
   // Put all keys
   for (const auto& key : keys) {
-    Status s = accesser_->Put(key, data.data(), data.size());
+    Status s = Put(key, data);
     ASSERT_TRUE(s.ok()) << "Put failed for key: " << key;
   }
 
@@ -212,21 +227,17 @@ TEST_F(FileAccesserTest, BatchDelete) {
 // Test AsyncPut
 TEST_F(FileAccesserTest, AsyncPut) {
   const std::string key = "async_put_key";
-  const std::string data = "Async put data";
+  auto data = std::make_shared<std::string>("Async put data");
+  auto state = std::make_shared<AsyncTestState>();
 
-  std::mutex mtx;
-  std::condition_variable cv;
-  bool callback_called = false;
-  Status async_status;
-
-  auto context = std::make_shared<PutObjectAsyncContext>(key);
-  context->buffer = data.data();
-  context->buffer_size = data.size();
-  context->cb = [&](const PutObjectAsyncContextSPtr& ctx) {
-    std::lock_guard<std::mutex> lock(mtx);
-    async_status = ctx->status;
-    callback_called = true;
-    cv.notify_one();
+  auto context = std::make_shared<PutObjectAsyncContext>(
+      key, PutPayload::Build({PayloadSegment{data->data(), data->size()}}));
+  context->cb = [state, data](const PutObjectAsyncContextSPtr& ctx) {
+    (void)data;
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->status = ctx->status;
+    state->called = true;
+    state->cv.notify_one();
   };
 
   // Execute async put
@@ -234,20 +245,20 @@ TEST_F(FileAccesserTest, AsyncPut) {
 
   // Wait for callback
   {
-    std::unique_lock<std::mutex> lock(mtx);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(10), [&] {
-      return callback_called;
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(state->cv.wait_for(lock, std::chrono::seconds(10), [&] {
+      return state->called;
     })) << "AsyncPut callback timeout";
   }
 
-  ASSERT_TRUE(async_status.ok())
-      << "AsyncPut failed: " << async_status.ToString();
+  ASSERT_TRUE(state->status.ok())
+      << "AsyncPut failed: " << state->status.ToString();
 
   // Verify data was written
   std::string retrieved_data;
   Status s = accesser_->Get(key, &retrieved_data);
   ASSERT_TRUE(s.ok()) << "Get after AsyncPut failed";
-  ASSERT_EQ(data, retrieved_data) << "AsyncPut data mismatch";
+  ASSERT_EQ(*data, retrieved_data) << "AsyncPut data mismatch";
 }
 
 // Test AsyncGet
@@ -256,24 +267,21 @@ TEST_F(FileAccesserTest, AsyncGet) {
   const std::string data = "Async get data";
 
   // Put data first
-  Status s = accesser_->Put(key, data.data(), data.size());
+  Status s = Put(key, data);
   ASSERT_TRUE(s.ok()) << "Put failed: " << s.ToString();
 
-  std::mutex mtx;
-  std::condition_variable cv;
-  bool callback_called = false;
-  Status async_status;
-  std::vector<char> buffer(data.size());
+  auto state = std::make_shared<AsyncTestState>();
+  state->buffer.resize(data.size());
 
   auto context = std::make_shared<GetObjectAsyncContext>(key);
-  context->buf = buffer.data();
+  context->buf = state->buffer.data();
   context->offset = 0;
   context->len = data.size();
-  context->cb = [&](const GetObjectAsyncContextSPtr& ctx) {
-    std::lock_guard<std::mutex> lock(mtx);
-    async_status = ctx->status;
-    callback_called = true;
-    cv.notify_one();
+  context->cb = [state](const GetObjectAsyncContextSPtr& ctx) {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->status = ctx->status;
+    state->called = true;
+    state->cv.notify_one();
   };
 
   // Execute async get
@@ -281,39 +289,38 @@ TEST_F(FileAccesserTest, AsyncGet) {
 
   // Wait for callback
   {
-    std::unique_lock<std::mutex> lock(mtx);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5), [&] {
-      return callback_called;
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(state->cv.wait_for(lock, std::chrono::seconds(5), [&] {
+      return state->called;
     })) << "AsyncGet callback timeout";
   }
 
-  ASSERT_TRUE(async_status.ok())
-      << "AsyncGet failed: " << async_status.ToString();
+  ASSERT_TRUE(state->status.ok())
+      << "AsyncGet failed: " << state->status.ToString();
   ASSERT_EQ(context->actual_len, data.size()) << "AsyncGet size mismatch";
-  ASSERT_EQ(std::string(buffer.data(), context->actual_len), data)
+  ASSERT_EQ(std::string(state->buffer.data(), context->actual_len), data)
       << "AsyncGet data mismatch";
 }
 
 // Test AsyncPut with multiple concurrent requests
 TEST_F(FileAccesserTest, AsyncPutConcurrent) {
   const int num_requests = 10;
-  std::mutex mtx;
-  std::condition_variable cv;
-  int completed_count = 0;
-  std::vector<Status> statuses(num_requests);
+  auto state = std::make_shared<AsyncTestState>();
+  state->statuses.resize(num_requests);
 
   for (int i = 0; i < num_requests; ++i) {
     std::string key = "concurrent_key_" + std::to_string(i);
-    std::string data = "Concurrent data " + std::to_string(i);
+    auto data =
+        std::make_shared<std::string>("Concurrent data " + std::to_string(i));
 
-    auto context = std::make_shared<PutObjectAsyncContext>(key);
-    context->buffer = data.data();
-    context->buffer_size = data.size();
-    context->cb = [&, i, key, data](const PutObjectAsyncContextSPtr& ctx) {
-      std::lock_guard<std::mutex> lock(mtx);
-      statuses[i] = ctx->status;
-      ++completed_count;
-      cv.notify_one();
+    auto context = std::make_shared<PutObjectAsyncContext>(
+        key, PutPayload::Build({PayloadSegment{data->data(), data->size()}}));
+    context->cb = [state, i, data](const PutObjectAsyncContextSPtr& ctx) {
+      (void)data;  // Keep the non-owning payload bytes alive through callback.
+      std::lock_guard<std::mutex> lock(state->mutex);
+      state->statuses[i] = ctx->status;
+      ++state->completed;
+      state->cv.notify_one();
     };
 
     accesser_->AsyncPut(key, context);
@@ -321,17 +328,18 @@ TEST_F(FileAccesserTest, AsyncPutConcurrent) {
 
   // Wait for all callbacks
   {
-    std::unique_lock<std::mutex> lock(mtx);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(10),
-                            [&] { return completed_count == num_requests; }))
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(
+        state->cv.wait_for(lock, std::chrono::seconds(10),
+                           [&] { return state->completed == num_requests; }))
         << "Timeout waiting for concurrent AsyncPut, completed: "
-        << completed_count;
+        << state->completed;
   }
 
   // Verify all succeeded
   for (int i = 0; i < num_requests; ++i) {
-    ASSERT_TRUE(statuses[i].ok())
-        << "AsyncPut " << i << " failed: " << statuses[i].ToString();
+    ASSERT_TRUE(state->statuses[i].ok())
+        << "AsyncPut " << i << " failed: " << state->statuses[i].ToString();
   }
 }
 
@@ -348,7 +356,7 @@ TEST_F(FileAccesserTest, MultiplePutGetCycles) {
   for (int i = 0; i < num_cycles; ++i) {
     std::string data = "Cycle " + std::to_string(i) + " data";
 
-    Status s = accesser_->Put(key, data.data(), data.size());
+    Status s = Put(key, data);
     ASSERT_TRUE(s.ok()) << "Put failed at cycle " << i;
 
     std::string retrieved_data;
@@ -362,32 +370,29 @@ TEST_F(FileAccesserTest, MultiplePutGetCycles) {
 TEST_F(FileAccesserTest, AsyncDelete) {
   const std::string key = "async_delete_key";
   const std::string data = "to be deleted";
-  ASSERT_TRUE(accesser_->Put(key, data.data(), data.size()).ok());
+  ASSERT_TRUE(Put(key, data).ok());
   ASSERT_TRUE(accesser_->BlockExist(key));
 
-  std::mutex mtx;
-  std::condition_variable cv;
-  bool called = false;
-  Status async_status;
+  auto state = std::make_shared<AsyncTestState>();
 
   auto context = std::make_shared<DeleteObjectAsyncContext>(key);
-  context->cb = [&](const DeleteObjectAsyncContextSPtr& ctx) {
-    std::lock_guard<std::mutex> lock(mtx);
-    async_status = ctx->status;
-    called = true;
-    cv.notify_one();
+  context->cb = [state](const DeleteObjectAsyncContextSPtr& ctx) {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->status = ctx->status;
+    state->called = true;
+    state->cv.notify_one();
   };
 
   accesser_->AsyncDelete(key, context);
 
   {
-    std::unique_lock<std::mutex> lock(mtx);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(10), [&] {
-      return called;
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(state->cv.wait_for(lock, std::chrono::seconds(10), [&] {
+      return state->called;
     })) << "AsyncDelete callback timeout";
   }
 
-  ASSERT_TRUE(async_status.ok()) << async_status.ToString();
+  ASSERT_TRUE(state->status.ok()) << state->status.ToString();
   ASSERT_FALSE(accesser_->BlockExist(key)) << "object not removed";
 }
 
@@ -395,27 +400,24 @@ TEST_F(FileAccesserTest, AsyncDelete) {
 TEST_F(FileAccesserTest, AsyncDeleteNonExistent) {
   const std::string key = "async_delete_missing_key";
 
-  std::mutex mtx;
-  std::condition_variable cv;
-  bool called = false;
-  Status async_status;
+  auto state = std::make_shared<AsyncTestState>();
 
   auto context = std::make_shared<DeleteObjectAsyncContext>(key);
-  context->cb = [&](const DeleteObjectAsyncContextSPtr& ctx) {
-    std::lock_guard<std::mutex> lock(mtx);
-    async_status = ctx->status;
-    called = true;
-    cv.notify_one();
+  context->cb = [state](const DeleteObjectAsyncContextSPtr& ctx) {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->status = ctx->status;
+    state->called = true;
+    state->cv.notify_one();
   };
 
   accesser_->AsyncDelete(key, context);
 
   {
-    std::unique_lock<std::mutex> lock(mtx);
-    ASSERT_TRUE(
-        cv.wait_for(lock, std::chrono::seconds(10), [&] { return called; }));
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(state->cv.wait_for(lock, std::chrono::seconds(10),
+                                   [&] { return state->called; }));
   }
-  ASSERT_TRUE(async_status.ok()) << async_status.ToString();
+  ASSERT_TRUE(state->status.ok()) << state->status.ToString();
 }
 
 // Test AsyncBatchDelete fires the callback and removes all objects.
@@ -423,33 +425,30 @@ TEST_F(FileAccesserTest, AsyncBatchDelete) {
   std::list<std::string> keys = {"abd_k1", "abd_k2", "abd_k3"};
   const std::string data = "x";
   for (const auto& k : keys) {
-    ASSERT_TRUE(accesser_->Put(k, data.data(), data.size()).ok());
+    ASSERT_TRUE(Put(k, data).ok());
     ASSERT_TRUE(accesser_->BlockExist(k));
   }
 
-  std::mutex mtx;
-  std::condition_variable cv;
-  bool called = false;
-  Status async_status;
+  auto state = std::make_shared<AsyncTestState>();
 
   auto context = std::make_shared<BatchDeleteObjectAsyncContext>(keys);
-  context->cb = [&](const BatchDeleteObjectAsyncContextSPtr& ctx) {
-    std::lock_guard<std::mutex> lock(mtx);
-    async_status = ctx->status;
-    called = true;
-    cv.notify_one();
+  context->cb = [state](const BatchDeleteObjectAsyncContextSPtr& ctx) {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->status = ctx->status;
+    state->called = true;
+    state->cv.notify_one();
   };
 
   accesser_->AsyncBatchDelete(keys, context);
 
   {
-    std::unique_lock<std::mutex> lock(mtx);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(10), [&] {
-      return called;
+    std::unique_lock<std::mutex> lock(state->mutex);
+    ASSERT_TRUE(state->cv.wait_for(lock, std::chrono::seconds(10), [&] {
+      return state->called;
     })) << "AsyncBatchDelete callback timeout";
   }
 
-  ASSERT_TRUE(async_status.ok()) << async_status.ToString();
+  ASSERT_TRUE(state->status.ok()) << state->status.ToString();
   for (const auto& k : keys) {
     ASSERT_FALSE(accesser_->BlockExist(k)) << "object not removed: " << k;
   }

--- a/test/unit/common/blockaccess/mock/mock_accesser.h
+++ b/test/unit/common/blockaccess/mock/mock_accesser.h
@@ -51,11 +51,7 @@ class MockBlockAccesser : public BlockAccesser {
 
   MOCK_METHOD(bool, ContainerExist, (), (override));
 
-  MOCK_METHOD(Status, Put, (const std::string& key, const std::string& data),
-              (override));
-
-  MOCK_METHOD(Status, Put,
-              (const std::string& key, const char* buffer, size_t length),
+  MOCK_METHOD(Status, Put, (const std::string& key, const PutPayload& payload),
               (override));
 
   MOCK_METHOD(void, AsyncPut,

--- a/test/unit/common/blockaccess/test_block_accesser.cc
+++ b/test/unit/common/blockaccess/test_block_accesser.cc
@@ -24,11 +24,14 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include "common/blockaccess/accesser_common.h"
 #include "common/blockaccess/block_accesser.h"
 #include "common/blockaccess/rados/rados_accesser.h"
+#include "common/blockaccess/s3/aws/aws_s3_common.h"
 #include "common/blockaccess/s3/s3_accesser.h"
+#include "common/io_buffer.h"
 #include "common/status.h"
 
 namespace dingofs {
@@ -64,6 +67,86 @@ class BlockAccesserImplTest : public ::testing::Test {
   std::string root_;
   std::unique_ptr<BlockAccesserImpl> accesser_;
 };
+
+TEST(PutPayloadTest, SharesImmutableSegmentMetadata) {
+  const std::string first = "hello";
+  const std::string second = " world";
+  auto payload = PutPayload::Build(
+      {{first.data(), first.size()}, {second.data(), second.size()}});
+  auto copy = payload;
+
+  EXPECT_EQ(payload.Size(), first.size() + second.size());
+  EXPECT_EQ(payload.SegmentCount(), 2);
+  EXPECT_EQ(copy.Segments().data(), payload.Segments().data());
+}
+
+TEST(PutPayloadDeathTest, RejectsEmptyPayloadAndSegment) {
+  EXPECT_DEATH((void)PutPayload::Build({}), "empty block payload");
+  const char data = 'x';
+  EXPECT_DEATH((void)PutPayload::Build({PayloadSegment{&data, 0}}),
+               "empty segment");
+}
+
+TEST(SegmentedStreamBufTest, ReadsAndSeeksAcrossSegments) {
+  const std::string first = "abc";
+  const std::string second = "defgh";
+  aws::SegmentedIOStream stream(PutPayload::Build(
+      {{first.data(), first.size()}, {second.data(), second.size()}}));
+
+  char output[6] = {};
+  stream.read(output, 5);
+  EXPECT_EQ(std::string(output, 5), "abcde");
+
+  stream.clear();
+  stream.seekg(2, std::ios_base::beg);
+  stream.read(output, 6);
+  EXPECT_EQ(std::string(output, 6), "cdefgh");
+
+  stream.clear();
+  stream.seekg(-3, std::ios_base::end);
+  stream.read(output, 3);
+  EXPECT_EQ(std::string(output, 3), "fgh");
+}
+
+TEST_F(BlockAccesserImplTest, SyncPutAcceptsSegmentedPayload) {
+  const std::string first = "segmented ";
+  const std::string second = "payload";
+  auto payload = PutPayload::Build(
+      {{first.data(), first.size()}, {second.data(), second.size()}});
+
+  ASSERT_TRUE(accesser_->Put("multi_segment", payload).ok());
+  std::string data;
+  ASSERT_TRUE(accesser_->Get("multi_segment", &data).ok());
+  EXPECT_EQ(data, first + second);
+}
+
+TEST_F(BlockAccesserImplTest, AsyncPutAcceptsSegmentedPayload) {
+  const std::string first = "async ";
+  const std::string second = "segments";
+  auto ctx = std::make_shared<PutObjectAsyncContext>(
+      "async_multi", PutPayload::Build({{first.data(), first.size()},
+                                        {second.data(), second.size()}}));
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool complete = false;
+  ctx->cb = [&](const PutObjectAsyncContextSPtr& result) {
+    std::lock_guard<std::mutex> lock(mutex);
+    EXPECT_TRUE(result->status.ok()) << result->status.ToString();
+    complete = true;
+    cv.notify_one();
+  };
+  accesser_->AsyncPut(ctx->origin_key, ctx);
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(
+        cv.wait_for(lock, std::chrono::seconds(10), [&] { return complete; }));
+  }
+
+  std::string data;
+  ASSERT_TRUE(accesser_->Get("async_multi", &data).ok());
+  EXPECT_EQ(data, first + second);
+}
 
 // The wrapper installs its own callback (log + bvar), but must restore the
 // caller's original callback before invoking it, so the caller can reuse the

--- a/test/unit/common/blockaccess/test_prefix_block_accesser.cc
+++ b/test/unit/common/blockaccess/test_prefix_block_accesser.cc
@@ -59,9 +59,8 @@ TEST(PrefixBlockAccesserTest, AsyncPutRetryDoesNotAccumulatePrefix) {
   const std::string logical_key = "blocks/100/100/100_0_4096";
 
   static const char kData[] = "data";
-  auto ctx = std::make_shared<PutObjectAsyncContext>(logical_key);
-  ctx->buffer = kData;
-  ctx->buffer_size = sizeof(kData);
+  auto ctx = std::make_shared<PutObjectAsyncContext>(
+      logical_key, PutPayload::Build({PayloadSegment{kData, sizeof(kData)}}));
   ctx->cb = [](const PutObjectAsyncContextSPtr&) {};
 
   // Simulate first call + 4 retries — caller passes the SAME ctx and
@@ -130,15 +129,18 @@ TEST(PrefixBlockAccesserTest, SyncPutPrefixesKeyOnce) {
   auto mock_inner = std::make_unique<MockBlockAccesser>();
   std::string seen_key;
 
-  EXPECT_CALL(*mock_inner, Put(_, ::testing::A<const char*>(), _))
-      .WillRepeatedly(Invoke([&](const std::string& key, const char*, size_t) {
-        seen_key = key;
-        return Status::OK();
-      }));
+  EXPECT_CALL(*mock_inner, Put(_, ::testing::A<const PutPayload&>()))
+      .WillRepeatedly(
+          Invoke([&](const std::string& key, const PutPayload& payload) {
+            seen_key = key;
+            EXPECT_EQ(payload.Size(), sizeof("hello"));
+            return Status::OK();
+          }));
 
   PrefixBlockAccesser wrapper("fs", std::move(mock_inner));
   static const char kData[] = "hello";
-  ASSERT_TRUE(wrapper.Put("a/b/c", kData, sizeof(kData)).ok());
+  ASSERT_TRUE(
+      wrapper.Put("a/b/c", PutPayload::Build({{kData, sizeof(kData)}})).ok());
   EXPECT_EQ(seen_key, "fs/a/b/c");
 }
 

--- a/test/unit/common/test_fake_accesser.cc
+++ b/test/unit/common/test_fake_accesser.cc
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include "common/blockaccess/fake/fake_accesser.h"
-
 #include <gtest/gtest.h>
 
 #include <future>
+
+#include "common/blockaccess/fake/fake_accesser.h"
 
 namespace dingofs {
 namespace blockaccess {
@@ -45,7 +45,10 @@ TEST_F(FakeAccesserTest, ContainerAlwaysExists) {
 
 TEST_F(FakeAccesserTest, PutAlwaysSucceeds) {
   const char data[] = "payload";
-  EXPECT_TRUE(accesser_.Put("key", data, sizeof(data)).ok());
+  EXPECT_TRUE(
+      accesser_
+          .Put("key", PutPayload::Build({PayloadSegment{data, sizeof(data)}}))
+          .ok());
 }
 
 TEST_F(FakeAccesserTest, GetFillsFixedSizeBuffer) {
@@ -56,9 +59,8 @@ TEST_F(FakeAccesserTest, GetFillsFixedSizeBuffer) {
 
 TEST_F(FakeAccesserTest, RangeReadSucceedsWithoutTouchingKeyOrOffset) {
   std::vector<char> buffer(128, 'x');
-  EXPECT_TRUE(accesser_.Range("key", /*offset=*/64, buffer.size(),
-                              buffer.data())
-                  .ok());
+  EXPECT_TRUE(
+      accesser_.Range("key", /*offset=*/64, buffer.size(), buffer.data()).ok());
 }
 
 TEST_F(FakeAccesserTest, BlockExistAlwaysTrue) {
@@ -75,9 +77,8 @@ TEST_F(FakeAccesserTest, BatchDeleteAlwaysSucceeds) {
 
 TEST_F(FakeAccesserTest, AsyncPutInvokesCallbackWithOkStatus) {
   const char data[] = "payload";
-  auto context = std::make_shared<PutObjectAsyncContext>("key");
-  context->buffer = data;
-  context->buffer_size = sizeof(data);
+  auto context = std::make_shared<PutObjectAsyncContext>(
+      "key", PutPayload::Build({PayloadSegment{data, sizeof(data)}}));
 
   std::promise<Status> promise;
   auto future = promise.get_future();
@@ -119,9 +120,8 @@ TEST_F(FakeAccesserTest, AsyncDeleteInvokesCallbackWithOkStatus) {
 }
 
 TEST_F(FakeAccesserTest, AsyncBatchDeleteInvokesCallbackWithOkStatus) {
-  auto context =
-      std::make_shared<BatchDeleteObjectAsyncContext>(std::list<std::string>{
-          "a", "b"});
+  auto context = std::make_shared<BatchDeleteObjectAsyncContext>(
+      std::list<std::string>{"a", "b"});
 
   std::promise<Status> promise;
   auto future = promise.get_future();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

The write-through block cache path currently coalesces a segmented `IOBuffer` into a newly allocated contiguous buffer before passing it to `StorageClient`. This adds one full-block allocation and copy even though the original block pages are already available for the duration of the asynchronous upload.

### What is changed and how it works?

What's Changed:

- Add immutable `PutPayload`/`PayloadSegment` types to the block access boundary.
- Pass segmented block data from `TierBlockCache` to `StorageClient` without `CopyBlock()`.
- Add segmented body streams for both legacy and CRT AWS S3 clients.
- Use librados write operations to append payload segments without a DingoFS-side coalescing copy.
- Migrate file, fake, prefix, benchmark, throttle/accounting, and test call sites.
- Keep non-empty payload as a checked BlockAccess contract.

How it Works:

`BlockData::ToIOBuffer()` exposes page-backed segments. The storage adapter converts those segments to a `PutPayload`, whose shared immutable representation keeps segment metadata stable across asynchronous request copies. S3 reads the payload through a seekable segmented stream; RADOS appends each segment to a write operation. Payload byte lifetime remains the caller's responsibility through callback completion.

Side effects(Breaking backward compatibility? Performance regression?):

- Internal BlockAccess `Put` implementations now consume `PutPayload`; string and pointer overloads remain convenience wrappers.
- Empty convenience `Put` calls return `InvalidParam`.
- This removes a DingoFS coalescing copy but does not claim physical end-to-end zero-copy through AWS SDK/TLS/socket layers.
- Local elbencho A/B results on the same upstream commit showed no regression: single-thread DIRECT=1 improved 2.16%-4.63%, four-thread improved 8.35%; equal-throughput perf runs reduced client task-clock by 25.72% and cycles by 29.28%.

### Validation

- `dingo-client` RelWithDebInfo build passed.
- 42 focused BlockAccess/PutPayload/File/Fake tests passed.
- S3 baseline/optimized smoke tests passed against MinIO.
- Three-round elbencho A/B and perf stat/profile validation completed.

### Check List

- [x] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license
