### PR TITLE
[fix][test] Fix SliceWriter lifecycle test races (flush drain barrier + AsyncWaiter)

### DIFF
--- a/test/unit/client/vfs/data/test_slice_writer.cc
+++ b/test/unit/client/vfs/data/test_slice_writer.cc
@@ -1260,17 +1260,17 @@ TEST_F(SliceWriterStreamingTest,
   });
   flush_waiter.Wait();
 
-  test::AsyncWaiter flush_drained;
-  flush_drained.Expect(1);
-  flush_executor_->Execute([&]() { flush_drained.Done(); });
-  flush_drained.Wait();
+  // Stop() joins the flush threads, so the DoFlush task -- the only async
+  // holder of a SliceWriter reference -- is destroyed before the expiry check.
+  // A drain task is not a barrier here: the pool has 2 threads, so it can
+  // finish on the idle thread while DoFlush is still unwinding on the other.
+  EXPECT_TRUE(flush_executor_->Stop());
 
   sw.reset();
   EXPECT_TRUE(weak_writer.expired());
 
   // A callback arriving after an earlier Fail only cleans up its barrier entry;
   // it has no dependency on SliceWriter or FlushExecutor.
-  EXPECT_TRUE(flush_executor_->Stop());
   StatusCallback late = take_callback(1);
   ASSERT_TRUE(static_cast<bool>(late));
   late(Status::OK());
@@ -1308,10 +1308,10 @@ TEST_F(SliceWriterStreamingTest,
   ASSERT_EQ(submitted_future.wait_for(std::chrono::seconds(5)),
             std::future_status::ready);
 
-  test::AsyncWaiter flush_drained;
-  flush_drained.Expect(1);
-  flush_executor_->Execute([&]() { flush_drained.Done(); });
-  flush_drained.Wait();
+  // Stop() joins the flush threads, so the DoFlush task -- the only async
+  // holder of a SliceWriter reference -- is destroyed before the expiry check
+  // (see UT13; a drain task is not a barrier on the 2-thread pool).
+  ASSERT_TRUE(flush_executor_->Stop());
 
   sw.reset();
   EXPECT_TRUE(weak_writer.expired());

--- a/test/unit/client/vfs/test_common.h
+++ b/test/unit/client/vfs/test_common.h
@@ -17,9 +17,9 @@
 #ifndef DINGOFS_TEST_UNIT_CLIENT_VFS_TEST_COMMON_H_
 #define DINGOFS_TEST_UNIT_CLIENT_VFS_TEST_COMMON_H_
 
+#include <glog/logging.h>
 #include <gtest/gtest.h>
 
-#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
@@ -38,26 +38,40 @@ namespace test {
 //   waiter.Expect(N);
 //   ... submit N ops, each calling waiter.Done() in callback ...
 //   waiter.Wait();
+// A timed-out Wait() only records an EXPECT failure; the callbacks it was
+// waiting for are still queued and still reference this object. The destructor
+// drains them before the stack frame dies -- otherwise a late Done() writes to
+// a dead frame, and its continuation may Execute() on an already-stopped
+// executor (SIGSEGV / CHECK abort seen under heavy scheduler starvation).
 struct AsyncWaiter {
   std::mutex mtx;
   std::condition_variable cv;
-  std::atomic<int> pending{0};
+  int pending{0};  // guarded by mtx (destructor handshake needs the lock)
 
-  void Expect(int n) { pending.store(n, std::memory_order_relaxed); }
+  ~AsyncWaiter() {
+    std::unique_lock<std::mutex> lk(mtx);
+    bool drained = cv.wait_for(lk, std::chrono::seconds(60),
+                               [this] { return pending <= 0; });
+    CHECK(drained) << "AsyncWaiter destroyed with " << pending
+                   << " callback(s) still pending";
+  }
+
+  void Expect(int n) {
+    std::lock_guard<std::mutex> lk(mtx);
+    pending = n;
+  }
 
   void Done() {
-    if (pending.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      std::lock_guard<std::mutex> lk(mtx);
+    std::lock_guard<std::mutex> lk(mtx);
+    if (--pending <= 0) {
       cv.notify_all();
     }
   }
 
   void Wait(std::chrono::seconds timeout = std::chrono::seconds(10)) {
     std::unique_lock<std::mutex> lk(mtx);
-    cv.wait_for(lk, timeout, [this] {
-      return pending.load(std::memory_order_acquire) == 0;
-    });
-    EXPECT_EQ(pending.load(std::memory_order_relaxed), 0);
+    cv.wait_for(lk, timeout, [this] { return pending <= 0; });
+    EXPECT_EQ(pending, 0);
   }
 };
 


### PR DESCRIPTION
## Problem

`SliceWriterStreamingTest.UT14_MissingUploadCallbackDoesNotCreateWriterBarrierCycle` failed on CI (run 29896215769, unrelated PR branch) at `test_slice_writer.cc:1317`: `weak_writer.expired()` was false after `sw.reset()`.

Two independent races in the test infrastructure, both reproduced and verified under 32-way parallel contention (16k+ iterations each configuration):

### 1. Drain-task barrier is not a barrier (UT13 / UT14)

`FlushAsync` hands `self = shared_from_this()` to the flush executor task running `DoFlush`; that task is the only async holder of a `SliceWriter` reference. UT13/UT14 waited for `DoFlush` to finish by posting a drain task to `flush_executor_` — but the test fixture's flush pool has 2 threads with a shared queue, so the drain task can complete on the idle thread while `DoFlush` is still unwinding on the other. The subsequent `weak_writer.expired()` check then races with the task destroying its captured `self`.

Repro (unpatched): 30/30 instances failed — 2123 hits at UT14's check, 135 at UT13's (same latent race, narrower window).

Fix: stop the flush executor before the expiry check. `Stop()` joins the worker threads, and the worker loop destroys each task at end of iteration, so join gives a happens-before edge to the reference release. UT13 already stopped the executor later in the test; the stop is only moved up. No timing constants involved.

### 2. AsyncWaiter completion/destruction race (all users of the helper)

`AsyncWaiter::Done()` decremented the atomic counter outside the mutex and only then locked to notify. A waiter woken between the decrement and the lock (e.g. spurious wake) sees `pending == 0`, returns from `Wait()`, and the test destroys the stack-allocated waiter while `Done()` is about to lock the now-dead mutex:

```
Fatal glibc error: pthread_mutex_lock.c:95 (___pthread_mutex_lock):
assertion failed: mutex->__data.__owner == 0
```

Repro: 5/32 instances crashed (4 SIGABRT, 1 SIGSEGV) with the tests from fix 1 already applied, so the two issues are independent. No `Wait()` timeout is needed — this fires on the happy path.

Fix: counter mutation and notification now happen under the mutex, so a waiter can only observe completion after `Done()` has released the lock. The destructor additionally drains pending callbacks (bounded, CHECK on overrun) so a timed-out `Wait()` can no longer let queued callbacks outlive the stack frame. Call sites are unchanged.

## Verification

- Full `test_client`: 384 tests / 45 suites pass.
- UT13+UT14, 32 parallel instances x 400 repeats (12,800 iterations) under full CPU contention: 0 failures, 0 signals (was: 30/30 assertion failures; 5/32 crashes).
- All `AsyncWaiter`-using suites (SliceWriter/ChunkWriter/FlushTask/Prefetch), 8 parallel x 50 repeats: clean.
