### PR TITLE
[feat][common] Configure AWS CRT S3 throughput target

### DIFF
--- a/src/common/blockaccess/s3/aws/aws_crt_s3_client.cc
+++ b/src/common/blockaccess/s3/aws/aws_crt_s3_client.cc
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <any>
+#include <cmath>
 #include <memory>
 
 #include "aws/s3-crt/model/DeleteObjectRequest.h"
@@ -61,6 +62,17 @@ void AwsCrtS3Client::Init(const S3Options& options) {
     config->verifySSL = options.aws_sdk_config.verify_ssl;
     config->region = options.aws_sdk_config.region;
     config->maxConnections = options.aws_sdk_config.max_connections;
+    if (options.aws_sdk_config.crt_throughput_target_gbps > 0) {
+      // crt ignores maxConnections; its connection count is
+      // ceil(throughputTargetGbps / 0.4Gbps-per-connection).
+      config->throughputTargetGbps =
+          static_cast<double>(
+              options.aws_sdk_config.crt_throughput_target_gbps);
+      LOG(INFO) << fmt::format(
+          "[s3_crt] throughputTargetGbps={} (~{} connections).",
+          config->throughputTargetGbps,
+          static_cast<int>(std::ceil(config->throughputTargetGbps / 0.4)));
+    }
     config->connectTimeoutMs = options.aws_sdk_config.connect_timeout;
     config->requestTimeoutMs = options.aws_sdk_config.request_timeout;
     config->useVirtualAddressing =

--- a/src/common/blockaccess/s3/s3_common.h
+++ b/src/common/blockaccess/s3/s3_common.h
@@ -50,6 +50,9 @@ struct AwsSdkConfig {
   int request_timeout{10000};
 
   bool use_crt_client{true};
+  // >0 overrides crt throughputTargetGbps (real concurrency knob on the
+  // crt path); 0 keeps the sdk default of 10.0 (=25 connections).
+  int crt_throughput_target_gbps{20};
 
   bool use_thread_pool{true};  // this only work when use_crt_client is false
   int async_thread_num{16};    // this only work when use_crt_client is false
@@ -84,6 +87,8 @@ inline void InitAwsSdkConfig(AwsSdkConfig* aws_sdk_config) {
   aws_sdk_config->request_timeout = FLAGS_s3_request_timeout;
 
   aws_sdk_config->use_crt_client = FLAGS_s3_use_crt_client;
+  aws_sdk_config->crt_throughput_target_gbps =
+      FLAGS_s3_crt_throughput_target_gbps;
   if (aws_sdk_config->use_crt_client) {
     LOG(INFO) << "s3 use crt client.";
   }

--- a/src/common/options/blockaccess.cc
+++ b/src/common/options/blockaccess.cc
@@ -29,6 +29,11 @@ DEFINE_string(s3_region, "us-east-1", "aws s3 region");
 DEFINE_int32(s3_loglevel, 4, "aws sdk log level");
 DEFINE_bool(s3_verify_ssl, false, "whether to verify ssl");
 DEFINE_int32(s3_max_connections, 32, "max connections to s3");
+DEFINE_int32(s3_crt_throughput_target_gbps, 20,
+              "crt client throughput target in Gbps; crt derives its real "
+              "connection count from ceil(target/0.4), maxConnections is "
+              "ignored on the crt path. Defaults to 20; 0 keeps the sdk "
+              "default (10.0 -> 25 connections)");
 DEFINE_int32(s3_connect_timeout, 60000, "s3 connect timeout in milliseconds");
 DEFINE_int32(s3_request_timeout, 10000, "s3 request timeout in milliseconds");
 DEFINE_bool(s3_use_crt_client, true, "whether to use crt client");

--- a/src/common/options/blockaccess.h
+++ b/src/common/options/blockaccess.h
@@ -29,6 +29,7 @@ DECLARE_string(s3_region);
 DECLARE_int32(s3_loglevel);
 DECLARE_bool(s3_verify_ssl);
 DECLARE_int32(s3_max_connections);
+DECLARE_int32(s3_crt_throughput_target_gbps);
 DECLARE_int32(s3_connect_timeout);
 DECLARE_int32(s3_request_timeout);
 DECLARE_bool(s3_use_crt_client);


### PR DESCRIPTION
## What

- add `--s3_crt_throughput_target_gbps` for the AWS CRT S3 client
- default the target to 20 Gbps
- preserve the AWS SDK default when explicitly set to 0
- log the approximate connection count derived by CRT

The CRT S3 path derives connection concurrency from `throughputTargetGbps`; `maxConnections` applies to the legacy client and does not control CRT concurrency.

## Verification

- `git diff --check`
- `cmake --build build --target aws_s3_adapter blockaccess_options test_blockaccess -j4`
- `ctest --test-dir build -R blockaccess --output-on-failure` (no blockaccess tests are registered with CTest on this branch)
