### PR TITLE
[feat][client] Introduce batched CPU-local WritePagePool.

### DIFF
--- a/src/cache/common/memory_pool.cc
+++ b/src/cache/common/memory_pool.cc
@@ -20,7 +20,7 @@
  * Author: Jingli Chen (Wine93)
  */
 
-#include "common/writemempool/memory_pool.h"
+#include "cache/common/memory_pool.h"
 
 #include <glog/logging.h>
 #include <sys/mman.h>
@@ -94,10 +94,10 @@ uint32_t MemoryPool::ThreadSlot() {
 //
 // Safe under concurrent pops: the NextOf(idx) read may be stale if idx was
 // concurrently popped and reused, but that value is only ever fed back into the
-// CAS, never dereferenced -- and a stale read implies the head moved, so the CAS
-// fails and we report contention. This is the crucial difference from a batch
-// pop that walks interior next-pointers, which would dereference a reused node
-// (NextOf(garbage)) and fault.
+// CAS, never dereferenced -- and a stale read implies the head moved, so the
+// CAS fails and we report contention. This is the crucial difference from a
+// batch pop that walks interior next-pointers, which would dereference a reused
+// node (NextOf(garbage)) and fault.
 uint32_t MemoryPool::TryPopFromShard(Shard& shard) {
   uint64_t old_head = shard.head.load(std::memory_order_acquire);
   uint32_t idx = Idx(old_head);
@@ -121,11 +121,11 @@ char* MemoryPool::TryRequireFromShard(Shard& shard) {
 }
 
 // Refill the thread cache one version-checked CAS at a time. An earlier version
-// popped a whole batch per CAS by walking interior next-pointers, but that races
-// with concurrent pops that reuse those nodes mid-walk -- NextOf(reused) becomes
-// a wild index and the next hop faults. Popping one node at a time never
-// dereferences anything but the current head, so it is race-safe; the extra CAS
-// per buffer only lands on the cold cache-refill path.
+// popped a whole batch per CAS by walking interior next-pointers, but that
+// races with concurrent pops that reuse those nodes mid-walk -- NextOf(reused)
+// becomes a wild index and the next hop faults. Popping one node at a time
+// never dereferences anything but the current head, so it is race-safe; the
+// extra CAS per buffer only lands on the cold cache-refill path.
 void MemoryPool::RefillCacheFromShards(Cache& c, uint32_t start_shard) {
   for (uint32_t i = 0; i < kNumShards && c.size < kRefillBatch; ++i) {
     Shard& s = shards_[(start_shard + i) % kNumShards];

--- a/src/cache/common/memory_pool.h
+++ b/src/cache/common/memory_pool.h
@@ -20,8 +20,8 @@
  * Author: Jingli Chen (Wine93)
  */
 
-#ifndef DINGOFS_SRC_COMMON_WRITEMEMPOOL_MEMORY_POOL_H_
-#define DINGOFS_SRC_COMMON_WRITEMEMPOOL_MEMORY_POOL_H_
+#ifndef DINGOFS_SRC_CACHE_COMMON_MEMORY_POOL_H_
+#define DINGOFS_SRC_CACHE_COMMON_MEMORY_POOL_H_
 
 #include <glog/logging.h>
 
@@ -116,4 +116,4 @@ class MemoryPool {
 
 }  // namespace dingofs
 
-#endif  // DINGOFS_SRC_COMMON_WRITEMEMPOOL_MEMORY_POOL_H_
+#endif  // DINGOFS_SRC_CACHE_COMMON_MEMORY_POOL_H_

--- a/src/cache/common/slab_allocator.h
+++ b/src/cache/common/slab_allocator.h
@@ -33,7 +33,7 @@
 #include <vector>
 
 #include "common/const.h"
-#include "common/writemempool/memory_pool.h"
+#include "cache/common/memory_pool.h"
 
 namespace dingofs {
 namespace cache {

--- a/src/cache/infiniband/memory.cc
+++ b/src/cache/infiniband/memory.cc
@@ -37,7 +37,7 @@
 #include "cache/infiniband/infiniband.h"
 #include "common/options/cache.h"
 #include "common/status.h"
-#include "common/writemempool/memory_pool.h"
+#include "cache/common/memory_pool.h"
 
 namespace dingofs {
 namespace cache {

--- a/src/cache/infiniband/memory.h
+++ b/src/cache/infiniband/memory.h
@@ -33,7 +33,7 @@
 #include "cache/infiniband/common.h"
 #include "cache/infiniband/infiniband.h"
 #include "common/status.h"
-#include "common/writemempool/memory_pool.h"
+#include "cache/common/memory_pool.h"
 
 namespace dingofs {
 namespace cache {

--- a/src/client/vfs/data/slice/block_data.cc
+++ b/src/client/vfs/data/slice/block_data.cc
@@ -33,18 +33,16 @@ namespace vfs {
 void BlockData::FreePageData() {
   VLOG(6) << fmt::format("{} FreePageData, block_data: {}", UUID(), ToString());
 
-  for (auto it = pages_.begin(); it != pages_.end();) {
-    uint32_t page_index = it->first;
-    PageData* page_data = it->second.get();
+  std::vector<char*> pages;
+  pages.reserve(pages_.size());
+  for (const auto& [page_index, page_data] : pages_) {
     CHECK_NOTNULL(page_data->page);
-
-    write_buffer_manager_->DeAllocate(page_data->page);
-
+    pages.push_back(page_data->page);
     VLOG(16) << fmt::format("{} Deallocating page at: {}", UUID(),
                             Helper::Char2Addr(page_data->page));
-
-    it = pages_.erase(it);
   }
+  pages_.clear();
+  write_buffer_manager_->DeAllocateBatch(pages.data(), pages.size());
 }
 
 PageData* BlockData::FindPageData(uint32_t page_index) {
@@ -68,46 +66,54 @@ Status BlockData::ReservePages(int32_t size, int32_t block_offset,
   uint32_t page_index = block_offset / page_size;
   int32_t page_offset = block_offset % page_size;
   int32_t remain_len = size;
-
-  // Allocate only the pages this write actually needs. Existing pages (e.g. a
-  // partially-filled straddle page) need no allocation and are NOT recorded, so
-  // a later RollbackPages won't free pages that predate this transaction. The
-  // first new page keeps its in-page offset; later pages start at 0 -- this
-  // matches the data_offset PageData::Write's contiguity CHECK expects.
+  std::vector<uint32_t> missing_indexes;
   while (remain_len > 0) {
     int32_t write_size = std::min(remain_len, page_size - page_offset);
     if (FindPageData(page_index) == nullptr) {
-      char* page = write_buffer_manager_->TryAllocate();
-      if (page == nullptr) {
-        return Status::NoSpace("write page pool exhausted");
-      }
-      auto [iter, inserted] = pages_.emplace(
-          page_index,
-          std::make_unique<PageData>(vfs_hub_, page_index, context_.page_size,
-                                     page, page_offset));
-      CHECK(inserted);
-      created_pages->push_back(page_index);
-      VLOG(12) << fmt::format(
-          "{} Reserved new page_data: {} for page index: {}", UUID(),
-          iter->second->ToString(), page_index);
+      missing_indexes.push_back(page_index);
     }
     remain_len -= write_size;
     page_offset = 0;
     ++page_index;
   }
-  return Status::OK();
+
+  if (missing_indexes.empty()) return Status::OK();
+  std::vector<char*> allocated(missing_indexes.size());
+  const size_t allocated_count = write_buffer_manager_->TryAllocateBatch(
+      allocated.size(), allocated.data());
+  const uint32_t first_page_index =
+      static_cast<uint32_t>(block_offset / page_size);
+  const int32_t first_page_offset = block_offset % page_size;
+  for (size_t i = 0; i < allocated_count; ++i) {
+    const uint32_t new_page_index = missing_indexes[i];
+    auto [iter, inserted] = pages_.emplace(
+        new_page_index,
+        std::make_unique<PageData>(
+            vfs_hub_, new_page_index, context_.page_size, allocated[i],
+            new_page_index == first_page_index ? first_page_offset : 0));
+    CHECK(inserted);
+    created_pages->push_back(new_page_index);
+    VLOG(12) << fmt::format("{} Reserved new page_data: {} for page index: {}",
+                            UUID(), iter->second->ToString(), new_page_index);
+  }
+  return allocated_count == missing_indexes.size()
+             ? Status::OK()
+             : Status::NoSpace("write page pool exhausted");
 }
 
 void BlockData::RollbackPages(const std::vector<uint32_t>& created_pages) {
+  std::vector<char*> pages;
+  pages.reserve(created_pages.size());
   for (uint32_t idx : created_pages) {
     auto it = pages_.find(idx);
     if (it != pages_.end()) {
       if (it->second->page != nullptr) {
-        write_buffer_manager_->DeAllocate(it->second->page);
+        pages.push_back(it->second->page);
       }
       pages_.erase(it);
     }
   }
+  write_buffer_manager_->DeAllocateBatch(pages.data(), pages.size());
   VLOG(6) << fmt::format("{} RollbackPages freed {} pages", UUID(),
                          created_pages.size());
 }

--- a/src/client/vfs/data/slice/block_data.h
+++ b/src/client/vfs/data/slice/block_data.h
@@ -52,10 +52,10 @@ class BlockData {
 
   // Phase 1: ensure every page this write needs exists; allocate only, no
   // memcpy, no len_ bump. New pages are appended to *created_pages (existing
-  // pages are skipped, not recorded). Allocates via TryAllocate (never blocks
-  // under the slice lock); on a miss returns NoSpace WITHOUT self-rollback so
-  // the caller can also undo pages it reserved in other blocks of the same
-  // SliceWriter transaction.
+  // pages are skipped, not recorded). Allocates via TryAllocateBatch (never
+  // waits for capacity under the slice lock); on a short allocation returns
+  // NoSpace WITHOUT self-rollback so the caller can also undo pages it
+  // reserved in other blocks of the same SliceWriter transaction.
   Status ReservePages(int32_t size, int32_t block_offset,
                       std::vector<uint32_t>* created_pages);
 

--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -218,7 +218,7 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
       // successful short write; the outcome is recorded uniformly in
       // VFSWrapper's access log (status + out_wsize), the pool-pressure
       // locality in SliceWriter, and the failure rate in the
-      // vfs_write_pool_alloc_fail_num metric.
+      // vfs_write_buffer_alloc_fail_num metric.
       VLOG(3) << "stop write at chunk, ino: " << ino_
               << ", chunk_index: " << chunk_index
               << ", chunk_offset: " << chunk_offset

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -711,7 +711,7 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
   // No status logging here: VFSImpl returns Status without logging per-op
   // outcomes (like the other ops); the uniform status + out_wsize record lives
   // in VFSWrapper's access log, the pool-pressure locality in SliceWriter, and
-  // the failure rate in the vfs_write_pool_alloc_fail_num metric.
+  // the failure rate in the vfs_write_buffer_alloc_fail_num metric.
   return s;
 }
 

--- a/src/common/readmempool/CMakeLists.txt
+++ b/src/common/readmempool/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Self-contained read memory pool: buddy over arena (+ slab/TLS). No dependency on common/writemempool/memory_pool.
+# Self-contained read memory pool: buddy over arena (+ slab/TLS). No dependency
+# on cache/common/memory_pool.
 # Links brpc for bvar::Adder metrics counters (per-thread sharded, lock-free).
 add_library(dingofs_read_mempool
     arena.cc

--- a/src/common/readmempool/read_mem_pool_vars.h
+++ b/src/common/readmempool/read_mem_pool_vars.h
@@ -27,8 +27,8 @@
 
 namespace dingofs {
 
-// Every var is named "{prefix}_read_mempool_{metric}" (built once, here).
-#define DINGOFS_RMP_NAME(metric) (prefix + "_read_mempool_" metric)
+// Every var is named "{prefix}_read_buffer_{metric}" (built once, here).
+#define DINGOFS_RMP_NAME(metric) (prefix + "_read_buffer_" metric)
 
 // A PassiveStatus<int64_t> whose scrape thunk reads one pool getter. A
 // captureless lambda decays to the int64_t(*)(void*) the ctor wants (+[] pins
@@ -39,7 +39,7 @@ namespace dingofs {
   }, pool)
 
 // Publishes a (singleton) ReadMemPool's metrics under brpc /vars as
-// {prefix}_read_mempool_* (the caller supplies the subsystem prefix, e.g.
+// {prefix}_read_buffer_* (the caller supplies the subsystem prefix, e.g.
 // "vfs", so this common component doesn't bake in a client naming convention).
 // The pool itself keeps anonymous bvar::Adder counters (so multiple pool
 // instances don't collide on global bvar names); this layer wraps named
@@ -47,14 +47,13 @@ namespace dingofs {
 // pool; its lifetime must be a subset of the pool's.
 //
 // usage_ratio is intentionally NOT exposed: derive it monitoring-side from
-// outstanding_bytes / total_bytes.
+// used_bytes / total_bytes.
 class ReadMemPoolVars {
  public:
   ReadMemPoolVars(ReadMemPool* pool, const std::string& prefix)
       : total_bytes_(DINGOFS_RMP_NAME("total_bytes"),
                      static_cast<int64_t>(pool->TotalSize())),
-        DINGOFS_RMP_VAR(outstanding_bytes_, "outstanding_bytes",
-                        OutstandingBytes),
+        DINGOFS_RMP_VAR(used_bytes_, "used_bytes", OutstandingBytes),
         DINGOFS_RMP_VAR(buddy_used_bytes_, "buddy_used_bytes", BuddyUsedBytes),
         DINGOFS_RMP_VAR(slab_occupied_bytes_, "slab_occupied_bytes",
                         SlabOccupiedBytes),
@@ -71,7 +70,7 @@ class ReadMemPoolVars {
 
  private:
   bvar::Status<int64_t> total_bytes_;
-  bvar::PassiveStatus<int64_t> outstanding_bytes_;
+  bvar::PassiveStatus<int64_t> used_bytes_;
   bvar::PassiveStatus<int64_t> buddy_used_bytes_;
   bvar::PassiveStatus<int64_t> slab_occupied_bytes_;
   bvar::PassiveStatus<int64_t> slab_used_bytes_;

--- a/src/common/readmempool/tls_cache.h
+++ b/src/common/readmempool/tls_cache.h
@@ -28,7 +28,7 @@
 namespace dingofs {
 
 // Concurrent fast-path cache for buddy's small/mid classes. Modeled on
-// common/writemempool/memory_pool's per-thread Cache, but **without
+// cache/common/memory_pool's per-thread Cache, but **without
 // thread_local**: a fixed
 // array of cache slots (caches_[kNumCaches]); a thread maps to one slot via a
 // thread-local slot id (threads beyond kNumCaches share, guarded by an

--- a/src/common/writemempool/CMakeLists.txt
+++ b/src/common/writemempool/CMakeLists.txt
@@ -14,7 +14,6 @@
 # Define the BASE_FLAGS and DINGO_DEFAULT_COPTS variables
 
 add_library(dingofs_write_mempool
-    memory_pool.cc
     write_mem_pool.cc
 )
 target_link_libraries(dingofs_write_mempool
@@ -22,4 +21,5 @@ target_link_libraries(dingofs_write_mempool
     gflags::gflags
     brpc::brpc
     fmt::fmt
+    cache_common
 )

--- a/src/common/writemempool/CMakeLists.txt
+++ b/src/common/writemempool/CMakeLists.txt
@@ -14,6 +14,8 @@
 # Define the BASE_FLAGS and DINGO_DEFAULT_COPTS variables
 
 add_library(dingofs_write_mempool
+    cpu_local.cc
+    write_page_pool.cc
     write_mem_pool.cc
 )
 target_link_libraries(dingofs_write_mempool
@@ -21,5 +23,14 @@ target_link_libraries(dingofs_write_mempool
     gflags::gflags
     brpc::brpc
     fmt::fmt
+)
+
+add_executable(write_mem_pool_bench EXCLUDE_FROM_ALL
+    bench/write_mem_pool_bench.cc
+)
+target_link_libraries(write_mem_pool_bench
+    dingofs_write_mempool
     cache_common
+    glog::glog
+    gflags::gflags
 )

--- a/src/common/writemempool/bench/write_mem_pool_bench.cc
+++ b/src/common/writemempool/bench/write_mem_pool_bench.cc
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <pthread.h>
+#include <sched.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "cache/common/memory_pool.h"
+#include "common/writemempool/write_page_pool.h"
+
+DEFINE_uint32(threads, 1, "Number of allocation threads.");
+DEFINE_uint32(iterations, 1000, "Iterations per thread.");
+DEFINE_uint32(batch_pages, 16, "Pages acquired and released per iteration.");
+DEFINE_uint32(alloc_batches_per_release, 1,
+              "Allocation batches accumulated before one ReleaseBatch; use 4 "
+              "to model four 1MiB writes filling one 4MiB block.");
+DEFINE_uint64(page_size, 64 * 1024, "Page size in bytes.");
+DEFINE_bool(touch_pages, true, "Memset every acquired page.");
+DEFINE_string(implementation, "write_page_pool",
+              "write_page_pool or legacy_single.");
+DEFINE_bool(pin_threads, false, "Pin worker N to logical CPU N.");
+DEFINE_uint32(inflight_batches, 1,
+              "Batches held before release; use > LLC/page batch for "
+              "streaming-memory measurements.");
+DEFINE_bool(cross_thread_release, false,
+            "Release batches on separate callback threads.");
+DEFINE_int64(pressure_free_pages, -1,
+             "Pre-acquire pages so only this many remain free; -1 disables "
+             "the exhaustion-pressure mode.");
+
+namespace {
+
+void PinToCpu(uint32_t cpu) {
+  cpu_set_t cpus;
+  CPU_ZERO(&cpus);
+  CPU_SET(cpu, &cpus);
+  const int rc = pthread_setaffinity_np(pthread_self(), sizeof(cpus), &cpus);
+  CHECK_EQ(rc, 0) << std::strerror(rc);
+}
+
+struct alignas(64) TransferSlot {
+  // 0: producer may fill pages; 1: callback may release pages.
+  std::atomic<uint32_t> state{0};
+  size_t count{0};
+  std::vector<char*> pages;
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  CHECK_GT(FLAGS_threads, 0);
+  CHECK_GT(FLAGS_iterations, 0);
+  CHECK_GT(FLAGS_batch_pages, 0);
+  CHECK_GT(FLAGS_alloc_batches_per_release, 0);
+  CHECK_GT(FLAGS_inflight_batches, 0);
+  CHECK_GE(FLAGS_pressure_free_pages, -1);
+  CHECK_GE(FLAGS_page_size, sizeof(uint32_t));
+  CHECK(FLAGS_implementation == "write_page_pool" ||
+        FLAGS_implementation == "legacy_single");
+
+  CHECK_LE(
+      static_cast<uint64_t>(FLAGS_batch_pages),
+      std::numeric_limits<uint64_t>::max() / FLAGS_alloc_batches_per_release);
+  const uint64_t pages_per_release = static_cast<uint64_t>(FLAGS_batch_pages) *
+                                     FLAGS_alloc_batches_per_release;
+  const uint64_t working_pages =
+      static_cast<uint64_t>(FLAGS_threads) * pages_per_release;
+  const uint64_t pool_pages = std::max<uint64_t>(
+      4096, working_pages * std::max<uint32_t>(4, FLAGS_inflight_batches) * 2);
+  CHECK_LE(pool_pages, INT64_MAX / FLAGS_page_size);
+
+  auto page_pool =
+      FLAGS_implementation == "write_page_pool"
+          ? dingofs::WritePagePool::Create(FLAGS_page_size, pool_pages)
+          : nullptr;
+  auto legacy_pool =
+      FLAGS_implementation == "legacy_single"
+          ? dingofs::MemoryPool::Create(FLAGS_page_size, pool_pages)
+          : nullptr;
+  CHECK(page_pool != nullptr || legacy_pool != nullptr);
+
+  std::vector<char*> pressure_hold;
+  if (FLAGS_pressure_free_pages >= 0) {
+    CHECK_LE(static_cast<uint64_t>(FLAGS_pressure_free_pages), pool_pages);
+    const size_t hold_count =
+        static_cast<size_t>(pool_pages - FLAGS_pressure_free_pages);
+    pressure_hold.resize(hold_count);
+    size_t held = 0;
+    if (page_pool != nullptr) {
+      held = page_pool->RequireBatch(pressure_hold.data(), hold_count);
+    } else {
+      while (held < hold_count) {
+        char* page = legacy_pool->Require();
+        CHECK_NOTNULL(page);
+        pressure_hold[held++] = page;
+      }
+    }
+    CHECK_EQ(held, hold_count);
+  }
+
+  std::atomic<bool> start{false};
+  std::atomic<uint64_t> failures{0};
+  std::atomic<uint64_t> successful_pages{0};
+  std::vector<std::thread> workers;
+  workers.reserve(FLAGS_threads * (FLAGS_cross_thread_release ? 2 : 1));
+
+  std::vector<std::unique_ptr<TransferSlot[]>> transfer_slots;
+  if (FLAGS_cross_thread_release) {
+    transfer_slots.reserve(FLAGS_threads);
+    for (uint32_t thread = 0; thread < FLAGS_threads; ++thread) {
+      auto slots = std::make_unique<TransferSlot[]>(FLAGS_inflight_batches);
+      for (uint32_t i = 0; i < FLAGS_inflight_batches; ++i) {
+        slots[i].pages.resize(pages_per_release);
+      }
+      transfer_slots.push_back(std::move(slots));
+    }
+  }
+
+  for (uint32_t thread = 0; thread < FLAGS_threads; ++thread) {
+    if (FLAGS_cross_thread_release) {
+      workers.emplace_back([&, thread]() {
+        if (FLAGS_pin_threads) {
+          PinToCpu(thread + FLAGS_threads);
+        }
+        while (!start.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        TransferSlot* slots = transfer_slots[thread].get();
+        for (uint32_t completed = 0; completed < FLAGS_iterations;
+             ++completed) {
+          TransferSlot& slot = slots[completed % FLAGS_inflight_batches];
+          while (slot.state.load(std::memory_order_acquire) != 1) {
+            std::this_thread::yield();
+          }
+          if (page_pool != nullptr) {
+            page_pool->ReleaseBatch(slot.pages.data(), slot.count);
+          } else {
+            for (size_t i = 0; i < slot.count; ++i) {
+              legacy_pool->Release(slot.pages[i]);
+            }
+          }
+          slot.state.store(0, std::memory_order_release);
+        }
+      });
+    }
+
+    workers.emplace_back([&, thread]() {
+      if (FLAGS_pin_threads) {
+        PinToCpu(thread);
+      }
+      if (FLAGS_cross_thread_release) {
+        while (!start.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        TransferSlot* slots = transfer_slots[thread].get();
+        for (uint32_t completed = 0; completed < FLAGS_iterations;
+             ++completed) {
+          TransferSlot& slot = slots[completed % FLAGS_inflight_batches];
+          while (slot.state.load(std::memory_order_acquire) != 0) {
+            std::this_thread::yield();
+          }
+          size_t count = 0;
+          for (uint32_t batch = 0; batch < FLAGS_alloc_batches_per_release;
+               ++batch) {
+            size_t batch_count = 0;
+            if (page_pool != nullptr) {
+              batch_count = page_pool->RequireBatch(slot.pages.data() + count,
+                                                    FLAGS_batch_pages);
+            } else {
+              while (batch_count < FLAGS_batch_pages) {
+                char* page = legacy_pool->Require();
+                if (page == nullptr) break;
+                slot.pages[count + batch_count++] = page;
+              }
+            }
+            count += batch_count;
+            if (batch_count != FLAGS_batch_pages) {
+              failures.fetch_add(1, std::memory_order_relaxed);
+            }
+          }
+          successful_pages.fetch_add(count, std::memory_order_relaxed);
+          slot.count = count;
+          if (FLAGS_touch_pages) {
+            for (size_t i = 0; i < count; ++i) {
+              std::memset(slot.pages[i], static_cast<int>(thread),
+                          FLAGS_page_size);
+            }
+          }
+          slot.state.store(1, std::memory_order_release);
+        }
+        return;
+      }
+      std::vector<char*> pages(static_cast<size_t>(pages_per_release) *
+                               FLAGS_inflight_batches);
+      std::vector<size_t> counts(FLAGS_inflight_batches);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      uint32_t completed = 0;
+      while (completed < FLAGS_iterations) {
+        const uint32_t window =
+            std::min(FLAGS_inflight_batches, FLAGS_iterations - completed);
+        for (uint32_t batch = 0; batch < window; ++batch) {
+          char** batch_pages =
+              pages.data() + (static_cast<size_t>(batch) * pages_per_release);
+          size_t count = 0;
+          for (uint32_t allocation = 0;
+               allocation < FLAGS_alloc_batches_per_release; ++allocation) {
+            size_t batch_count = 0;
+            if (page_pool != nullptr) {
+              batch_count = page_pool->RequireBatch(batch_pages + count,
+                                                    FLAGS_batch_pages);
+            } else {
+              while (batch_count < FLAGS_batch_pages) {
+                char* page = legacy_pool->Require();
+                if (page == nullptr) break;
+                batch_pages[count + batch_count++] = page;
+              }
+            }
+            count += batch_count;
+            if (batch_count != FLAGS_batch_pages) {
+              failures.fetch_add(1, std::memory_order_relaxed);
+            }
+          }
+          successful_pages.fetch_add(count, std::memory_order_relaxed);
+          counts[batch] = count;
+          if (FLAGS_touch_pages) {
+            for (size_t i = 0; i < count; ++i) {
+              std::memset(batch_pages[i], static_cast<int>(thread),
+                          FLAGS_page_size);
+            }
+          }
+        }
+
+        for (uint32_t batch = 0; batch < window; ++batch) {
+          char** batch_pages =
+              pages.data() + (static_cast<size_t>(batch) * pages_per_release);
+          if (page_pool != nullptr) {
+            page_pool->ReleaseBatch(batch_pages, counts[batch]);
+          } else {
+            for (size_t i = 0; i < counts[batch]; ++i) {
+              legacy_pool->Release(batch_pages[i]);
+            }
+          }
+        }
+        completed += window;
+      }
+    });
+  }
+
+  const auto begin = std::chrono::steady_clock::now();
+  start.store(true, std::memory_order_release);
+  for (auto& worker : workers) worker.join();
+  const double seconds =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - begin)
+          .count();
+
+  const uint64_t release_groups =
+      static_cast<uint64_t>(FLAGS_threads) * FLAGS_iterations;
+  const uint64_t allocation_requests =
+      release_groups * FLAGS_alloc_batches_per_release;
+  const uint64_t pages = release_groups * pages_per_release;
+  const double gib =
+      static_cast<double>(pages) * FLAGS_page_size / (1024.0 * 1024 * 1024);
+  const uint64_t completed_pages =
+      successful_pages.load(std::memory_order_relaxed);
+
+  if (page_pool != nullptr) {
+    page_pool->ReleaseBatch(pressure_hold.data(), pressure_hold.size());
+  } else {
+    for (char* page : pressure_hold) {
+      legacy_pool->Release(page);
+    }
+  }
+
+  LOG(INFO) << "implementation=" << FLAGS_implementation
+            << " threads=" << FLAGS_threads
+            << " batch_pages=" << FLAGS_batch_pages
+            << " alloc_batches_per_release=" << FLAGS_alloc_batches_per_release
+            << " pages_per_release=" << pages_per_release << " refill_pages=32"
+            << " iterations=" << FLAGS_iterations
+            << " touch_pages=" << FLAGS_touch_pages
+            << " pin_threads=" << FLAGS_pin_threads
+            << " inflight_batches=" << FLAGS_inflight_batches
+            << " cross_thread_release=" << FLAGS_cross_thread_release
+            << " pressure_free_pages=" << FLAGS_pressure_free_pages
+            << " allocation_requests_per_sec=" << allocation_requests / seconds
+            << " release_groups_per_sec=" << release_groups / seconds
+            << " ns_per_requested_page=" << seconds * 1e9 / pages
+            << " ns_per_successful_page="
+            << (completed_pages == 0 ? 0 : seconds * 1e9 / completed_pages)
+            << " touched_gib_per_sec="
+            << (FLAGS_touch_pages ? gib / seconds : 0)
+            << " allocation_failures=" << failures.load();
+  return FLAGS_pressure_free_pages >= 0 || failures.load() == 0 ? 0 : 1;
+}

--- a/src/common/writemempool/cpu_local.cc
+++ b/src/common/writemempool/cpu_local.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/writemempool/cpu_local.h"
+
+#include <glog/logging.h>
+#include <sched.h>
+
+#include <functional>
+#include <limits>
+#include <thread>
+
+namespace dingofs {
+namespace {
+
+constexpr uint32_t kMinCpuLocalCaches = 8;
+
+bool IsPowerOfTwo(uint32_t value) {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+}  // namespace
+
+uint32_t CpuLocalCacheCount() {
+  const uint32_t cpus = std::thread::hardware_concurrency();
+  uint32_t count = kMinCpuLocalCaches;
+  while (count < cpus) {
+    CHECK_LE(count, std::numeric_limits<uint32_t>::max() / 2);
+    count <<= 1;
+  }
+  return count;
+}
+
+uint32_t CurrentCpuLocalCache(uint32_t cache_count) {
+  DCHECK(IsPowerOfTwo(cache_count));
+  const int cpu = sched_getcpu();
+  if (cpu >= 0) {
+    return static_cast<uint32_t>(cpu) & (cache_count - 1);
+  }
+
+  static thread_local const uint32_t fallback = static_cast<uint32_t>(
+      std::hash<std::thread::id>{}(std::this_thread::get_id()));
+  return fallback & (cache_count - 1);
+}
+
+}  // namespace dingofs

--- a/src/common/writemempool/cpu_local.h
+++ b/src/common/writemempool/cpu_local.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_COMMON_WRITEMEMPOOL_CPU_LOCAL_H_
+#define DINGOFS_SRC_COMMON_WRITEMEMPOOL_CPU_LOCAL_H_
+
+#include <cstdint>
+
+namespace dingofs {
+
+// Returns a power-of-two CPU-local slot count that is at least eight and at
+// least std::thread::hardware_concurrency(). A zero hardware hint therefore
+// degrades to eight slots.
+uint32_t CpuLocalCacheCount();
+
+// Maps the current logical CPU to a slot. `cache_count` must be the
+// power-of-two value returned by CpuLocalCacheCount(). If the current CPU
+// cannot be queried, a thread-local hash supplies a stable fallback.
+uint32_t CurrentCpuLocalCache(uint32_t cache_count);
+
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_COMMON_WRITEMEMPOOL_CPU_LOCAL_H_

--- a/src/common/writemempool/write_mem_pool.cc
+++ b/src/common/writemempool/write_mem_pool.cc
@@ -18,44 +18,54 @@
 
 #include <glog/logging.h>
 
+#include <limits>
+
 namespace dingofs {
+namespace {
+
+WritePagePoolUPtr CreatePagePool(int64_t total_bytes, int64_t page_size) {
+  CHECK_GT(page_size, 0);
+  CHECK_GE(total_bytes, page_size);
+  CHECK_EQ(total_bytes % page_size, 0)
+      << "write pool capacity must be an exact multiple of page size";
+  CHECK_LE(static_cast<uint64_t>(total_bytes),
+           static_cast<uint64_t>(std::numeric_limits<size_t>::max()));
+
+  auto pool =
+      WritePagePool::Create(static_cast<size_t>(page_size),
+                            static_cast<size_t>(total_bytes / page_size));
+  CHECK(pool != nullptr) << "WriteMemPool failed to create WritePagePool: page="
+                         << page_size << " total_bytes=" << total_bytes;
+  return pool;
+}
+
+}  // namespace
 
 WriteMemPool::WriteMemPool(int64_t total_bytes, int64_t page_size)
     : total_bytes_(total_bytes),
       page_size_(page_size),
-      pool_(MemoryPool::Create(static_cast<size_t>(page_size),
-                               static_cast<size_t>(total_bytes / page_size))),
+      page_pool_(CreatePagePool(total_bytes, page_size)),
       capacity_pages_("vfs_write_pool_capacity_pages",
-                      page_size > 0 ? total_bytes / page_size : 0),
+                      static_cast<int64_t>(page_pool_->BufferCount())),
       used_pages_var_("vfs_write_pool_used_pages", UsedPages, this),
       used_bytes_var_("vfs_write_pool_used_bytes", UsedBytes, this),
-      alloc_fail_num_("vfs_write_pool_alloc_fail_num") {
-  CHECK(pool_ != nullptr) << "WriteMemPool failed to create MemoryPool: page="
-                          << page_size
-                          << " count=" << (total_bytes / page_size);
-}
+      alloc_fail_num_("vfs_write_pool_alloc_fail_num") {}
 
-char* WriteMemPool::TryAllocate() {
-  // One Require(): try-semantics, never blocks, so it is safe under
-  // write_flush_mutex_ / slice_mutex_. Require() already sweeps all shards and
-  // steals from other caches internally, so a nullptr is a strong (near-)
-  // exhaustion signal; the caller (FileWriter throttle / short-write retry)
-  // owns any waiting, never this lock-holding layer.
-  char* page = pool_->Require();
-  if (page != nullptr) {
-    used_pages_ << 1;
-  } else {
+size_t WriteMemPool::TryAllocateBatch(size_t count, char** pages) {
+  const size_t allocated = page_pool_->RequireBatch(pages, count);
+  if (allocated != 0) {
+    used_pages_ << static_cast<int64_t>(allocated);
+  }
+  if (allocated != count) {
     alloc_fail_num_ << 1;
   }
-  return page;
+  return allocated;
 }
 
-void WriteMemPool::DeAllocate(char* page) {
-  if (page == nullptr) {
-    return;
-  }
-  pool_->Release(page);
-  used_pages_ << -1;
+void WriteMemPool::DeAllocateBatch(char* const* pages, size_t count) {
+  if (count == 0) return;
+  page_pool_->ReleaseBatch(pages, count);
+  used_pages_ << -static_cast<int64_t>(count);
 }
 
 int64_t WriteMemPool::GetPageSize() const { return page_size_; }
@@ -78,8 +88,12 @@ bool WriteMemPool::IsHighPressure(double threshold) const {
   return GetUsageRatio() >= threshold;
 }
 
-char* WriteMemPool::BaseAddr() const { return pool_->BaseAddr(); }
+char* WriteMemPool::BaseAddr() const { return page_pool_->BaseAddr(); }
 
-size_t WriteMemPool::TotalSize() const { return pool_->TotalSize(); }
+size_t WriteMemPool::BufferSize() const { return page_pool_->BufferSize(); }
+
+size_t WriteMemPool::BufferCount() const { return page_pool_->BufferCount(); }
+
+size_t WriteMemPool::TotalSize() const { return page_pool_->TotalSize(); }
 
 }  // namespace dingofs

--- a/src/common/writemempool/write_mem_pool.cc
+++ b/src/common/writemempool/write_mem_pool.cc
@@ -45,11 +45,11 @@ WriteMemPool::WriteMemPool(int64_t total_bytes, int64_t page_size)
     : total_bytes_(total_bytes),
       page_size_(page_size),
       page_pool_(CreatePagePool(total_bytes, page_size)),
-      capacity_pages_("vfs_write_pool_capacity_pages",
+      capacity_pages_("vfs_write_buffer_capacity_pages",
                       static_cast<int64_t>(page_pool_->BufferCount())),
-      used_pages_var_("vfs_write_pool_used_pages", UsedPages, this),
-      used_bytes_var_("vfs_write_pool_used_bytes", UsedBytes, this),
-      alloc_fail_num_("vfs_write_pool_alloc_fail_num") {}
+      used_pages_var_("vfs_write_buffer_used_pages", UsedPages, this),
+      used_bytes_var_("vfs_write_buffer_used_bytes", UsedBytes, this),
+      alloc_fail_num_("vfs_write_buffer_alloc_fail_num") {}
 
 size_t WriteMemPool::TryAllocateBatch(size_t count, char** pages) {
   const size_t allocated = page_pool_->RequireBatch(pages, count);

--- a/src/common/writemempool/write_mem_pool.h
+++ b/src/common/writemempool/write_mem_pool.h
@@ -24,7 +24,7 @@
 #include "bvar/passive_status.h"
 #include "bvar/reducer.h"
 #include "bvar/status.h"
-#include "cache/common/memory_pool.h"
+#include "common/writemempool/write_page_pool.h"
 
 namespace dingofs {
 
@@ -34,15 +34,17 @@ class WriteMemPool {
 
   ~WriteMemPool() = default;
 
-  // Single try, never blocks -- the only allocation primitive. Safe under
-  // write_flush_mutex_ / slice_mutex_ (SliceWriter, BlockData hold them). The
-  // underlying MemoryPool::Require() already sweeps every shard and steals from
-  // other caches, so a nullptr is a strong (near-)exhaustion signal, not a
-  // casual shard-race miss. Any waiting/retry on a null is the caller's job
-  // (FileWriter's lock-free throttle / short-write retry), never this layer.
-  char* TryAllocate();
+  // Try-style capacity semantics: never waits for pages to be returned and
+  // does not use a capacity wait queue. Internal synchronization may be
+  // briefly contended. Each call only consumes pages currently available in
+  // the backing pool, then returns the pages acquired so far; the caller owns
+  // rollback and any later retry.
+  size_t TryAllocateBatch(size_t count, char** pages);
 
-  void DeAllocate(char* page);
+  // Returns exactly `count` pairwise-distinct outstanding pages previously
+  // obtained from this pool. Duplicate, stale, or foreign pages violate the
+  // contract and may corrupt the underlying intrusive free lists.
+  void DeAllocateBatch(char* const* pages, size_t count);
 
   int64_t GetPageSize() const;
 
@@ -54,9 +56,12 @@ class WriteMemPool {
 
   bool IsHighPressure(double threshold = 0.8) const;
 
-  // RDMA-ready: forward the underlying pool's contiguous arena base + total
-  // length for ibv_reg_mr. Mirrors ReadMemPool::BaseAddr()/TotalSize().
+  // RDMA-ready: expose the complete fixed-page arena geometry for MR
+  // registration, buffer descriptor construction, and address-to-index
+  // conversion.
   char* BaseAddr() const;
+  size_t BufferSize() const;
+  size_t BufferCount() const;
   size_t TotalSize() const;
 
  private:
@@ -72,25 +77,20 @@ class WriteMemPool {
 
   const int64_t total_bytes_{0};
   const int64_t page_size_{0};
-  // Outstanding page count. A single shared atomic here was a true-sharing
-  // bottleneck: every Allocate/DeAllocate RMW'd one cache line, so the
-  // per-thread-cache MemoryPool below it could not scale (measured 64-thread
-  // alloc went 15ns->2939ns). bvar::Adder is per-thread sharded -- "<< 1" hits
-  // only the caller's shard; get_value() aggregates and is read only on the
-  // throttle check / bvar dump, not per page.
+
+  // Outstanding pages. bvar::Adder keeps updates sharded per thread; reads
+  // aggregate only on throttle checks and bvar sampling.
   bvar::Adder<int64_t> used_pages_;
-  MemoryPoolUPtr pool_;
+
+  WritePagePoolUPtr page_pool_;
 
   // Capacity / usage. PassiveStatus is sampled on /vars dump (off the hot
-  // path); the underlying used_pages_ atomic is the only per-op cost and it
-  // predates pooling.
+  // path); updates use the sharded reducer above.
   bvar::Status<int64_t> capacity_pages_;
   bvar::PassiveStatus<int64_t> used_pages_var_;
   bvar::PassiveStatus<int64_t> used_bytes_var_;
 
-  // Count of TryAllocate() failures (pool returned null -> caller surfaces
-  // ENOSPC / short write). Lock-free per-thread Adder, bumped only on the miss
-  // branch.
+  // Count of allocation requests that were not fully satisfied.
   bvar::Adder<int64_t> alloc_fail_num_;
 };
 

--- a/src/common/writemempool/write_mem_pool.h
+++ b/src/common/writemempool/write_mem_pool.h
@@ -24,7 +24,7 @@
 #include "bvar/passive_status.h"
 #include "bvar/reducer.h"
 #include "bvar/status.h"
-#include "common/writemempool/memory_pool.h"
+#include "cache/common/memory_pool.h"
 
 namespace dingofs {
 

--- a/src/common/writemempool/write_page_pool.cc
+++ b/src/common/writemempool/write_page_pool.cc
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/writemempool/write_page_pool.h"
+
+#include <glog/logging.h>
+#include <sys/mman.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <limits>
+
+#include "common/writemempool/cpu_local.h"
+
+namespace dingofs {
+namespace {
+
+constexpr size_t kHugePageSize = 2 * 1024 * 1024;
+
+size_t AlignHugePage(size_t size) {
+  return (size + kHugePageSize - 1) & ~(kHugePageSize - 1);
+}
+
+}  // namespace
+
+WritePagePool::WritePagePool(char* base, size_t page_size, size_t page_count)
+    : base_(base),
+      page_size_(page_size),
+      page_shift_(
+          (page_size & (page_size - 1)) == 0 ? __builtin_ctzll(page_size) : 0),
+      page_count_(page_count),
+      next_(std::make_unique<uint32_t[]>(page_count)) {
+  cache_count_ = CpuLocalCacheCount();
+  caches_ = std::make_unique<Cache[]>(cache_count_);
+  for (uint32_t i = 0; i < cache_count_; ++i) {
+    caches_[i].next_refill_shard = i % kNumShards;
+  }
+
+  std::array<uint32_t, kNumShards> tails;
+  tails.fill(kNil);
+  for (uint32_t index = 0; index < page_count_; ++index) {
+    const uint32_t owner = OwnerOfIndex(index);
+    Shard& shard = shards_[owner];
+    if (shard.head == kNil) {
+      shard.head = index;
+    } else {
+      NextOf(tails[owner]) = index;
+    }
+    tails[owner] = index;
+    ++shard.count;
+  }
+  for (uint32_t owner = 0; owner < kNumShards; ++owner) {
+    if (tails[owner] != kNil) NextOf(tails[owner]) = kNil;
+  }
+}
+
+WritePagePool::~WritePagePool() {
+  if (base_ != nullptr) FreeArena(base_);
+}
+
+WritePagePoolUPtr WritePagePool::Create(size_t page_size, size_t page_count) {
+  CHECK_GT(page_size, 0);
+  CHECK_GT(page_count, 0);
+  CHECK_LE(page_count,
+           static_cast<size_t>(std::numeric_limits<uint32_t>::max() - 1));
+  CHECK_LE(page_count, std::numeric_limits<size_t>::max() / page_size);
+
+  const size_t arena_size = page_size * page_count;
+  constexpr size_t kMaxArenaOverhead = (2 * kHugePageSize) - 1;
+  CHECK_LE(arena_size, std::numeric_limits<size_t>::max() - kMaxArenaOverhead)
+      << "write page pool arena size overflows huge-page alignment";
+
+  void* base = AllocateArena(arena_size);
+  if (base == nullptr) return nullptr;
+  return WritePagePoolUPtr(
+      new WritePagePool(static_cast<char*>(base), page_size, page_count));
+}
+
+size_t WritePagePool::TakeFromCache(Cache* cache, char** pages, size_t count) {
+  const size_t take = std::min(count, static_cast<size_t>(cache->size));
+  for (size_t i = 0; i < take; ++i) {
+    pages[i] = PageAt(cache->entries[--cache->size]);
+  }
+  return take;
+}
+
+bool WritePagePool::RefillCache(Cache* cache) {
+  CHECK_LT(cache->size, kCacheCapacity);
+  const uint32_t start = cache->next_refill_shard;
+  for (uint32_t offset = 0; offset < kNumShards; ++offset) {
+    const uint32_t owner = (start + offset) % kNumShards;
+    Shard& shard = shards_[owner];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    const size_t take = std::min(
+        static_cast<size_t>(kCacheCapacity - cache->size), shard.count);
+    if (take == 0) continue;
+
+    for (size_t i = 0; i < take; ++i) {
+      const uint32_t index = shard.head;
+      CHECK_NE(index, kNil);
+      shard.head = NextOf(index);
+      cache->entries[cache->size++] = index;
+    }
+    shard.count -= take;
+    cache->next_refill_shard = (owner + 1) % kNumShards;
+    return true;
+  }
+  return false;
+}
+
+size_t WritePagePool::RequireBatch(char** pages, size_t count) {
+  return RequireBatchFromCache(pages, count,
+                               CurrentCpuLocalCache(cache_count_));
+}
+
+size_t WritePagePool::RequireBatchFromCache(char** pages, size_t count,
+                                            uint32_t cache_index) {
+  if (count == 0) return 0;
+  CHECK_NOTNULL(pages);
+  CHECK_LT(cache_index, cache_count_);
+
+  size_t acquired = 0;
+  {
+    Cache& cache = caches_[cache_index];
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    while (acquired < count) {
+      acquired += TakeFromCache(&cache, pages + acquired, count - acquired);
+      if (acquired == count || !RefillCache(&cache)) break;
+    }
+  }
+
+  // Shards can be empty while idle cache slots still hold free pages. Reclaim
+  // those pages before reporting a short allocation.
+  for (uint32_t offset = 1; offset < cache_count_ && acquired < count;
+       ++offset) {
+    Cache& cache = caches_[(cache_index + offset) % cache_count_];
+    std::lock_guard<std::mutex> lock(cache.mutex);
+    acquired += TakeFromCache(&cache, pages + acquired, count - acquired);
+  }
+
+  return acquired;
+}
+
+size_t WritePagePool::TEST_FreePages() const {
+  size_t total = 0;
+  for (const auto& shard : shards_) {
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    total += shard.count;
+  }
+  for (uint32_t i = 0; i < cache_count_; ++i) {
+    std::lock_guard<std::mutex> lock(caches_[i].mutex);
+    total += caches_[i].size;
+  }
+  return total;
+}
+
+void WritePagePool::ReleaseBatch(char* const* pages, size_t count) {
+  if (count == 0) return;
+  CHECK_NOTNULL(pages);
+
+  std::array<Chain, kNumShards> chains;
+  for (size_t i = 0; i < count; ++i) {
+    char* page = pages[i];
+    CHECK_NOTNULL(page);
+    CHECK_GE(page, base_);
+    CHECK_LT(page, base_ + TotalSize());
+    CHECK(PageAligned(page - base_));
+
+    const uint32_t index = IndexOf(page);
+    Chain& chain = chains[OwnerOfIndex(index)];
+    if (chain.first == kNil) {
+      chain.first = index;
+    } else {
+      NextOf(chain.last) = index;
+    }
+    chain.last = index;
+    ++chain.count;
+  }
+
+  for (uint32_t owner = 0; owner < kNumShards; ++owner) {
+    Chain& chain = chains[owner];
+    if (chain.count == 0) continue;
+    Shard& shard = shards_[owner];
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    NextOf(chain.last) = shard.head;
+    shard.head = chain.first;
+    shard.count += chain.count;
+  }
+}
+
+void* WritePagePool::AllocateArena(size_t size) {
+  const size_t allocation_size = AlignHugePage(size) + kHugePageSize;
+  char* allocation = static_cast<char*>(
+      mmap(nullptr, allocation_size, PROT_READ | PROT_WRITE,
+           MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE | MAP_HUGETLB, -1, 0));
+  if (allocation == MAP_FAILED) {
+    void* aligned = nullptr;
+    if (posix_memalign(&aligned, kHugePageSize, allocation_size) != 0) {
+      return nullptr;
+    }
+    allocation = static_cast<char*>(aligned);
+    *reinterpret_cast<size_t*>(allocation) = 0;
+  } else {
+    *reinterpret_cast<size_t*>(allocation) = allocation_size;
+  }
+  return allocation + kHugePageSize;
+}
+
+void WritePagePool::FreeArena(void* ptr) {
+  char* allocation = static_cast<char*>(ptr) - kHugePageSize;
+  const size_t allocation_size = *reinterpret_cast<size_t*>(allocation);
+  if (allocation_size == 0) {
+    std::free(allocation);
+  } else {
+    munmap(allocation, allocation_size);
+  }
+}
+
+}  // namespace dingofs

--- a/src/common/writemempool/write_page_pool.h
+++ b/src/common/writemempool/write_page_pool.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PAGE_POOL_H_
+#define DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PAGE_POOL_H_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+namespace dingofs {
+
+class WritePagePool;
+using WritePagePoolUPtr = std::unique_ptr<WritePagePool>;
+
+class WritePagePool {
+ public:
+  static WritePagePoolUPtr Create(size_t page_size, size_t page_count);
+  ~WritePagePool();
+
+  // Acquires up to `count` pages and stores them in pages[0..return_value).
+  // A short result is allowed; only the returned prefix becomes outstanding.
+  size_t RequireBatch(char** pages, size_t count);
+
+  // Returns exactly `count` outstanding pages to this pool. Every entry must
+  // have been returned by this pool, entries must be pairwise distinct, and
+  // none may have been released already. Ownership of all entries transfers
+  // back to the pool when this function is called. Violating this exactly-once
+  // contract corrupts the intrusive free lists; production builds do not scan
+  // the pool to detect duplicate or stale releases.
+  void ReleaseBatch(char* const* pages, size_t count);
+
+  // RDMA-ready arena geometry. The complete tuple is needed both to register
+  // the MR and to map an address back to its fixed-size page index.
+  char* BaseAddr() const { return base_; }
+  size_t BufferSize() const { return page_size_; }
+  size_t BufferCount() const { return page_count_; }
+  size_t TotalSize() const { return page_size_ * page_count_; }
+
+ private:
+  friend class WritePagePoolTestPeer;
+
+  static constexpr uint32_t kNumShards = 32;
+  static constexpr uint32_t kNil = UINT32_MAX;
+  static constexpr uint32_t kCacheCapacity = 32;
+  static constexpr uint32_t kOwnerExtentPages = kCacheCapacity;
+
+  struct alignas(64) Shard {
+    mutable std::mutex mutex;
+    uint32_t head{kNil};
+    size_t count{0};
+  };
+
+  struct alignas(64) Cache {
+    mutable std::mutex mutex;
+    uint32_t size{0};
+    uint32_t next_refill_shard{0};
+    std::array<uint32_t, kCacheCapacity> entries{};
+  };
+
+  struct Chain {
+    uint32_t first{kNil};
+    uint32_t last{kNil};
+    size_t count{0};
+  };
+
+  WritePagePool(char* base, size_t page_size, size_t page_count);
+
+  uint32_t& NextOf(uint32_t index) { return next_[index]; }
+  // page_shift_ is 0 when page_size_ is not a power of two (the shift fast
+  // path only applies to the power-of-two geometry used in production).
+  uint32_t IndexOf(const char* page) const {
+    const size_t offset = page - base_;
+    return static_cast<uint32_t>(page_shift_ != 0 ? offset >> page_shift_
+                                                  : offset / page_size_);
+  }
+  // Test-only. Call only while pool operations are quiescent; this is not a
+  // coherent snapshot under concurrent allocation and release.
+  size_t TEST_FreePages() const;
+  bool PageAligned(size_t offset) const {
+    return page_shift_ != 0 ? (offset & (page_size_ - 1)) == 0
+                            : offset % page_size_ == 0;
+  }
+  uint32_t OwnerShard(const char* page) const {
+    return OwnerOfIndex(IndexOf(page));
+  }
+  static uint32_t OwnerOfIndex(uint32_t index) {
+    return (index / kOwnerExtentPages) % kNumShards;
+  }
+  char* PageAt(uint32_t index) const { return base_ + (index * page_size_); }
+
+  static void* AllocateArena(size_t size);
+  static void FreeArena(void* ptr);
+
+  bool RefillCache(Cache* cache);
+  size_t TakeFromCache(Cache* cache, char** pages, size_t count);
+  size_t RequireBatchFromCache(char** pages, size_t count,
+                               uint32_t cache_index);
+
+  char* base_;
+  size_t page_size_;
+  size_t page_shift_;
+  size_t page_count_;
+  std::unique_ptr<uint32_t[]> next_;
+  std::array<Shard, kNumShards> shards_;
+  uint32_t cache_count_{0};
+  std::unique_ptr<Cache[]> caches_;
+};
+
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PAGE_POOL_H_

--- a/test/unit/cache/common/test_memory_pool.cc
+++ b/test/unit/cache/common/test_memory_pool.cc
@@ -26,7 +26,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "common/writemempool/memory_pool.h"
+#include "cache/common/memory_pool.h"
 
 namespace dingofs {
 

--- a/test/unit/client/vfs/data/test_block_data.cc
+++ b/test/unit/client/vfs/data/test_block_data.cc
@@ -119,6 +119,38 @@ TEST_F(BlockDataTest, ReservePages_SkipsExistingPages) {
   EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
 }
 
+TEST_F(BlockDataTest, ExistingPagePartialBatchRollbackKeepsExistingPage) {
+  auto pool = MakePool(2);
+  auto block = MakeBlock(pool.get());
+
+  std::vector<uint32_t> existing;
+  ASSERT_TRUE(block->ReservePages(kPageSize, 0, &existing).ok());
+  ASSERT_EQ(existing, std::vector<uint32_t>({0}));
+  ASSERT_EQ(pool->GetUsedBytes(), kPageSize);
+
+  // Page 0 already exists. Only one pool page remains, so page 1 is returned
+  // as the successful prefix and page 2 causes a short allocation.
+  std::vector<uint32_t> created;
+  Status status = block->ReservePages(3 * kPageSize, 0, &created);
+  ASSERT_TRUE(status.IsNoSpace()) << status.ToString();
+  ASSERT_EQ(created, std::vector<uint32_t>({1}));
+  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
+
+  block->RollbackPages(created);
+  EXPECT_EQ(pool->GetUsedBytes(), kPageSize);
+
+  // The pre-existing page must remain usable after rolling back the partial
+  // batch, and a same-offset retry must not hit a contiguity CHECK.
+  std::vector<uint32_t> retry_created;
+  ASSERT_TRUE(block->ReservePages(kPageSize, 0, &retry_created).ok());
+  EXPECT_TRUE(retry_created.empty());
+  std::vector<char> data(kPageSize, 'r');
+  block->ApplyWrite(ctx_, data.data(), data.size(), 0);
+  std::vector<char> copied(data.size());
+  block->ToIOBuffer().CopyTo(copied.data(), copied.size());
+  EXPECT_EQ(copied, data);
+}
+
 // RollbackPages frees exactly the named pages and nothing else.
 TEST_F(BlockDataTest, RollbackPages_FreesOnlyNamedPages) {
   auto pool = MakePool(4);
@@ -134,6 +166,14 @@ TEST_F(BlockDataTest, RollbackPages_FreesOnlyNamedPages) {
 
   // Roll back the rest -> back to empty.
   block->RollbackPages({created[0], created[1]});
+  EXPECT_EQ(pool->GetUsedBytes(), 0);
+}
+
+TEST_F(BlockDataTest, EmptyRollbackIsNoOp) {
+  auto pool = MakePool(2);
+  auto block = MakeBlock(pool.get());
+
+  block->RollbackPages({});
   EXPECT_EQ(pool->GetUsedBytes(), 0);
 }
 
@@ -155,6 +195,41 @@ TEST_F(BlockDataTest, ApplyWrite_NoAllocation_AfterReserve) {
   EXPECT_EQ(pool->GetUsedBytes(), size);  // ApplyWrite did not allocate
   // Data is durable in the pages.
   EXPECT_EQ(block->ToIOBuffer().Size(), static_cast<size_t>(size));
+}
+
+TEST_F(BlockDataTest, MultiPageUnalignedWritePreservesByteOrder) {
+  auto pool = MakePool(4);
+  constexpr int32_t kStart = 137;
+  constexpr int32_t kSize = 2 * kPageSize + 777;
+  auto block = MakeBlock(pool.get(), kStart);
+
+  std::vector<uint32_t> created;
+  ASSERT_TRUE(block->ReservePages(kSize, kStart, &created).ok());
+  ASSERT_EQ(created.size(), 3);
+
+  std::vector<char> input(kSize);
+  for (size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<char>((i * 37 + 11) % 251);
+  }
+  block->ApplyWrite(ctx_, input.data(), input.size(), kStart);
+
+  IOBuffer output = block->ToIOBuffer();
+  ASSERT_EQ(output.Size(), input.size());
+  ASSERT_EQ(output.BackingBlockNum(), created.size());
+  std::vector<char> copied(input.size());
+  output.CopyTo(copied.data(), copied.size());
+  EXPECT_EQ(copied, input);
+}
+
+TEST_F(BlockDataTest, DestructorReturnsAllPagesInOneBatch) {
+  auto pool = MakePool(4);
+  {
+    auto block = MakeBlock(pool.get());
+    std::vector<uint32_t> created;
+    ASSERT_TRUE(block->ReservePages(3 * kPageSize, 0, &created).ok());
+    ASSERT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
+  }
+  EXPECT_EQ(pool->GetUsedBytes(), 0);
 }
 
 // The reserve -> rollback -> reserve+apply sequence (what SliceWriter drives

--- a/test/unit/client/vfs/data/test_chunk_writer.cc
+++ b/test/unit/client/vfs/data/test_chunk_writer.cc
@@ -609,7 +609,7 @@ TEST_F(ChunkWriterTest, ConcurrentFlush_HoldsSliceMutexUntilQueuePush) {
 #endif  // NDEBUG
 }
 
-// --- P2 failure-path: pool exhaustion (WriteMemPool::TryAllocate -> nullptr)
+// --- P2 failure-path: pool exhaustion (TryAllocateBatch returns short)
 // ---
 
 // A tiny pool makes exhaustion deterministic (TryAllocate never waits). A write

--- a/test/unit/client/vfs/data/test_slice_writer.cc
+++ b/test/unit/client/vfs/data/test_slice_writer.cc
@@ -181,6 +181,110 @@ TEST_F(SliceWriterTest, FlushAsync_BasicSuccess) {
   EXPECT_EQ(sw_->GetCommitSlice().id, 42u);
 }
 
+TEST_F(SliceWriterTest, FlushAsync_PutPayloadPreservesCrossBlockByteOrder) {
+  EXPECT_CALL(*mock_meta_system_, NewSliceId(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<2>(43u), Return(Status::OK())));
+
+  const int32_t first_size = static_cast<int32_t>(kPageSize + 137);
+  const int32_t total_size =
+      static_cast<int32_t>(kBlockSize + (2 * kPageSize) + 333);
+  std::vector<char> input(total_size);
+  for (size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<char>((i * 41 + 17) % 251);
+  }
+
+  std::mutex payload_mutex;
+  std::map<uint32_t, std::vector<char>> uploaded;
+  EXPECT_CALL(*mock_block_store_, PutAsync(_, _, _))
+      .WillRepeatedly(Invoke([&](ContextSPtr, PutReq req, StatusCallback cb) {
+        std::vector<char> bytes(req.data.Size());
+        req.data.CopyTo(bytes.data(), bytes.size());
+        {
+          std::lock_guard<std::mutex> lock(payload_mutex);
+          uploaded.emplace(HandleIndex(req.handle), std::move(bytes));
+        }
+        cb(Status::OK());
+      }));
+
+  ASSERT_TRUE(sw_->Write(ctx_, input.data(), first_size, 0).ok());
+  ASSERT_TRUE(sw_
+                  ->Write(ctx_, input.data() + first_size,
+                          total_size - first_size, first_size)
+                  .ok());
+
+  test::AsyncWaiter waiter;
+  waiter.Expect(1);
+  sw_->FlushAsync([&](Status status) {
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    waiter.Done();
+  });
+  waiter.Wait();
+
+  std::lock_guard<std::mutex> lock(payload_mutex);
+  ASSERT_EQ(uploaded.size(), 2);
+  ASSERT_EQ(uploaded[0].size(), kBlockSize);
+  ASSERT_EQ(uploaded[1].size(), input.size() - kBlockSize);
+  EXPECT_TRUE(std::equal(uploaded[0].begin(), uploaded[0].end(), input.begin()));
+  EXPECT_TRUE(std::equal(uploaded[1].begin(), uploaded[1].end(),
+                         input.begin() + kBlockSize));
+}
+
+TEST_F(SliceWriterTest, FlushAsync_PagesLiveUntilUploadCallback) {
+  EXPECT_CALL(*mock_meta_system_, NewSliceId(_, _, _))
+      .WillOnce(DoAll(SetArgPointee<2>(44u), Return(Status::OK())));
+
+  std::mutex callback_mutex;
+  StatusCallback held_callback;
+  PutReq held_request;
+  std::promise<void> submitted;
+  auto submitted_future = submitted.get_future();
+  EXPECT_CALL(*mock_block_store_, PutAsync(_, _, _))
+      .WillOnce(Invoke([&](ContextSPtr, PutReq req, StatusCallback cb) {
+        {
+          std::lock_guard<std::mutex> lock(callback_mutex);
+          held_request = std::move(req);
+          held_callback = std::move(cb);
+        }
+        submitted.set_value();
+      }));
+
+  constexpr int32_t kSize = (2 * kPageSize) + 123;
+  std::vector<char> input(kSize);
+  for (size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<char>((i * 29 + 7) % 253);
+  }
+  ASSERT_TRUE(sw_->Write(ctx_, input.data(), input.size(), 0).ok());
+  ASSERT_GT(write_buf_mgr_->GetUsedBytes(), 0);
+
+  test::AsyncWaiter waiter;
+  waiter.Expect(1);
+  sw_->FlushAsync([&](Status status) {
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    waiter.Done();
+  });
+  ASSERT_EQ(submitted_future.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+
+  // PutAsync has returned but its completion has not fired. BlockData must
+  // still own the pages, and the non-owning IOBuffer observed by the backend
+  // must contain the original bytes.
+  EXPECT_GT(write_buf_mgr_->GetUsedBytes(), 0);
+
+  StatusCallback callback;
+  std::vector<char> uploaded;
+  {
+    std::lock_guard<std::mutex> lock(callback_mutex);
+    uploaded.resize(held_request.data.Size());
+    held_request.data.CopyTo(uploaded.data(), uploaded.size());
+    callback = std::move(held_callback);
+  }
+  EXPECT_EQ(uploaded, input);
+  ASSERT_TRUE(static_cast<bool>(callback));
+  callback(Status::OK());
+  waiter.Wait(std::chrono::seconds(5));
+  EXPECT_EQ(write_buf_mgr_->GetUsedBytes(), 0);
+}
+
 // 4. Verify slice has correct offset, length, id after flush.
 TEST_F(SliceWriterTest, FlushAsync_CommitSlice_CorrectFields) {
   EXPECT_CALL(*mock_meta_system_, NewSliceId(_, _, _))

--- a/test/unit/common/writemempool/test_write_mem_pool.cc
+++ b/test/unit/common/writemempool/test_write_mem_pool.cc
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-#include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
-#include <chrono>
 #include <thread>
 #include <vector>
 
@@ -28,15 +27,27 @@ namespace dingofs {
 
 // ─── WriteMemPool ──────────────────────────────────────────────────────
 
-TEST(WriteMemPoolTest, DeAllocate_DecreasesUsed) {
+TEST(WriteMemPoolDeathTest, RejectsZeroPageSizeBeforeDivision) {
+  EXPECT_DEATH({ WriteMemPool pool(4096, 0); }, "page_size > 0");
+}
+
+TEST(WriteMemPoolDeathTest, RejectsCapacitySmallerThanOnePage) {
+  EXPECT_DEATH({ WriteMemPool pool(4096, 8192); }, "total_bytes >= page_size");
+}
+
+TEST(WriteMemPoolDeathTest, RejectsNonIntegralPageCapacity) {
+  EXPECT_DEATH({ WriteMemPool pool(10 * 1024, 4096); }, "exact multiple");
+}
+
+TEST(WriteMemPoolTest, DeAllocateBatch_DecreasesUsed) {
   constexpr int64_t kPageSize = 4096;
   WriteMemPool mgr(kPageSize * 4, kPageSize);
 
-  char* page = mgr.TryAllocate();
-  ASSERT_NE(page, nullptr);
+  char* page = nullptr;
+  ASSERT_EQ(mgr.TryAllocateBatch(1, &page), 1);
   EXPECT_EQ(mgr.GetUsedBytes(), kPageSize);
 
-  mgr.DeAllocate(page);
+  mgr.DeAllocateBatch(&page, 1);
   EXPECT_EQ(mgr.GetUsedBytes(), 0);
 }
 
@@ -47,6 +58,10 @@ TEST(WriteMemPoolTest, GetPageSize_GetTotalBytes) {
 
   EXPECT_EQ(mgr.GetPageSize(), kPageSize);
   EXPECT_EQ(mgr.GetTotalBytes(), kTotal);
+  EXPECT_NE(mgr.BaseAddr(), nullptr);
+  EXPECT_EQ(mgr.BufferSize(), kPageSize);
+  EXPECT_EQ(mgr.BufferCount(), 8);
+  EXPECT_EQ(mgr.TotalSize(), kTotal);
 }
 
 TEST(WriteMemPoolTest, IsHighPressure_True_WhenAboveThreshold) {
@@ -54,15 +69,12 @@ TEST(WriteMemPoolTest, IsHighPressure_True_WhenAboveThreshold) {
   // 2 pages total; allocate 2 to hit 100% usage
   WriteMemPool mgr(kPageSize * 2, kPageSize);
 
-  char* p1 = mgr.TryAllocate();
-  char* p2 = mgr.TryAllocate();
-  ASSERT_NE(p1, nullptr);
-  ASSERT_NE(p2, nullptr);
+  std::array<char*, 2> pages{};
+  ASSERT_EQ(mgr.TryAllocateBatch(pages.size(), pages.data()), pages.size());
 
   EXPECT_TRUE(mgr.IsHighPressure());
 
-  mgr.DeAllocate(p1);
-  mgr.DeAllocate(p2);
+  mgr.DeAllocateBatch(pages.data(), pages.size());
 }
 
 TEST(WriteMemPoolTest, Concurrent_AllocAndDealloc_FinalZero) {
@@ -78,8 +90,9 @@ TEST(WriteMemPoolTest, Concurrent_AllocAndDealloc_FinalZero) {
   for (int t = 0; t < kThreads; ++t) {
     threads.emplace_back([&mgr]() {
       for (int i = 0; i < kIters; ++i) {
-        char* page = mgr.TryAllocate();
-        mgr.DeAllocate(page);
+        char* page = nullptr;
+        const size_t count = mgr.TryAllocateBatch(1, &page);
+        mgr.DeAllocateBatch(&page, count);
       }
     });
   }
@@ -90,116 +103,88 @@ TEST(WriteMemPoolTest, Concurrent_AllocAndDealloc_FinalZero) {
   EXPECT_EQ(mgr.GetUsedBytes(), 0);
 }
 
-// ─── TryAllocate ───────────────────────────────────────────────────────
+// ─── TryAllocateBatch ──────────────────────────────────────────────────
 
-TEST(WriteMemPoolTest, TryAllocate_ReturnsNonNull_IncreasesUsed) {
+TEST(WriteMemPoolTest, TryAllocateBatch_ReturnsPage_IncreasesUsed) {
   constexpr int64_t kPageSize = 4096;
   WriteMemPool mgr(kPageSize * 4, kPageSize);
 
-  char* page = mgr.TryAllocate();
-  ASSERT_NE(page, nullptr);
+  char* page = nullptr;
+  ASSERT_EQ(mgr.TryAllocateBatch(1, &page), 1);
   EXPECT_EQ(mgr.GetUsedBytes(), kPageSize);
 
-  mgr.DeAllocate(page);
+  mgr.DeAllocateBatch(&page, 1);
   EXPECT_EQ(mgr.GetUsedBytes(), 0);
 }
 
-TEST(WriteMemPoolTest, TryAllocate_ReturnsNull_WhenExhausted_NoBlock) {
+TEST(WriteMemPoolTest, TryAllocateBatch_ReturnsShort_WhenExhausted_NoBlock) {
   constexpr int64_t kPageSize = 4096;
   WriteMemPool mgr(kPageSize * 2, kPageSize);  // 2 slots
 
-  char* a = mgr.TryAllocate();
-  char* b = mgr.TryAllocate();
-  ASSERT_NE(a, nullptr);
-  ASSERT_NE(b, nullptr);
+  std::array<char*, 2> pages{};
+  ASSERT_EQ(mgr.TryAllocateBatch(pages.size(), pages.data()), pages.size());
 
-  // Pool drained -- TryAllocate returns immediately (no bounded wait) and used
-  // stays at capacity (a null result must not bump used_pages_).
-  char* c = mgr.TryAllocate();
-  EXPECT_EQ(c, nullptr);
+  // Pool drained -- TryAllocateBatch returns immediately (no bounded wait) and
+  // used stays at capacity (a short result must not bump used_pages_).
+  char* extra = nullptr;
+  EXPECT_EQ(mgr.TryAllocateBatch(1, &extra), 0);
   EXPECT_EQ(mgr.GetUsedBytes(), 2 * kPageSize);
 
-  mgr.DeAllocate(a);
-  mgr.DeAllocate(b);
+  mgr.DeAllocateBatch(pages.data(), pages.size());
 }
 
-// ─── Perf: pooled Allocate/DeAllocate vs new char[] baseline ───────────
+TEST(WriteMemPoolTest, EmptyBatchIsNoOp) {
+  constexpr int64_t kPageSize = 4096;
+  WriteMemPool mgr(kPageSize * 2, kPageSize);
 
-namespace {
+  EXPECT_EQ(mgr.TryAllocateBatch(0, nullptr), 0);
+  mgr.DeAllocateBatch(nullptr, 0);
+  EXPECT_EQ(mgr.GetUsedBytes(), 0);
+}
 
-// One op = Allocate + DeAllocate. Pool is sized so the fast path always hits
-// (no bounded-acquire, no slow-path metric bumps), so this measures the
-// steady-state hot path: Require() + used_pages atomic (+ the untriggered
-// metric branch). Returns ops/sec across all threads.
-double RunPooledBench(WriteMemPool* wmp, int num_threads, int iters) {
-  std::atomic<bool> start{false};
-  std::vector<std::thread> ts;
-  ts.reserve(num_threads);
-  for (int t = 0; t < num_threads; ++t) {
-    ts.emplace_back([&] {
-      while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
-      for (int i = 0; i < iters; ++i) {
-        char* p = wmp->TryAllocate();
-        if (p != nullptr) wmp->DeAllocate(p);
+TEST(WriteMemPoolTest, CrossThreadBatchAccountingReturnsToZero) {
+  constexpr int64_t kPageSize = 4096;
+  constexpr size_t kMaxBatch = 64;
+  constexpr int kIterations = 2000;
+  constexpr std::array<size_t, 3> kBatchSizes = {1, 16, 64};
+  WriteMemPool mgr(kPageSize * 256, kPageSize);
+
+  struct TransferSlot {
+    // 0: producer may allocate; 1: releaser owns the returned prefix.
+    std::atomic<uint32_t> state{0};
+    size_t count{0};
+    std::array<char*, kMaxBatch> pages{};
+  } slot;
+  std::atomic<bool> short_allocation{false};
+
+  std::thread producer([&]() {
+    for (int iteration = 0; iteration < kIterations; ++iteration) {
+      while (slot.state.load(std::memory_order_acquire) != 0) {
+        std::this_thread::yield();
       }
-    });
-  }
-  auto t0 = std::chrono::steady_clock::now();
-  start.store(true, std::memory_order_release);
-  for (auto& t : ts) t.join();
-  double sec =
-      std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
-          .count();
-  return static_cast<double>(num_threads) * iters / sec;
-}
-
-// Baseline: new char[page]/delete[] -- exactly what WriteMemPool::Allocate did
-// before pooling. Touch byte 0 so the alloc isn't optimized away.
-double RunMallocBench(int64_t page_size, int num_threads, int iters) {
-  std::atomic<bool> start{false};
-  std::vector<std::thread> ts;
-  ts.reserve(num_threads);
-  for (int t = 0; t < num_threads; ++t) {
-    ts.emplace_back([&] {
-      while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
-      for (int i = 0; i < iters; ++i) {
-        char* p = new char[page_size];
-        p[0] = static_cast<char>(i);
-        delete[] p;
+      const size_t requested =
+          kBatchSizes[iteration % kBatchSizes.size()];
+      slot.count = mgr.TryAllocateBatch(requested, slot.pages.data());
+      if (slot.count != requested) {
+        short_allocation.store(true, std::memory_order_relaxed);
       }
-    });
-  }
-  auto t0 = std::chrono::steady_clock::now();
-  start.store(true, std::memory_order_release);
-  for (auto& t : ts) t.join();
-  double sec =
-      std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
-          .count();
-  return static_cast<double>(num_threads) * iters / sec;
-}
+      slot.state.store(1, std::memory_order_release);
+    }
+  });
+  std::thread releaser([&]() {
+    for (int iteration = 0; iteration < kIterations; ++iteration) {
+      while (slot.state.load(std::memory_order_acquire) != 1) {
+        std::this_thread::yield();
+      }
+      mgr.DeAllocateBatch(slot.pages.data(), slot.count);
+      slot.state.store(0, std::memory_order_release);
+    }
+  });
 
-}  // namespace
-
-// Prints throughput + ns/op for pooled (incl. metrics埋点) vs new char[] at
-// 1/4/16/64 threads. Not asserting numbers -- visibility for the "接池+埋点 vs
-// new char[]" comparison. Pool sized large (256 MiB) so the fast path is hit
-// and slow-path metric branches never fire.
-TEST(WriteMemPoolPerf, PooledVsMalloc) {
-  constexpr int64_t kPageSize = 65536;
-  constexpr int64_t kTotalBytes = 4096LL * kPageSize;  // 256 MiB, 4096 slots
-  constexpr int kIters = 200000;
-  WriteMemPool wmp(kTotalBytes, kPageSize);
-
-  for (int n : {1, 4, 16, 64}) {
-    double pooled = RunPooledBench(&wmp, n, kIters);
-    double mallocd = RunMallocBench(kPageSize, n, kIters);
-    LOG(INFO) << "threads=" << n
-              << "  pooled=" << static_cast<long long>(pooled) << " ops/s ("
-              << (1e9 / pooled * n)
-              << " ns/op)  malloc=" << static_cast<long long>(mallocd)
-              << " ops/s (" << (1e9 / mallocd * n)
-              << " ns/op)  pooled/malloc=" << (pooled / mallocd) << "x";
-  }
+  producer.join();
+  releaser.join();
+  EXPECT_FALSE(short_allocation.load(std::memory_order_relaxed));
+  EXPECT_EQ(mgr.GetUsedBytes(), 0);
 }
 
 }  // namespace dingofs

--- a/test/unit/common/writemempool/test_write_page_pool.cc
+++ b/test/unit/common/writemempool/test_write_page_pool.cc
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "common/writemempool/cpu_local.h"
+#include "common/writemempool/write_page_pool.h"
+
+namespace dingofs {
+
+class WritePagePoolTestPeer {
+ public:
+  static size_t RequireBatchFromCache(WritePagePool* pool, char** pages,
+                                      size_t count, uint32_t cache_index) {
+    return pool->RequireBatchFromCache(pages, count, cache_index);
+  }
+
+  static size_t FreePages(const WritePagePool* pool) {
+    return pool->TEST_FreePages();
+  }
+
+  static uint32_t OwnerShard(const WritePagePool* pool, const char* page) {
+    return pool->OwnerShard(page);
+  }
+
+  static constexpr uint32_t NumShards() { return WritePagePool::kNumShards; }
+};
+
+namespace {
+
+TEST(WritePagePoolDeathTest, RejectsArenaAlignmentOverflow) {
+  constexpr size_t kNearSizeMax =
+      std::numeric_limits<size_t>::max() & ~size_t{3};
+  EXPECT_DEATH({ WritePagePool::Create(kNearSizeMax, 1); },
+               "arena size overflows huge-page alignment");
+}
+
+TEST(WritePagePoolTest, SideCarAllowsUnalignedPageSize) {
+  constexpr size_t kPageSize = 5;
+  constexpr size_t kPageCount = 16;
+  auto pool = WritePagePool::Create(kPageSize, kPageCount);
+  ASSERT_NE(pool, nullptr);
+
+  std::array<char*, kPageCount> pages{};
+  ASSERT_EQ(pool->RequireBatch(pages.data(), pages.size()), pages.size());
+  for (size_t i = 0; i < pages.size(); ++i) {
+    EXPECT_EQ((pages[i] - pool->BaseAddr()) % kPageSize, 0);
+  }
+  pool->ReleaseBatch(pages.data(), pages.size());
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+}
+
+TEST(CpuLocalTest, CacheCountAndCurrentIndexAreValid) {
+  const uint32_t count = CpuLocalCacheCount();
+  EXPECT_GE(count, 8);
+  EXPECT_EQ(count & (count - 1), 0);
+  EXPECT_LT(CurrentCpuLocalCache(count), count);
+}
+
+TEST(WritePagePoolTest, ExposesCompleteRdmaArenaGeometry) {
+  constexpr size_t kPageSize = 64 * 1024;
+  constexpr size_t kPageCount = 4096;
+  auto pool = WritePagePool::Create(kPageSize, kPageCount);
+  ASSERT_NE(pool, nullptr);
+
+  EXPECT_NE(pool->BaseAddr(), nullptr);
+  EXPECT_EQ(pool->BufferSize(), kPageSize);
+  EXPECT_EQ(pool->BufferCount(), kPageCount);
+  EXPECT_EQ(pool->TotalSize(), kPageSize * kPageCount);
+}
+
+TEST(WritePagePoolTest, RefillServesTwoMaxWritesFromOneOwner) {
+  auto pool = WritePagePool::Create(64, 4096);
+  ASSERT_NE(pool, nullptr);
+
+  std::array<char*, 16> first{};
+  std::array<char*, 16> second{};
+  ASSERT_EQ(pool->RequireBatch(first.data(), first.size()), first.size());
+  ASSERT_EQ(pool->RequireBatch(second.data(), second.size()), second.size());
+
+  const uint32_t owner =
+      WritePagePoolTestPeer::OwnerShard(pool.get(), first[0]);
+  for (size_t i = 0; i < first.size(); ++i) {
+    EXPECT_EQ(WritePagePoolTestPeer::OwnerShard(pool.get(), first[i]), owner);
+    if (i != 0) EXPECT_EQ(first[i - 1] - first[i], 64);
+  }
+  for (size_t i = 0; i < second.size(); ++i) {
+    EXPECT_EQ(WritePagePoolTestPeer::OwnerShard(pool.get(), second[i]), owner);
+    if (i != 0) EXPECT_EQ(second[i - 1] - second[i], 64);
+  }
+  EXPECT_EQ(second[0] - first.back(), -64);
+
+  pool->ReleaseBatch(first.data(), first.size());
+  pool->ReleaseBatch(second.data(), second.size());
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), 4096);
+}
+
+TEST(WritePagePoolTest, MixedOwnerBatchReturnsToOwnerShards) {
+  constexpr size_t kPageCount = 4096;
+  auto pool = WritePagePool::Create(64, kPageCount);
+  ASSERT_NE(pool, nullptr);
+
+  std::vector<char*> pages(kPageCount);
+  ASSERT_EQ(pool->RequireBatch(pages.data(), pages.size()), pages.size());
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), 0);
+
+  pool->ReleaseBatch(pages.data(), pages.size());
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+
+  std::vector<char*> reacquired(kPageCount);
+  ASSERT_EQ(pool->RequireBatch(reacquired.data(), reacquired.size()),
+            reacquired.size());
+  std::vector<size_t> owners(WritePagePoolTestPeer::NumShards());
+  for (char* page : reacquired) {
+    ++owners[WritePagePoolTestPeer::OwnerShard(pool.get(), page)];
+  }
+  for (size_t count : owners) {
+    EXPECT_EQ(count, kPageCount / WritePagePoolTestPeer::NumShards());
+  }
+}
+
+TEST(WritePagePoolTest, ReclaimsPagesStrandedInIdleCache) {
+  constexpr size_t kPageCount = 4096;
+  auto pool = WritePagePool::Create(64, kPageCount);
+  ASSERT_NE(pool, nullptr);
+
+  char* worker_page = nullptr;
+  ASSERT_EQ(WritePagePoolTestPeer::RequireBatchFromCache(pool.get(),
+                                                         &worker_page, 1, 0),
+            1);
+  ASSERT_NE(worker_page, nullptr);
+
+  std::vector<char*> pages(kPageCount - 1);
+  ASSERT_EQ(WritePagePoolTestPeer::RequireBatchFromCache(
+                pool.get(), pages.data(), pages.size(), 1),
+            pages.size());
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), 0);
+
+  pool->ReleaseBatch(pages.data(), pages.size());
+  pool->ReleaseBatch(&worker_page, 1);
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+}
+
+TEST(WritePagePoolTest, ConcurrentBatchAllocationIsUnique) {
+  constexpr size_t kPageSize = 64;
+  constexpr size_t kPageCount = 4096;
+  constexpr size_t kBatchSize = 16;
+  constexpr int kThreads = 8;
+  constexpr int kIterations = 1000;
+  auto pool = WritePagePool::Create(kPageSize, kPageCount);
+  ASSERT_NE(pool, nullptr);
+
+  std::vector<bool> held(kPageCount, false);
+  std::mutex held_mutex;
+  std::atomic<bool> duplicate{false};
+  std::atomic<bool> start{false};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+  for (int thread = 0; thread < kThreads; ++thread) {
+    workers.emplace_back([&]() {
+      std::array<char*, kBatchSize> pages{};
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        const size_t count = pool->RequireBatch(pages.data(), pages.size());
+        if (count != pages.size()) {
+          duplicate.store(true, std::memory_order_relaxed);
+        }
+        std::array<char*, kBatchSize> owned_pages{};
+        size_t owned_count = 0;
+        {
+          std::lock_guard<std::mutex> lock(held_mutex);
+          for (size_t i = 0; i < count; ++i) {
+            char* page = pages[i];
+            const size_t index =
+                static_cast<size_t>(page - pool->BaseAddr()) / kPageSize;
+            if (held[index]) {
+              duplicate.store(true, std::memory_order_relaxed);
+            } else {
+              held[index] = true;
+              owned_pages[owned_count++] = page;
+            }
+          }
+        }
+        {
+          // Keep ownership bookkeeping serialized through publication back to
+          // the pool. A page cannot be legitimately reacquired before
+          // ReleaseBatch publishes it.
+          std::lock_guard<std::mutex> lock(held_mutex);
+          for (size_t i = 0; i < owned_count; ++i) {
+            char* page = owned_pages[i];
+            const size_t index =
+                static_cast<size_t>(page - pool->BaseAddr()) / kPageSize;
+            if (!held[index]) {
+              duplicate.store(true, std::memory_order_relaxed);
+            }
+            held[index] = false;
+          }
+          pool->ReleaseBatch(owned_pages.data(), owned_count);
+        }
+      }
+    });
+  }
+  start.store(true, std::memory_order_release);
+  for (auto& worker : workers) worker.join();
+
+  EXPECT_FALSE(duplicate.load(std::memory_order_relaxed));
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+  std::vector<char*> all_pages(kPageCount);
+  EXPECT_EQ(pool->RequireBatch(all_pages.data(), all_pages.size()), kPageCount);
+  pool->ReleaseBatch(all_pages.data(), all_pages.size());
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+}
+
+TEST(WritePagePoolTest, ConcurrentBatchReleasePreservesAllPages) {
+  constexpr size_t kPageSize = 64;
+  constexpr size_t kPageCount = 4096;
+  constexpr size_t kThreads = 8;
+  auto pool = WritePagePool::Create(kPageSize, kPageCount);
+  ASSERT_NE(pool, nullptr);
+
+  std::vector<char*> pages(kPageCount);
+  ASSERT_EQ(pool->RequireBatch(pages.data(), pages.size()), pages.size());
+  ASSERT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), 0);
+
+  // Round-robin distribution gives every releaser pages from many owner
+  // shards, so the threads contend on the same shard mutexes.
+  std::array<std::vector<char*>, kThreads> batches;
+  for (size_t i = 0; i < pages.size(); ++i) {
+    batches[i % kThreads].push_back(pages[i]);
+  }
+
+  std::atomic<size_t> ready{0};
+  std::atomic<bool> start{false};
+  std::vector<std::thread> workers;
+  workers.reserve(kThreads);
+  for (size_t i = 0; i < kThreads; ++i) {
+    workers.emplace_back([&, i]() {
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      pool->ReleaseBatch(batches[i].data(), batches[i].size());
+    });
+  }
+  while (ready.load(std::memory_order_acquire) != kThreads) {
+    std::this_thread::yield();
+  }
+  start.store(true, std::memory_order_release);
+  for (auto& worker : workers) worker.join();
+
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+
+  std::vector<char*> reacquired(kPageCount);
+  ASSERT_EQ(pool->RequireBatch(reacquired.data(), reacquired.size()),
+            reacquired.size());
+  std::vector<bool> seen(kPageCount, false);
+  for (char* page : reacquired) {
+    const size_t index =
+        static_cast<size_t>(page - pool->BaseAddr()) / kPageSize;
+    ASSERT_LT(index, kPageCount);
+    EXPECT_FALSE(seen[index]);
+    seen[index] = true;
+  }
+  pool->ReleaseBatch(reacquired.data(), reacquired.size());
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+}
+
+TEST(WritePagePoolTest, CrossThreadAllocateAndReleasePreservesInventory) {
+  constexpr size_t kPageSize = 64;
+  constexpr size_t kPageCount = 4096;
+  constexpr size_t kPairs = 2;
+  constexpr size_t kMaxBatch = 64;
+  constexpr int kIterations = 2000;
+  constexpr std::array<size_t, 3> kBatchSizes = {1, 16, 64};
+
+  struct alignas(64) TransferSlot {
+    // 0: producer owns the slot; 1: releaser owns it.
+    std::atomic<uint32_t> state{0};
+    size_t count{0};
+    std::array<char*, kMaxBatch> pages{};
+  };
+
+  auto pool = WritePagePool::Create(kPageSize, kPageCount);
+  ASSERT_NE(pool, nullptr);
+  std::array<TransferSlot, kPairs> slots;
+  std::atomic<bool> short_allocation{false};
+  std::vector<std::thread> workers;
+  workers.reserve(kPairs * 2);
+
+  for (size_t pair = 0; pair < kPairs; ++pair) {
+    workers.emplace_back([&, pair]() {
+      TransferSlot& slot = slots[pair];
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        while (slot.state.load(std::memory_order_acquire) != 0) {
+          std::this_thread::yield();
+        }
+        const size_t requested =
+            kBatchSizes[(iteration + pair) % kBatchSizes.size()];
+        slot.count = pool->RequireBatch(slot.pages.data(), requested);
+        if (slot.count != requested) {
+          short_allocation.store(true, std::memory_order_relaxed);
+        }
+        slot.state.store(1, std::memory_order_release);
+      }
+    });
+    workers.emplace_back([&, pair]() {
+      TransferSlot& slot = slots[pair];
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        while (slot.state.load(std::memory_order_acquire) != 1) {
+          std::this_thread::yield();
+        }
+        pool->ReleaseBatch(slot.pages.data(), slot.count);
+        slot.state.store(0, std::memory_order_release);
+      }
+    });
+  }
+  for (auto& worker : workers) worker.join();
+
+  EXPECT_FALSE(short_allocation.load(std::memory_order_relaxed));
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+}
+
+}  // namespace
+}  // namespace dingofs


### PR DESCRIPTION
## What

- move the existing generic `MemoryPool` to `cache/common` for slab and RDMA consumers
- replace the write-path pool with a fixed-arena, CPU-local `WritePagePool` backed by owner-sharded free lists
- allocate and release write pages in batches through `BlockData`
- keep page metadata in a side-car array so free-list traversal does not touch cold payload pages
- preserve contiguous arena geometry required by RDMA registration
- expose read/write memory metrics consistently as `vfs_read_buffer_*` and `vfs_write_buffer_*`

## Why

The previous write pool could report false exhaustion under shard contention and could migrate free pages toward completion-thread shards. The new hierarchy uses CPU-local caches for the allocation fast path and mutex-protected owner shards as the shared backing layer. Batch allocation matches the write path, where a 1 MiB block typically reserves 16 64-KiB pages.

## Compatibility

- the generic cache/RDMA `MemoryPool` implementation is retained and only relocated
- the write arena remains one contiguous region and continues to expose base address, page size/count, and total size
- the bvar rename intentionally aligns with dingocli 3.1 metric names

## Verification

- `cmake --build build --target test_common test_client dingo-client -j 8`
- `test_common`: 230/230 passed
- `test_client`: 389 passed, 1 existing NDEBUG-only skip
- 4-thread Elbencho write: ~1061 MiB/s, peak write buffer ~6.40 GiB, allocation failures 0
- 1-thread cold O_DIRECT Elbencho read: ~2418 MiB/s, peak read buffer 256 MiB, allocation failures 0
