### PR TITLE
[fix][client] Report data block read failures as EIO

### DIFF
--- a/src/client/vfs/data/reader/chunk_req_reader.cc
+++ b/src/client/vfs/data/reader/chunk_req_reader.cc
@@ -96,9 +96,17 @@ void ChunkReqReader::OnAllBlocksComplete(ReaderSharedState* shared) {
     std::lock_guard<std::mutex> lock(shared->mtx);
     final_status = shared->status;
     if (!final_status.ok()) {
-      LOG(WARNING) << fmt::format(
-          "{} ChunkReqReader Read failed, status: {}, req: {}", UUID(),
-          final_status.ToString(), req_.ToString());
+      // MDS guarantees that every non-hole block referenced by inode slice
+      // metadata has valid block metadata. Sparse holes are handled by
+      // IsHole() before reaching here. Therefore, any failure at this point is
+      // a data-block read failure and must be reported as EIO.
+      const std::string original_status = final_status.ToString();
+      LOG(ERROR) << fmt::format(
+          "{} Data block read failed, convert status to IoError, "
+          "original_status: {}, req: {}",
+          UUID(), original_status, req_.ToString());
+      final_status = Status::IoError(
+          fmt::format("data block read failed: {}", original_status));
     }
   }
 

--- a/test/unit/client/vfs/data/test_file_reader.cc
+++ b/test/unit/client/vfs/data/test_file_reader.cc
@@ -318,6 +318,73 @@ TEST_F(FileReaderTest, Read_BlockStoreError_ReturnsError) {
   CloseAndRelease(r);
 }
 
+// A failure after resolving a non-hole block from inode slice metadata is a
+// data I/O failure. It must not leak a storage/cache status such as NotFound
+// (ENOENT) to the file read caller.
+TEST_F(FileReaderTest, Read_BlockStoreNotFound_ReturnsIoError) {
+  ON_CALL(*mock_meta_system_, ReadSlice)
+      .WillByDefault([](ContextSPtr, Ino, uint64_t, uint64_t,
+                        std::vector<Slice>* s, uint64_t& v) {
+        s->clear();
+        Slice sl;
+        sl.id = 1;
+        sl.pos = 0;
+        sl.size = 4 * 1024 * 1024;
+        sl.off = 0;
+        sl.len = sl.size;
+        s->push_back(sl);
+        v = 1;
+        return Status::OK();
+      });
+
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault([](ContextSPtr, RangeReq, StatusCallback cb) {
+        cb(Status::NotFound("no such object"));
+      });
+
+  auto* r = MakeOpenReader();
+
+  DataBuffer buf;
+  uint64_t rsize = 0;
+  Status s = r->Read(ctx_, &buf, 4096, 0, &rsize);
+  EXPECT_TRUE(s.IsIoError());
+  EXPECT_EQ(s.ToSysErrNo(), EIO);
+
+  CloseAndRelease(r);
+}
+
+TEST_F(FileReaderTest, Read_BlockStoreNonIoError_ReturnsIoError) {
+  ON_CALL(*mock_meta_system_, ReadSlice)
+      .WillByDefault([](ContextSPtr, Ino, uint64_t, uint64_t,
+                        std::vector<Slice>* s, uint64_t& v) {
+        s->clear();
+        Slice sl;
+        sl.id = 1;
+        sl.pos = 0;
+        sl.size = 4 * 1024 * 1024;
+        sl.off = 0;
+        sl.len = sl.size;
+        s->push_back(sl);
+        v = 1;
+        return Status::OK();
+      });
+
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault([](ContextSPtr, RangeReq, StatusCallback cb) {
+        cb(Status::Timeout("storage timeout"));
+      });
+
+  auto* r = MakeOpenReader();
+
+  DataBuffer buf;
+  uint64_t rsize = 0;
+  Status s = r->Read(ctx_, &buf, 4096, 0, &rsize);
+  EXPECT_TRUE(s.IsIoError());
+  EXPECT_EQ(s.ToSysErrNo(), EIO);
+
+  CloseAndRelease(r);
+}
+
 // 7. Invalidate() on a range where there are no active requests does not crash.
 TEST_F(FileReaderTest, Invalidate_NoRequests_NoCrash) {
   auto* r = MakeOpenReader();


### PR DESCRIPTION
## What problem does this PR solve?

When a non-hole data block referenced by inode slice metadata is missing from object storage, the block read path propagates `Status::NotFound` to FUSE. The generic status mapping turns it into `ENOENT`, so `read(2)` incorrectly reports "No such file or directory" instead of an I/O failure.

MDS guarantees valid block metadata for non-hole blocks referenced by inode slices, and sparse holes are handled before block access. Therefore, any failure after all block reads complete is a data-block read failure.

## What is changed?

- Normalize every non-OK block-read completion status to `Status::IoError` in `ChunkReqReader::OnAllBlocksComplete`.
- Preserve the original status and request details in an error log.
- Add regression coverage for `NotFound` and another non-I/O status (`Timeout`), both of which must surface as `EIO`.
- Keep hole reads and read-mempool `ENOMEM` behavior unchanged.

## Tests

```text
FileReaderTest.Read_Hole_ReturnsZero
FileReaderTest.Read_BlockStoreError_ReturnsError
FileReaderTest.Read_BlockStoreNotFound_ReturnsIoError
FileReaderTest.Read_BlockStoreNonIoError_ReturnsIoError
FileReaderTest.Read_PoolExhausted_ReturnsOutOfMemory
```

All 5 tests passed.