### PR TITLE
[fix][common] Use write_full for rados block upload

### DIFF
--- a/src/common/blockaccess/rados/rados_accesser.cc
+++ b/src/common/blockaccess/rados/rados_accesser.cc
@@ -239,13 +239,17 @@ bool RadosAccesser::ContainerExist() {
 Status RadosAccesser::Put(const std::string& key, const char* buffer,
                           size_t length) {
   return ExecuteSyncOp(key, [&](rados_ioctx_t ioctx) {
-    int err = rados_write(ioctx, key.c_str(), buffer, length, 0);
+    // write_full replaces the whole object atomically. An offset write on an
+    // existing object is rejected (EOPNOTSUPP) on EC pools without
+    // allow_ec_overwrites, and keeps the stale tail on replicated pools when
+    // the new data is shorter.
+    int err = rados_write_full(ioctx, key.c_str(), buffer, length);
     if (err < 0) {
       LOG(ERROR) << "Failed to write object, key: " << key
                  << ", length: " << length << ", err: " << strerror(-err);
       if (err == -EOPNOTSUPP) {
-        // e.g. overwrite on an EC pool without allow_ec_overwrites: resending
-        // the identical request can never succeed, must not be retried.
+        // semantic rejection by the osd, resending the identical request can
+        // never succeed, must not be retried.
         return Status::NotSupport(strerror(-err));
       }
       return Status::IoError("Failed to write object");
@@ -452,8 +456,8 @@ static void AsyncPutCallback(RadosAsyncIOUnit* io_unit, int ret_code) {
   auto put_context =
       std::get<std::shared_ptr<PutObjectAsyncContext>>(io_unit->async_context);
   if (ret_code == -EOPNOTSUPP) {
-    // e.g. overwrite on an EC pool without allow_ec_overwrites: resending the
-    // identical request can never succeed, must not be retried.
+    // semantic rejection by the osd, resending the identical request can
+    // never succeed, must not be retried.
     put_context->status = Status::NotSupport(strerror(-ret_code));
   } else if (ret_code < 0) {
     put_context->status = Status::IoError(strerror(-ret_code));
@@ -469,9 +473,10 @@ void RadosAccesser::AsyncPut(std::shared_ptr<PutObjectAsyncContext> context) {
 
   // transfer ownership of io_unit to the callback
   ExecuteAsyncOperation(io_unit, [this, context](RadosAsyncIOUnit* unit) {
-    int err =
-        rados_aio_write(unit->ioctx, context->key.c_str(), unit->completion,
-                        context->buffer, context->buffer_size, 0);
+    // whole-object replace, same semantics as the sync Put above
+    int err = rados_aio_write_full(unit->ioctx, context->key.c_str(),
+                                   unit->completion, context->buffer,
+                                   context->buffer_size);
     if (err < 0) {
       LOG(ERROR) << "Fail AsyncPut key: " << context->key
                  << ", length: " << context->buffer_size


### PR DESCRIPTION
## What

- `RadosAccesser::Put`: replace `rados_write(..., off=0)` with `rados_write_full`
- `RadosAccesser::AsyncPut`: replace `rados_aio_write(..., off=0)` with `rados_aio_write_full`

## Why

An offset write (`CEPH_OSD_OP_WRITE`) at offset 0 is not a whole-object put:

- On an EC pool with `allow_ec_overwrites=false`, the OSD accepts it only when the object does not exist (create) or offset == object size (aligned append). Re-uploading a block whose object already exists — e.g. stage blocks reloaded after a restart where the process stopped between the upload completing and the stage file being removed — deterministically fails with `EOPNOTSUPP` and can never succeed by retrying. Observed in production as an unbounded `Operation not supported` upload-retry storm on `from=reload` stage blocks against an EC pool.
- On a replicated pool, a shorter write over a longer existing object does not truncate (object size stays `max(old, new)`), silently leaving a stale tail that `Get` (stat + read full size) would return.

`write_full` (`CEPH_OSD_OP_WRITEFULL`) atomically replaces the whole object and truncates it to the new length, on both replicated and EC pools, matching the S3 accesser's PutObject semantics.

## Verification

librados A/B test against a replicated pool and an EC pool (k=2, m=1, `allow_ec_overwrites=false`), 4 MiB object:

| op on EXISTING object | replicated | EC (no overwrites) |
|---|---|---|
| `write(off=0)` / `aio_write(off=0)` | OK, but no truncate: 1M over 4M keeps size=4M with stale tail | `-95 EOPNOTSUPP` |
| `write_full` / `aio_write_full` | OK, truncates (1M over 4M -> size=1M) | OK, truncates |

First-time upload (object absent, `write(off=0)`) succeeds on both pools, which is why only re-uploads of already-persisted blocks were affected.

Complements the retry-policy fix (`improve(cache): improve storage retry policy`), which stopped the retry storm; this removes the reason the upload could never succeed.