### PR TITLE
[fix][common] Use write_full for rados block upload

### DIFF
--- a/src/common/blockaccess/rados/rados_accesser.cc
+++ b/src/common/blockaccess/rados/rados_accesser.cc
@@ -70,10 +70,17 @@ void DestroyIoctx(rados_ioctx_t ioctx) {
 }
 
 void AppendPayload(rados_write_op_t op, const PutPayload& payload) {
-  uint64_t offset = 0;
-  for (const auto& segment : payload.Segments()) {
-    rados_write_op_write(op, segment.data, segment.size, offset);
-    offset += segment.size;
+  // The first segment goes as write_full: it atomically replaces the whole
+  // object, truncating any longer previous version (a plain offset-0 write
+  // neither truncates on replicated pools nor is accepted on EC pools
+  // without allow_ec_overwrites once the object exists). The remaining
+  // segments extend the object in order within the same op.
+  const auto& segments = payload.Segments();
+  rados_write_op_write_full(op, segments[0].data, segments[0].size);
+  uint64_t offset = segments[0].size;
+  for (size_t i = 1; i < segments.size(); i++) {
+    rados_write_op_write(op, segments[i].data, segments[i].size, offset);
+    offset += segments[i].size;
   }
 }
 }  // namespace
@@ -262,8 +269,8 @@ Status RadosAccesser::Put(const std::string& key, const PutPayload& payload) {
                  << ", length: " << payload.Size()
                  << ", err: " << strerror(-err);
       if (err == -EOPNOTSUPP) {
-        // e.g. overwrite on an EC pool without allow_ec_overwrites: resending
-        // the identical request can never succeed, must not be retried.
+        // semantic rejection by the osd, resending the identical request can
+        // never succeed, must not be retried.
         return Status::NotSupport(strerror(-err));
       }
       return Status::IoError("Failed to write object");
@@ -519,8 +526,8 @@ static void AsyncPutCallback(RadosAsyncIOUnit* io_unit, int ret_code) {
   if (ret_code == -ENOMEM) {
     put_context->status = Status::OutOfMemory("rados put ran out of memory");
   } else if (ret_code == -EOPNOTSUPP) {
-    // e.g. overwrite on an EC pool without allow_ec_overwrites: resending the
-    // identical request can never succeed, must not be retried.
+    // semantic rejection by the osd, resending the identical request can
+    // never succeed, must not be retried.
     put_context->status = Status::NotSupport(strerror(-ret_code));
   } else if (ret_code < 0) {
     put_context->status = Status::IoError(strerror(-ret_code));

--- a/test/unit/common/blockaccess/test_block_accesser.cc
+++ b/test/unit/common/blockaccess/test_block_accesser.cc
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdlib>
 #include <filesystem>
 #include <list>
 #include <memory>
@@ -244,6 +245,156 @@ TEST(S3AccesserTest, BatchDeleteEmptyKeys) {
   S3Accesser accesser(options);
 
   EXPECT_TRUE(accesser.BatchDelete({}).ok());
+}
+
+// ---- Rados Put whole-object-replace semantics (needs a real cluster) ----
+
+// Skipped unless a cluster is provided via environment:
+//   DINGOFS_UT_RADOS_MON_HOST  e.g. 192.168.10.2
+//   DINGOFS_UT_RADOS_KEY       e.g. $(ceph auth get-key client.admin)
+//   DINGOFS_UT_RADOS_POOL      pool to write test objects into
+//   DINGOFS_UT_RADOS_USER      optional, default client.admin
+// Run once against a replicated pool and once against an EC pool with
+// allow_ec_overwrites=false: a put over an existing object must succeed on
+// both (offset-write based puts get EOPNOTSUPP on the EC pool), and a
+// shorter re-put must truncate instead of leaving a stale tail.
+class RadosPutSemanticsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* mon_host = std::getenv("DINGOFS_UT_RADOS_MON_HOST");
+    const char* key = std::getenv("DINGOFS_UT_RADOS_KEY");
+    const char* pool = std::getenv("DINGOFS_UT_RADOS_POOL");
+    if (mon_host == nullptr || key == nullptr || pool == nullptr) {
+      GTEST_SKIP() << "DINGOFS_UT_RADOS_{MON_HOST,KEY,POOL} not set";
+    }
+
+    RadosOptions options;
+    options.mon_host = mon_host;
+    options.key = key;
+    options.pool_name = pool;
+    const char* user = std::getenv("DINGOFS_UT_RADOS_USER");
+    options.user_name = user != nullptr ? user : "client.admin";
+
+    accesser_ = std::make_unique<RadosAccesser>(options);
+    ASSERT_TRUE(accesser_->Init());
+
+    key_ = std::string("dingofs_ut_put_semantics_") +
+           ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  }
+
+  void TearDown() override {
+    if (accesser_) {
+      (void)accesser_->Delete(key_);
+      accesser_->Destroy();
+    }
+  }
+
+  // 1 MiB boundaries stay aligned to any practical EC stripe_width: EC pools
+  // without overwrites accept the non-first segments only as aligned appends.
+  static constexpr size_t kSegSize = 1ULL << 20;
+
+  static std::string MakeSegment(char fill) {
+    return std::string(kSegSize, fill);
+  }
+
+  static PutPayload BuildPayload(const std::vector<std::string>& segments) {
+    std::vector<PayloadSegment> refs;
+    refs.reserve(segments.size());
+    for (const auto& segment : segments) {
+      refs.push_back({segment.data(), segment.size()});
+    }
+    return PutPayload::Build(std::move(refs));
+  }
+
+  Status AsyncPutAndWait(const PutPayload& payload) {
+    auto ctx = std::make_shared<PutObjectAsyncContext>(key_, payload);
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool done = false;
+    ctx->cb = [&](const std::shared_ptr<PutObjectAsyncContext>&) {
+      std::lock_guard<std::mutex> lock(mtx);
+      done = true;
+      cv.notify_one();
+    };
+
+    accesser_->AsyncPut(key_, ctx);
+
+    std::unique_lock<std::mutex> lock(mtx);
+    if (!cv.wait_for(lock, std::chrono::seconds(30), [&] { return done; })) {
+      return Status::Internal("async put timed out");
+    }
+    return ctx->status;
+  }
+
+  std::unique_ptr<RadosAccesser> accesser_;
+  std::string key_;
+};
+
+TEST_F(RadosPutSemanticsTest, MultiSegmentPutRoundTrip) {
+  std::vector<std::string> segments = {MakeSegment('A'), MakeSegment('B')};
+  auto status = accesser_->Put(key_, BuildPayload(segments));
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  std::string data;
+  ASSERT_TRUE(accesser_->Get(key_, &data).ok());
+  ASSERT_EQ(data.size(), 2 * kSegSize);
+  EXPECT_EQ(data.front(), 'A');
+  EXPECT_EQ(data[kSegSize - 1], 'A');
+  EXPECT_EQ(data[kSegSize], 'B');
+  EXPECT_EQ(data.back(), 'B');
+}
+
+TEST_F(RadosPutSemanticsTest, RePutExistingObject) {
+  auto status =
+      accesser_->Put(key_, BuildPayload({MakeSegment('A'), MakeSegment('A')}));
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  // The re-upload of an already-persisted block (e.g. a reloaded stage
+  // block): with offset writes this fails EOPNOTSUPP on EC pools.
+  std::vector<std::string> segments = {MakeSegment('C'), MakeSegment('D')};
+  status = accesser_->Put(key_, BuildPayload(segments));
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  std::string data;
+  ASSERT_TRUE(accesser_->Get(key_, &data).ok());
+  ASSERT_EQ(data.size(), 2 * kSegSize);
+  EXPECT_EQ(data.front(), 'C');
+  EXPECT_EQ(data.back(), 'D');
+}
+
+TEST_F(RadosPutSemanticsTest, ShorterRePutTruncates) {
+  auto status =
+      accesser_->Put(key_, BuildPayload({MakeSegment('A'), MakeSegment('A'),
+                                         MakeSegment('A'), MakeSegment('A')}));
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  status = accesser_->Put(key_, BuildPayload({MakeSegment('B')}));
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  // Get sizes the read from stat: a non-truncating put would return 4 MiB
+  // here with a stale 'A' tail after the first MiB.
+  std::string data;
+  ASSERT_TRUE(accesser_->Get(key_, &data).ok());
+  ASSERT_EQ(data.size(), kSegSize);
+  EXPECT_EQ(data.front(), 'B');
+  EXPECT_EQ(data.back(), 'B');
+}
+
+TEST_F(RadosPutSemanticsTest, AsyncRePutExistingObject) {
+  auto status =
+      accesser_->Put(key_, BuildPayload({MakeSegment('A'), MakeSegment('A')}));
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  std::vector<std::string> segments = {MakeSegment('E'), MakeSegment('F')};
+  auto payload = BuildPayload(segments);
+  status = AsyncPutAndWait(payload);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  std::string data;
+  ASSERT_TRUE(accesser_->Get(key_, &data).ok());
+  ASSERT_EQ(data.size(), 2 * kSegSize);
+  EXPECT_EQ(data.front(), 'E');
+  EXPECT_EQ(data.back(), 'F');
 }
 
 }  // namespace unit_test


### PR DESCRIPTION
## What

`AppendPayload` (shared by `RadosAccesser::Put` and `AsyncPut`): emit the first payload segment as `rados_write_op_write_full` instead of `rados_write_op_write(off=0)`; the remaining segments still extend the object in order within the same compound op, so the zero-copy segmented upload (#1012) is preserved. Single-segment payloads become a pure whole-object `write_full`.

## Why

An offset write (`CEPH_OSD_OP_WRITE`) at offset 0 is not a whole-object put:

- On an EC pool with `allow_ec_overwrites=false`, the OSD accepts it only when the object does not exist (create) or offset == object size (aligned append). Re-uploading a block whose object already exists — e.g. stage blocks reloaded after a restart where the process stopped between the upload completing and the stage file being removed — deterministically fails with `EOPNOTSUPP` and can never succeed by retrying. Observed in production as an unbounded `Operation not supported` upload-retry storm on `from=reload` stage blocks against an EC pool.
- On a replicated pool, a shorter put over a longer existing object does not truncate (object size stays `max(old, new)`), silently leaving a stale tail that `Get` (stat + read full size) would return.

`write_full` (`CEPH_OSD_OP_WRITEFULL`) atomically replaces the whole object and truncates it to the new length on both replicated and EC pools, matching the S3 accesser's PutObject semantics.

## Verification

librados compound-op test against a replicated pool and an EC pool (k=2, m=1, `allow_ec_overwrites=false`), re-putting 2 MiB (2 x 1 MiB segments) onto an EXISTING 4 MiB object:

| compound op shape | replicated | EC (no overwrites) |
|---|---|---|
| `[write@0 + write@1M]` (current) | OK but size stays 4M, stale bytes readable at 2M | `-95 EOPNOTSUPP` |
| `[write_full + write@1M]` (this PR) | OK, size=2M, old tail gone | OK, size=2M, old tail gone |
| same via `rados_aio_write_op_operate` | OK, size=2M | OK, size=2M |

Note: on EC pools without overwrites, follow-up segments are accepted as ordered appends and therefore still require segment boundaries aligned to the pool's `stripe_width` — a pre-existing property of the segmented op, unchanged by this PR.

## Tests

`RadosPutSemanticsTest` in `test/unit/common/blockaccess/test_block_accesser.cc` exercises the real `RadosAccesser::Put`/`AsyncPut` against a live cluster, gated by `DINGOFS_UT_RADOS_{MON_HOST,KEY,POOL}` env vars (all 4 cases GTEST_SKIP when unset, so CI without a cluster is unaffected):

- `MultiSegmentPutRoundTrip` — 2 x 1 MiB segmented put to a new object, content round-trip
- `RePutExistingObject` / `AsyncRePutExistingObject` — re-put over an existing object (the reloaded-stage-block scenario)
- `ShorterRePutTruncates` — 1 MiB re-put over a 4 MiB object must read back exactly 1 MiB

Results: with this fix, 4/4 pass on both a replicated pool and an EC pool (`allow_ec_overwrites=false`). Negative control with the previous offset-write `AppendPayload`: 3 failures on the EC pool (both re-puts `EOPNOTSUPP` + shrink) and 1 failure on the replicated pool (`ShorterRePutTruncates` reads back 4 MiB with a stale tail), confirming the tests discriminate both defects.

Same fix for the single-buffer v5.1 code path: #1014. Complements the retry-policy fix (`improve(cache): improve storage retry policy`), which stopped the retry storm; this removes the reason the upload could never succeed.
