### PR TITLE
[feat][client] Support cleanup of uncommitted compaction slice blocks

### DIFF
--- a/src/client/vfs/compaction/compactor.h
+++ b/src/client/vfs/compaction/compactor.h
@@ -44,6 +44,18 @@ class Compactor {
   virtual Status ForceCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
                               const std::vector<Slice>& slices,
                               std::vector<Slice>& out_slices) = 0;
+
+  // Best-effort cleanup for slices produced by compaction but never committed
+  // to metadata. Callers must never pass committed slices: their blocks are
+  // live data. Two traps for the commit path:
+  // - An unknown-outcome commit failure (e.g. CompactChunk RPC timeout) must
+  //   NOT be cleaned up: the MDS may have accepted the slices, and deleting
+  //   their blocks would destroy committed data. Leak instead.
+  // - Compact() folds the skipped prefix of the input into out_slices, so on
+  //   commit failure the caller must filter out_slices down to the ids absent
+  //   from the input before passing them here.
+  virtual Status CleanupUncommittedSlices(ContextSPtr ctx,
+                                          const std::vector<Slice>& slices) = 0;
 };
 
 }  // namespace vfs

--- a/src/client/vfs/compaction/compactor_impl.cc
+++ b/src/client/vfs/compaction/compactor_impl.cc
@@ -16,9 +16,12 @@
 
 #include "client/vfs/compaction/compactor_impl.h"
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <list>
 
 #include "client/vfs/common/basync_util.h"
 #include "client/vfs/common/helper.h"
@@ -27,12 +30,20 @@
 #include "client/vfs/data/slice/common.h"
 #include "client/vfs/data/slice/slice_writer.h"
 #include "client/vfs/hub/vfs_hub.h"
+#include "common/block/block_utils.h"
 #include "utils/scoped_cleanup.h"
 
 namespace dingofs {
 namespace client {
 namespace vfs {
 using namespace compaction;
+
+DEFINE_uint32(vfs_compact_cleanup_batch_size, 100,
+              "maximum block keys per uncommitted compaction cleanup batch");
+
+// S3 DeleteObjects hard limit; the sync BatchDelete path has no guard of its
+// own, so clamp here (same bound as mds gc kBatchDeleteObjectSize).
+constexpr size_t kMaxCleanupBatchSize = 1000;
 
 Status CompactorImpl::Start() {
   LOG(INFO) << "CompactorImpl started";
@@ -148,8 +159,27 @@ Status CompactorImpl::DoCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
     writer->FlushAsync(sync.AsStatusCallBack(s));
     sync.Wait();
     if (!s.ok()) {
+      uint64_t slice_id = writer->SliceId();
       LOG(WARNING) << "Fail compaction because flush failed: " << s.ToString()
-                   << ", ino: " << ino << ", chunk_index: " << chunk_index;
+                   << ", ino: " << ino << ", chunk_index: " << chunk_index
+                   << ", slice_id: " << slice_id;
+      // slice_id 0 means allocation never published: no block was ever
+      // uploaded, so there is nothing to reclaim.
+      if (slice_id != 0) {
+        int32_t len = writer->Len();
+        Slice orphan{.id = slice_id,
+                     .size = len,
+                     .off = 0,
+                     .len = len,
+                     .pos = offset_in_chunk};
+        Status cleanup_status =
+            DoCleanupUncommittedSlices(SpanScope::GetContext(span), {orphan});
+        if (!cleanup_status.ok()) {
+          LOG(WARNING) << "Fail cleanup of uncommitted compaction slice "
+                       << slice_id << ": " << cleanup_status.ToString()
+                       << ", ino: " << ino << ", chunk_index: " << chunk_index;
+        }
+      }
       return s;
     }
 
@@ -161,7 +191,9 @@ Status CompactorImpl::DoCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
   return Status::OK();
 }
 
-// TODO: delete compact object after fail
+// Read/write failures upload nothing and flush failures self-clean in
+// DoCompact; the remaining orphan case is a failed metadata commit, which the
+// caller reclaims via CleanupUncommittedSlices.
 Status CompactorImpl::Compact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
                               const std::vector<Slice>& slices,
                               std::vector<Slice>& out_slices) {
@@ -231,6 +263,66 @@ Status CompactorImpl::ForceCompact(ContextSPtr ctx, Ino ino,
   out_slices.push_back(compacted);
 
   return Status::OK();
+}
+
+Status CompactorImpl::CleanupUncommittedSlices(
+    ContextSPtr ctx, const std::vector<Slice>& slices) {
+  DINGOFS_RETURN_NOT_OK(IncInflight());
+  auto cleanup = MakeScopedCleanup([&]() { DecInflight(); });
+
+  return DoCleanupUncommittedSlices(ctx, slices);
+}
+
+Status CompactorImpl::DoCleanupUncommittedSlices(
+    ContextSPtr ctx, const std::vector<Slice>& slices) {
+  auto span = vfs_hub_->GetTraceManager()->StartChildSpan(
+      "CompactorImpl::CleanupUncommittedSlices", ctx->GetTraceSpan());
+
+  uint32_t block_size = vfs_hub_->GetFsInfo().block_size;
+
+  std::list<std::string> keys;
+  for (const auto& slice : slices) {
+    if (slice.id == 0 || slice.size <= 0) continue;  // holes have no blocks
+    size_t slice_blocks = 0;
+    for (const auto& key :
+         EnumerateBlockKeys(slice.id, slice.size, block_size)) {
+      keys.push_back(key.StoreKey());
+      slice_blocks++;
+    }
+    LOG(INFO) << "Cleanup uncommitted compaction slice, slice_id: " << slice.id
+              << ", size: " << slice.size << ", block_size: " << block_size
+              << ", blocks: " << slice_blocks;
+  }
+
+  if (keys.empty()) return Status::OK();
+
+  VLOG(9) << "CompactorImpl::CleanupUncommittedSlices slices: " << slices.size()
+          << ", blocks: " << keys.size();
+
+  // Keep each cleanup request bounded: zero would stall this loop forever,
+  // and the upper cap keeps a misconfigured flag from tripping the backend
+  // request limit.
+  const size_t batch_size = std::clamp<size_t>(
+      FLAGS_vfs_compact_cleanup_batch_size, 1, kMaxCleanupBatchSize);
+
+  auto* accesser = vfs_hub_->GetBlockAccesser();
+  Status status = Status::OK();
+  while (!keys.empty()) {
+    auto it = keys.begin();
+    std::advance(it, std::min(keys.size(), batch_size));
+    std::list<std::string> batch;
+    batch.splice(batch.begin(), keys, keys.begin(), it);
+
+    Status s = accesser->BatchDelete(batch);
+    if (!s.ok()) {
+      LOG(WARNING)
+          << "CompactorImpl::CleanupUncommittedSlices batch delete failed: "
+          << s.ToString() << ", batch size: " << batch.size();
+      status = s;
+    }
+  }
+
+  return status;
 }
 
 }  // namespace vfs

--- a/src/client/vfs/compaction/compactor_impl.h
+++ b/src/client/vfs/compaction/compactor_impl.h
@@ -50,9 +50,15 @@ class CompactorImpl : public Compactor {
                       const std::vector<Slice>& slices,
                       std::vector<Slice>& out_slices) override;
 
+  Status CleanupUncommittedSlices(ContextSPtr ctx,
+                                  const std::vector<Slice>& slices) override;
+
  private:
   Status DoCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
                    const std::vector<Slice>& slices, Slice& out_slice);
+
+  Status DoCleanupUncommittedSlices(ContextSPtr ctx,
+                                    const std::vector<Slice>& slices);
 
   Status IncInflight();
   void DecInflight();

--- a/src/client/vfs/data/reader/file_reader.cc
+++ b/src/client/vfs/data/reader/file_reader.cc
@@ -346,8 +346,6 @@ ReadRequestSptr FileReader::NewReadRequest(int64_t s, int64_t e) {
     }
   }
 
-  RunReadRequest(new_req);
-
   return new_req;
 }
 
@@ -368,24 +366,25 @@ void FileReader::DeleteReadRequest(ReadRequestSptr req) {
 
 // Caller holds mutex_; req->mutex is not required.
 //
-// erase() is intentionally idempotent. A request may be reclaimed by several
-// uncoordinated paths that all delete on the same (kInvalid && readers==0)
-// condition: the scheduled cleanup from ScheduleReadRequestCleanup,
-// OnReadRequestComplete, the per-read CleanUpRequest, the periodic ShrinkMem,
-// and the foreground Read cleanup. The async path decides to delete while
-// holding only req->mutex and erases later under mutex_, so a synchronous path
-// can erase the same request in the gap -- erase() then legitimately finds it
-// already gone. A CHECK(erase()==1) here SIGABRTs once pool exhaustion turns
-// many readahead requests kInvalid at the same time.
+// The CHECK is sound because eligibility is stable once true: kInvalid has no
+// outgoing transition, and readers can only rise under mutex_ (PrepareRequests
+// registers the reference before the request first runs). A failure means that
+// invariant was broken — an IncReader outside mutex_, or a request made
+// runnable before its reference was registered.
+//
+// erase() stays idempotent on purpose: several paths reclaim on the same
+// (kInvalid && readers == 0) condition — the scheduled async cleanup,
+// CleanUpRequest, ShrinkMem, InvalidateRange, the foreground Read release,
+// and the destructor. A synchronous path can erase the request between the
+// async decision and this call, so finding it already gone is legitimate;
+// assert eligibility, never the erase count.
 void FileReader::DeleteReadRequestUnlock(ReadRequestSptr req) {
   VLOG(9) << fmt::format("{} DeleteReadRequest req: {}", uuid_,
                          req->ToString());
-  CHECK(CanDeleteRequest(req));
+  CHECK(CanDeleteRequest(req)) << req->ToString() << " cannot be deleted";
 
-  // The pool slot is released when req->buffer's IOBuf block refcount hits zero
-  // (after the reply), which auto-updates the pool's OutstandingBytes. No
-  // explicit release here.
-
+  // The pool slot is released when req->buffer's IOBuf block refcount hits
+  // zero (after the reply), which auto-updates the pool's OutstandingBytes.
   requests_.erase(req->ReqId());
 }
 
@@ -605,6 +604,7 @@ void FileReader::MakeReadahead(ContextSPtr ctx, const FileRange& frange) {
           "{} MakeReadahead create new req for range [{},{}), len: {}", uuid_,
           s, e, (e - s));
       auto req = NewReadRequest(s, e);
+      RunReadRequest(req);
 
       s = req->req.frange.End();
     }
@@ -733,6 +733,11 @@ std::vector<PartialReadRequest> FileReader::PrepareRequests(
         read_reqs.emplace_back(PartialReadRequest{
             .req = req, .offset = 0, .len = req->req.frange.len});
         req->IncReader();
+        // Publish the foreground ownership before the request can complete.
+        // Some BlockStore implementations and test doubles invoke callbacks
+        // synchronously; starting first would let completion observe zero
+        // readers and race a cleanup task against this acquisition.
+        RunReadRequest(req);
 
         s = req->req.frange.End();
       }

--- a/src/client/vfs/data/slice/slice_writer.h
+++ b/src/client/vfs/data/slice/slice_writer.h
@@ -75,6 +75,10 @@ class SliceWriter : public std::enable_shared_from_this<SliceWriter> {
     return len_;
   }
 
+  // Published slice id, or 0 if allocation has not succeeded. Uploads can
+  // only be submitted after an id is published.
+  uint64_t SliceId() const { return slice_id_state_->Get(); }
+
   bool IsFlushCompleted() const {
     return flush_completion_state_->IsCompleted();
   }

--- a/test/unit/client/vfs/compaction/test_compactor.cc
+++ b/test/unit/client/vfs/compaction/test_compactor.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include <atomic>
@@ -29,16 +30,20 @@
 #include "client/vfs/metasystem/mds/compact.h"
 #include "client/vfs/metasystem/mds/mds_client.h"
 #include "client/vfs/vfs_meta.h"
+#include "common/block/block_key.h"
 #include "common/status.h"
 #include "common/trace/trace_manager.h"
 #include "mds/filesystem/fs_info.h"
 #include "test/unit/client/vfs/mock/mock_compactor.h"
 #include "test/unit/client/vfs/test_base.h"
 #include "test/unit/client/vfs/test_common.h"
+#include "test/unit/common/blockaccess/mock/mock_accesser.h"
 
 namespace dingofs {
 namespace client {
 namespace vfs {
+
+DECLARE_uint32(vfs_compact_cleanup_batch_size);
 
 using ::testing::_;
 using ::testing::AnyNumber;
@@ -349,6 +354,127 @@ TEST_F(CompactorTest, RegressionHeapAllocSliceWriter_RepeatedDoCompact_Stable) {
     ASSERT_TRUE(s.ok()) << "iter=" << i << " status=" << s.ToString();
     ASSERT_EQ(out.size(), 1u) << "iter=" << i;
   }
+}
+
+// 12. CleanupUncommittedSlices reconstructs the exact dense block layout of a
+// slice: full blocks plus a partial tail, keyed under the slice id.
+TEST_F(CompactorTest, CleanupUncommittedSlices_EnumeratesDenseBlockKeys) {
+  blockaccess::MockBlockAccesser accesser;
+  ON_CALL(*mock_hub_, GetBlockAccesser()).WillByDefault(Return(&accesser));
+  EXPECT_CALL(*mock_hub_, GetBlockAccesser()).Times(AnyNumber());
+
+  std::list<std::string> deleted;
+  EXPECT_CALL(accesser, BatchDelete(_))
+      .WillOnce([&](const std::list<std::string>& keys) {
+        deleted = keys;
+        return Status::OK();
+      });
+
+  // 10 MB slice with 4 MB blocks: two full blocks + one 2 MB tail. The hole
+  // slice (id=0) must contribute nothing.
+  constexpr int32_t kSize = 10 * 1024 * 1024;
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/1001, /*pos=*/0, kSize),
+      MakeZeroSlice(0, 4096)};
+  Status s = compactor_->CleanupUncommittedSlices(ctx_, slices);
+  EXPECT_TRUE(s.ok()) << s.ToString();
+
+  std::list<std::string> expected = {
+      BlockKey(1001, 0, 4 * 1024 * 1024).StoreKey(),
+      BlockKey(1001, 1, 4 * 1024 * 1024).StoreKey(),
+      BlockKey(1001, 2, 2 * 1024 * 1024).StoreKey()};
+  EXPECT_EQ(deleted, expected);
+}
+
+// 13. Hole-only input never touches the accesser.
+TEST_F(CompactorTest, CleanupUncommittedSlices_HolesOnly_NoDelete) {
+  blockaccess::MockBlockAccesser accesser;
+  ON_CALL(*mock_hub_, GetBlockAccesser()).WillByDefault(Return(&accesser));
+  EXPECT_CALL(*mock_hub_, GetBlockAccesser()).Times(AnyNumber());
+  EXPECT_CALL(accesser, BatchDelete(_)).Times(0);
+
+  std::vector<Slice> slices = {MakeZeroSlice(0, 4096)};
+  EXPECT_TRUE(compactor_->CleanupUncommittedSlices(ctx_, slices).ok());
+}
+
+// 14. CleanupUncommittedSlices after Stop is rejected like other entry points.
+TEST_F(CompactorTest, CleanupUncommittedSlices_AfterStop_ReturnsStopError) {
+  compactor_->Stop();
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(1, 0, 4096)};
+  Status s = compactor_->CleanupUncommittedSlices(ctx_, slices);
+  EXPECT_TRUE(s.IsStop()) << s.ToString();
+}
+
+// 15. A failed flush waits for all block callbacks before reclaiming the
+// never-committed slice. Cleanup failure must not replace the flush error.
+TEST_F(CompactorTest,
+       ForceCompact_PartialUploadFailure_CleansUpAfterAllCallbacks) {
+  std::atomic<int> upload_callbacks{0};
+  ON_CALL(*mock_block_store_, PutAsync)
+      .WillByDefault([&](ContextSPtr, PutReq, StatusCallback cb) {
+        int completed = upload_callbacks.fetch_add(1) + 1;
+        if (completed == 2) {
+          cb(Status::IoError("simulated upload failure"));
+        } else {
+          cb(Status::OK());
+        }
+      });
+  EXPECT_CALL(*mock_block_store_, PutAsync).Times(3);
+
+  blockaccess::MockBlockAccesser accesser;
+  ON_CALL(*mock_hub_, GetBlockAccesser()).WillByDefault(Return(&accesser));
+  EXPECT_CALL(*mock_hub_, GetBlockAccesser()).Times(AnyNumber());
+
+  std::list<std::string> deleted;
+  EXPECT_CALL(accesser, BatchDelete(_))
+      .WillOnce([&](const std::list<std::string>& keys) {
+        EXPECT_EQ(upload_callbacks.load(), 3);
+        deleted = keys;
+        return Status::IoError("simulated cleanup failure");
+      });
+
+  constexpr int32_t kSize = 10 * 1024 * 1024;
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(1, 0, kSize)};
+  std::vector<Slice> out;
+  Status s = compactor_->ForceCompact(ctx_, 400, 0, slices, out);
+
+  EXPECT_TRUE(s.IsIoError()) << s.ToString();
+  EXPECT_NE(s.ToString().find("simulated upload failure"), std::string::npos);
+  EXPECT_TRUE(out.empty());
+  EXPECT_EQ(deleted.size(), 3u);
+}
+
+// 16. The cleanup batch loop splits keys by vfs_compact_cleanup_batch_size
+// and keeps deleting the remaining batches after one fails.
+TEST_F(CompactorTest, CleanupUncommittedSlices_SplitsBatches_KeepsGoingOnFail) {
+  const uint32_t saved_batch_size = FLAGS_vfs_compact_cleanup_batch_size;
+  FLAGS_vfs_compact_cleanup_batch_size = 1;
+
+  blockaccess::MockBlockAccesser accesser;
+  ON_CALL(*mock_hub_, GetBlockAccesser()).WillByDefault(Return(&accesser));
+  EXPECT_CALL(*mock_hub_, GetBlockAccesser()).Times(AnyNumber());
+
+  int calls = 0;
+  EXPECT_CALL(accesser, BatchDelete(_))
+      .Times(3)
+      .WillRepeatedly([&](const std::list<std::string>& keys) {
+        EXPECT_EQ(keys.size(), 1u);
+        return ++calls == 2 ? Status::IoError("simulated delete failure")
+                            : Status::OK();
+      });
+
+  // 10 MB slice with 4 MB blocks: 3 keys -> 3 single-key batches.
+  constexpr int32_t kSize = 10 * 1024 * 1024;
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/1002, /*pos=*/0, kSize)};
+  Status s = compactor_->CleanupUncommittedSlices(ctx_, slices);
+
+  EXPECT_TRUE(s.IsIoError()) << s.ToString();
+  EXPECT_EQ(calls, 3);
+
+  FLAGS_vfs_compact_cleanup_batch_size = saved_batch_size;
 }
 
 }  // namespace vfs

--- a/test/unit/client/vfs/mock/mock_compactor.h
+++ b/test/unit/client/vfs/mock/mock_compactor.h
@@ -32,12 +32,16 @@ class MockCompactor : public Compactor {
   MOCK_METHOD(Status, Stop, (), (override));
   MOCK_METHOD(Status, Compact,
               (ContextSPtr ctx, Ino ino, int64_t chunk_index,
-               const std::vector<Slice>& slices, std::vector<Slice>& out_slices),
+               const std::vector<Slice>& slices,
+               std::vector<Slice>& out_slices),
               (override));
   MOCK_METHOD(Status, ForceCompact,
               (ContextSPtr ctx, Ino ino, int64_t chunk_index,
-               const std::vector<Slice>& slices, std::vector<Slice>& out_slices),
+               const std::vector<Slice>& slices,
+               std::vector<Slice>& out_slices),
               (override));
+  MOCK_METHOD(Status, CleanupUncommittedSlices,
+              (ContextSPtr ctx, const std::vector<Slice>& slices), (override));
 };
 
 }  // namespace test


### PR DESCRIPTION
## What

Add `Compactor::CleanupUncommittedSlices` to delete the data blocks backing slices that compaction wrote but never committed to metadata, and wire it into the internal flush-failure path (closing the long-standing `TODO: delete compact object after fail`).

## Why

When a compacted slice fails before its metadata commit (SliceWriter flush failure, or later an MDS CompactChunk rejection), its uploaded blocks are orphaned: the MDS never learns the slice id, so server-side GC can never reclaim them.

## How

- `CleanupUncommittedSlices(ctx, slices)`: reconstructs every block key from `(slice_id, size, block_size)` via the shared `EnumerateBlockKeys` (same enumeration MDS GC uses), then deletes through `BlockAccesser::BatchDelete`. Deletion is idempotent (S3 delete of a missing key succeeds; rados tolerates `-ENOENT`).
- Batching is bounded by `vfs_compact_cleanup_batch_size` (default 100), clamped to `[1, 1000]` since the sync `BatchDelete` path has no guard against the S3 DeleteObjects 1000-key limit.
- `DoCompact` flush-failure path now reclaims the orphan in place. This is race-free because the compaction writer never calls `StartPrepareSliceId`: no block can stream-upload during `Write`, so every upload is registered with the flush barrier and the flush callback runs only after all of them completed. `slice_id == 0` means allocation never published and nothing was uploaded.
- Deletions stay attributable: an unconditional flush-failure WARNING carries `ino/chunk_index/slice_id`, and the cleanup choke point logs one INFO line per slice (keys are fully reconstructible from it; block filenames embed the slice id).
- Contract notes for the future MDS-commit-failure caller: never pass committed slices; never clean up on unknown-outcome failures (e.g. CompactChunk timeout); filter `Compact()` out_slices down to fresh ids first.

## Tests

Six new cases in `test_compactor.cc`: exact dense key enumeration incl. partial tail, hole-only no-op, stop-gate rejection, flush-failure cleanup ordering (delete only after all upload callbacks, cleanup error never masks the flush error), and batch splitting that keeps deleting after a mid-batch failure. Full client unit suite: 397 tests, 396 passed, 1 pre-existing skip.