### PR TITLE
[fix][client] Fix unlocked req state reads; add file reader concurrency tests

### DIFF
--- a/src/client/vfs/data/reader/file_reader.cc
+++ b/src/client/vfs/data/reader/file_reader.cc
@@ -312,9 +312,9 @@ ReadRequestSptr FileReader::NewReadRequest(int64_t s, int64_t e) {
       "actual=[{}-{}), len={}",
       uuid_, s, e, block_end, s, req_end, (req_end - s));
 
-  std::shared_ptr<ReadRequest> req(
-      new ReadRequest(ino_, chunk_indx, chunk_offset,
-                      FileRange{.offset = s, .len = (req_end - s)}));
+  std::shared_ptr<ReadRequest> req = std::make_shared<ReadRequest>(
+      ino_, chunk_indx, chunk_offset,
+      FileRange{.offset = s, .len = (req_end - s)});
 
   req->state = ReadRequestState::kNew;
   req->status = Status::OK();
@@ -353,7 +353,7 @@ ReadRequestSptr FileReader::NewReadRequest(int64_t s, int64_t e) {
 // path so request erasure runs in the reader cleanup lane.
 void FileReader::ScheduleReadRequestCleanup(ReadRequestSptr req) {
   AcquireRef();
-  vfs_hub_->GetReadCleanupExecutor()->Execute([&, req]() {
+  vfs_hub_->GetReadCleanupExecutor()->Execute([this, req]() {
     DeleteReadRequest(req);
     ReleaseRef();
   });
@@ -548,8 +548,10 @@ void FileReader::MakeReadahead(ContextSPtr ctx, const FileRange& frange) {
     int64_t req_id = it->first;
     ReadRequest* req = it->second.get();
 
+    std::unique_lock<std::mutex> req_lock(req->mutex);
+
     VLOG(9) << fmt::format("{} MakeReadahead check req: {} for frange: {}",
-                           uuid_, req->ToString(), ahead.ToString());
+                           uuid_, req->ToStringUnlock(), ahead.ToString());
 
     if (req->state == ReadRequestState::kInvalid) {
       continue;
@@ -661,8 +663,12 @@ std::vector<int64_t> FileReader::SplitRange(ContextSPtr ctx,
   };
 
   for (const auto& [uuid, req] : requests_) {
+    // state is written by completion threads under req->mutex only; an
+    // unlocked read here is a data race even though mutex_ is held.
+    std::unique_lock<std::mutex> req_lock(req->mutex);
+
     VLOG(9) << fmt::format("{} SplitRange check req: {} for frange: {}", uuid_,
-                           req->ToString(), frange.ToString());
+                           req->ToStringUnlock(), frange.ToString());
 
     if (req->state == ReadRequestState::kInvalid) {
       continue;
@@ -822,15 +828,27 @@ void FileReader::CheckPrefetch(ContextSPtr ctx, const Attr& attr,
       "FileReader::CheckPrefetch", ctx->GetTraceSpan());
 
   uint64_t time_now = butil::monotonic_time_s();
-  if (FLAGS_vfs_intime_warmup_enable &&
-      ((time_now - last_intime_warmup_trigger_) >
-           FLAGS_vfs_warmup_trigger_restart_interval_secs ||
-       (attr.mtime - last_intime_warmup_mtime_) >
-           FLAGS_vfs_warmup_mtime_restart_interval_secs)) {
-    LOG(INFO) << fmt::format("{} Trigger intime warmup", uuid_);
-    last_intime_warmup_trigger_ = time_now;
-    last_intime_warmup_mtime_ = attr.mtime;
+  bool trigger_warmup = false;
+  if (FLAGS_vfs_intime_warmup_enable) {
+    // Concurrent reads reach here without mutex_, so checking and advancing
+    // the two watermarks must be one atomic step or racing readers all pass
+    // the threshold and double-submit. An mtime regression (clock fix,
+    // cross-node drift, truncate-recreate) means changed content, so it
+    // triggers explicitly instead of via unsigned-subtraction wraparound.
+    std::lock_guard<std::mutex> lk(intime_warmup_mutex_);
+    if ((time_now - last_intime_warmup_trigger_) >
+            FLAGS_vfs_warmup_trigger_restart_interval_secs ||
+        attr.mtime < last_intime_warmup_mtime_ ||
+        (attr.mtime - last_intime_warmup_mtime_) >
+            FLAGS_vfs_warmup_mtime_restart_interval_secs) {
+      last_intime_warmup_trigger_ = time_now;
+      last_intime_warmup_mtime_ = attr.mtime;
+      trigger_warmup = true;
+    }
+  }
 
+  if (trigger_warmup) {
+    LOG(INFO) << fmt::format("{} Trigger intime warmup", uuid_);
     vfs_hub_->GetWarmupManager()->SubmitTask(WarmupTaskContext{ino_});
   }
 

--- a/src/client/vfs/data/reader/file_reader.h
+++ b/src/client/vfs/data/reader/file_reader.h
@@ -36,6 +36,7 @@ namespace client {
 namespace vfs {
 
 class VFSHub;
+class FileReaderTestPeer;
 
 class FileReader {
  public:
@@ -60,6 +61,8 @@ class FileReader {
   void ReleaseRef();
 
  private:
+  friend class FileReaderTestPeer;
+
   Status GetAttr(ContextSPtr ctx, Attr* attr);
 
   void CheckPrefetch(ContextSPtr ctx, const Attr& attr,
@@ -73,33 +76,34 @@ class FileReader {
   int64_t UsedMem() const;
   double UsedRatio() const;
 
-  // pretected by mutex_
+  // Posts DoReadRequst to the read executor; takes no locks itself.
   void RunReadRequest(ReadRequestSptr req);
+  // Run on executor threads WITHOUT mutex_; they only take req->mutex. This is
+  // why cleanup eligibility must be re-established under mutex_ before erase.
   void OnReadRequestComplete(ReadRequestSptr req, Status s);
-  // pretected by mutex_
   void DoReadRequst(ReadRequestSptr req);
 
-  // pretected by mutex_
+  // Caller must hold mutex_.
   ReadRequestSptr NewReadRequest(int64_t s, int64_t e);
-  // pretected by mutex_
+  // Caller must hold mutex_.
   void DeleteReadRequestUnlock(ReadRequestSptr req);
   void DeleteReadRequest(ReadRequestSptr req);
   void ScheduleReadRequestCleanup(ReadRequestSptr req);
 
-  // pretected by mutex_
+  // Caller must hold mutex_.
   void CheckReadahead(ContextSPtr ctx, const FileRange& frange, int64_t flen);
-  // pretected by mutex_
+  // Caller must hold mutex_.
   void MakeReadahead(ContextSPtr ctx, const FileRange& frange);
 
-  // pretected by mutex_
+  // Caller must hold mutex_.
   std::vector<int64_t> SplitRange(ContextSPtr ctx, const FileRange& frange);
-  // pretected by mutex_
+  // Caller must hold mutex_.
   std::vector<PartialReadRequest> PrepareRequests(
       ContextSPtr ctx, const std::vector<int64_t>& ranges);
 
-  // pretected by mutex_
+  // Caller must hold mutex_.
   bool IsProtectedReq(const ReadRequestSptr& req) const;
-  // pretected by mutex_
+  // Caller must hold mutex_.
   void CleanUpRequest(ContextSPtr ctx, const FileRange& frange);
 
   Status WaitAllReadRequest(ContextSPtr ctx,
@@ -114,6 +118,9 @@ class FileReader {
 
   std::atomic<int64_t> refs_{0};
 
+  // Guards the two warmup watermarks below: CheckPrefetch runs before Read
+  // takes mutex_, and check-plus-advance must be atomic across readers.
+  std::mutex intime_warmup_mutex_;
   uint64_t last_intime_warmup_mtime_{0};
   uint64_t last_intime_warmup_trigger_{0};
 
@@ -125,8 +132,6 @@ class FileReader {
   // seq -> ReadRequestSptr
   std::map<int64_t, ReadRequestSptr> requests_;
 };
-
-using FileReaderUPtr = std::unique_ptr<FileReader>;
 
 }  // namespace vfs
 }  // namespace client

--- a/src/client/vfs/handle/handle_manager.cc
+++ b/src/client/vfs/handle/handle_manager.cc
@@ -185,18 +185,8 @@ Handle* HandleManager::NewHandle(uint64_t fh, Ino ino, int flags) {
   // Reader is always per-fh.
   handle->resources.reader = new FileReader(vfs_hub_, fh, ino);
   handle->resources.reader->AcquireRef();
-  Status s = handle->resources.reader->Open();
-  if (!s.ok()) {
-    LOG(ERROR) << fmt::format(
-        "NewHandle: reader Open failed, fh={}, ino={}, "
-        "status={}",
-        fh, ino, s.ToString());
-    // Reader holds 1 ref from AcquireRef above; release it (reader will
-    // delete-this when refs hit 0). Then drop the bare handle.
-    handle->resources.reader->ReleaseRef();
-    delete handle;
-    return nullptr;
-  }
+  CHECK(handle->resources.reader->Open().ok())
+      << "FileReader::Open is currently infallible";
 
   // Writer only for writable opens. Borrowed from WriterTable.
   if ((flags & O_ACCMODE) != O_RDONLY) {

--- a/test/unit/client/vfs/data/test_file_reader.cc
+++ b/test/unit/client/vfs/data/test_file_reader.cc
@@ -19,16 +19,22 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <memory>
 #include <mutex>
+#include <random>
+#include <thread>
 
 #include "client/vfs/data/reader/file_reader.h"
 #include "client/vfs/data_buffer.h"
 #include "common/options/client.h"
 #include "common/trace/trace_manager.h"
 #include "test/unit/client/vfs/test_base.h"
+#include "utils/scoped_cleanup.h"
 
 namespace dingofs {
 namespace client {
@@ -85,6 +91,34 @@ class FileReaderTest : public test::VFSTestBase {
   static constexpr uint64_t kFh = 3;
   uint64_t file_length_ = 0;
   std::unique_ptr<TraceManager> trace_manager_;
+};
+
+// Read-only white-box synchronization for concurrency tests. Production
+// behavior is still driven exclusively through FileReader's public API; the
+// peer only lets a test wait for a precise state instead of guessing executor
+// progress with sleep_for().
+class FileReaderTestPeer {
+ public:
+  static bool WaitForRequest(
+      FileReader* reader, int64_t offset, ReadRequestState state,
+      int32_t min_readers,
+      std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    do {
+      {
+        std::lock_guard<std::mutex> reader_lock(reader->mutex_);
+        for (const auto& [id, req] : reader->requests_) {
+          std::lock_guard<std::mutex> req_lock(req->mutex);
+          if (req->req.frange.offset == offset && req->state == state &&
+              req->readers >= min_readers) {
+            return true;
+          }
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return false;
+  }
 };
 
 // 1. Read() of a zero-length range returns 0 bytes.
@@ -403,13 +437,8 @@ TEST_F(FileReaderTest, Close_SetsClosingFlag_ReadAborted) {
   DataBuffer buf;
   uint64_t rsize = 0;
   Status s = r->Read(ctx_, &buf, 4096, 0, &rsize);
-  // After Close() the reader is closing; read should fail or return 0.
-  // Depending on timing it may succeed with 0 bytes or return Abort.
-  if (s.ok()) {
-    EXPECT_EQ(rsize, 0u);
-  } else {
-    EXPECT_FALSE(s.ok());
-  }
+  EXPECT_TRUE(s.IsAbort()) << s.ToString();
+  EXPECT_EQ(rsize, 0u);
 
   r->ReleaseRef();
 }
@@ -459,6 +488,7 @@ TEST_F(FileReaderTest, Read_PoolExhausted_ReturnsOutOfMemory) {
   // bounded wait (~2s); we're testing the hard-fail path, not the wait.
   double saved_wm = FLAGS_vfs_read_mempool_backpressure_watermark;
   FLAGS_vfs_read_mempool_backpressure_watermark = 2.0;
+  SCOPED_CLEANUP({ FLAGS_vfs_read_mempool_backpressure_watermark = saved_wm; });
 
   // Hog the entire read mempool: any further Allocate returns an empty handle.
   auto hog = mock_hub_->GetReadMemPool()->Allocate(64ull * 1024 * 1024);
@@ -487,7 +517,463 @@ TEST_F(FileReaderTest, Read_PoolExhausted_ReturnsOutOfMemory) {
   EXPECT_TRUE(s.IsOutOfMemory()) << s.ToString();
 
   CloseAndRelease(r);
-  FLAGS_vfs_read_mempool_backpressure_watermark = saved_wm;
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency coverage. Methodology: a "gated" RangeAsync mock blocks the
+// first matching callback on a test-controlled latch, turning racy windows
+// (request kBusy, foreground waiting) into deterministic interleavings
+// without touching production code.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// One non-hole slice covering the whole 4 MiB file so reads consult the
+// block store instead of zero-filling holes.
+void InstallFullSlice(test::MockMetaSystem* meta) {
+  ON_CALL(*meta, ReadSlice)
+      .WillByDefault([](ContextSPtr, Ino, uint64_t, uint64_t,
+                        std::vector<Slice>* s, uint64_t& v) {
+        s->clear();
+        Slice sl;
+        sl.id = 1;
+        sl.pos = 0;
+        sl.size = 4 * 1024 * 1024;
+        sl.off = 0;
+        sl.len = sl.size;
+        s->push_back(sl);
+        v = 1;
+        return Status::OK();
+      });
+}
+
+// Latch that blocks the first RangeAsync matching (offset, length); later
+// calls (and all non-matching calls) complete inline with zero-filled data.
+struct RangeGate {
+  std::mutex mu;
+  std::condition_variable cv;
+  bool released{false};
+  std::once_flag enter_once;
+  std::promise<void> entered_promise;
+  std::shared_future<void> entered{entered_promise.get_future().share()};
+
+  void EnterAndWait() {
+    std::call_once(enter_once, [&] { entered_promise.set_value(); });
+    std::unique_lock<std::mutex> lk(mu);
+    cv.wait(lk, [&] { return released; });
+  }
+
+  bool WaitEntered(
+      std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+    return entered.wait_for(timeout) == std::future_status::ready;
+  }
+
+  void Release() {
+    {
+      std::lock_guard<std::mutex> lk(mu);
+      released = true;
+    }
+    cv.notify_all();
+  }
+};
+
+}  // namespace
+
+// 15. Regression for the request birth-window race: a request must not become
+// runnable before its creator registered a reference. With an inline-error
+// BlockStore the completion path fires as early as possible; pre-fix this
+// crashed CHECK(CanDeleteRequest) within a few hundred iterations on 2 cores.
+TEST_F(FileReaderTest, Read_RepeatedInlineError_NoCleanupRace) {
+  InstallFullSlice(mock_meta_system_);
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault([](ContextSPtr, RangeReq, StatusCallback cb) {
+        cb(Status::IoError("inline failure"));
+      });
+
+  auto* r = MakeOpenReader();
+  for (int i = 0; i < 200; ++i) {
+    DataBuffer buf;
+    uint64_t rsize = 0;
+    Status s = r->Read(ctx_, &buf, 4096, /*offset=*/0, &rsize);
+    ASSERT_FALSE(s.ok()) << "iter=" << i;
+  }
+  CloseAndRelease(r);
+}
+
+// 16. Invalidate() on a kBusy request must trigger a re-read (kRefresh ->
+// kNew -> second RangeAsync). Even if the invalidated first attempt fails, its
+// result is stale and must not be returned to the foreground reader.
+TEST_F(FileReaderTest, Invalidate_BusyFailedRequest_RefreshRereads) {
+  InstallFullSlice(mock_meta_system_);
+
+  // Gate only the first fetch of the foreground request (offset 0, 4 KiB) so
+  // an ungated readahead fetch cannot steal the latch and let the read finish
+  // before Invalidate() lands on the kBusy request.
+  auto gate = std::make_shared<RangeGate>();
+  auto target_calls = std::make_shared<std::atomic<int>>(0);
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault(
+          [gate, target_calls](ContextSPtr, RangeReq req, StatusCallback cb) {
+            bool is_target = (req.offset == 0 && req.length == 4096);
+            int call = is_target ? target_calls->fetch_add(1) : -1;
+            if (call == 0) {
+              gate->EnterAndWait();
+            }
+            if (call == 0) {
+              cb(Status::IoError("stale first attempt"));
+              return;
+            }
+            if (req.dst.base != nullptr && req.length > 0) {
+              std::memset(req.dst.data(), 0, req.length);
+            }
+            cb(Status::OK());
+          });
+
+  auto* r = MakeOpenReader();
+
+  DataBuffer buf;
+  uint64_t rsize = 0;
+  Status read_status;
+  std::thread reader(
+      [&] { read_status = r->Read(ctx_, &buf, 4096, 0, &rsize); });
+
+  if (!gate->WaitEntered()) {
+    gate->Release();
+    reader.join();
+    CloseAndRelease(r);
+    FAIL() << "foreground request did not enter RangeAsync";
+  }
+  r->Invalidate(0, 4096);  // kBusy -> kRefresh
+  r->Invalidate(0, 4096);  // repeated invalidation must remain refresh-safe
+  gate->Release();         // first read completes, must be discarded
+
+  reader.join();
+  EXPECT_TRUE(read_status.ok()) << read_status.ToString();
+  EXPECT_EQ(rsize, 4096u);
+  // The refreshed request re-fetched its block from the block store.
+  EXPECT_EQ(target_calls->load(), 2);
+
+  CloseAndRelease(r);
+}
+
+// 17. Two concurrent reads of the same range share one in-flight request
+// (readers > 1) instead of each fetching the block.
+TEST_F(FileReaderTest, ConcurrentReads_ShareOneRequest) {
+  InstallFullSlice(mock_meta_system_);
+
+  auto gate = std::make_shared<RangeGate>();
+  auto target_calls = std::make_shared<std::atomic<int>>(0);
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault(
+          [gate, target_calls](ContextSPtr, RangeReq req, StatusCallback cb) {
+            bool is_target = (req.offset == 0 && req.length == 4096);
+            if (is_target && target_calls->fetch_add(1) == 0) {
+              gate->EnterAndWait();
+            }
+            if (req.dst.base != nullptr && req.length > 0) {
+              std::memset(req.dst.data(), 0, req.length);
+            }
+            cb(Status::OK());
+          });
+
+  auto* r = MakeOpenReader();
+
+  DataBuffer buf1, buf2;
+  uint64_t rsize1 = 0, rsize2 = 0;
+  Status s1, s2;
+  std::thread t1([&] { s1 = r->Read(ctx_, &buf1, 4096, 0, &rsize1); });
+  if (!gate->WaitEntered()) {
+    gate->Release();
+    t1.join();
+    CloseAndRelease(r);
+    FAIL() << "first request did not enter RangeAsync";
+  }
+  std::thread t2([&] { s2 = r->Read(ctx_, &buf2, 4096, 0, &rsize2); });
+
+  // Do not release the fetch until the second foreground read has actually
+  // attached to this kBusy request. This makes readers>1 deterministic.
+  if (!FileReaderTestPeer::WaitForRequest(
+          r, /*offset=*/0, ReadRequestState::kBusy, /*min_readers=*/2)) {
+    gate->Release();
+    t1.join();
+    t2.join();
+    CloseAndRelease(r);
+    FAIL() << "second reader did not attach to the shared request";
+  }
+  gate->Release();
+
+  t1.join();
+  t2.join();
+  EXPECT_TRUE(s1.ok()) << s1.ToString();
+  EXPECT_TRUE(s2.ok()) << s2.ToString();
+  EXPECT_EQ(rsize1, 4096u);
+  EXPECT_EQ(rsize2, 4096u);
+  // Exactly one fetch of the shared block: the second read attached to the
+  // in-flight request rather than issuing its own.
+  EXPECT_EQ(target_calls->load(), 1);
+
+  CloseAndRelease(r);
+}
+
+// 18. Close() while a read is blocked waiting for its request must abort the
+// read once the in-flight completion delivers (completion sees closing_ and
+// invalidates even a successful fetch).
+TEST_F(FileReaderTest, Close_WhileWaiting_ReturnsAbort) {
+  InstallFullSlice(mock_meta_system_);
+
+  // Gate only the foreground request (offset 0, 4 KiB): the first read jumps
+  // readahead to level 1, and an ungated readahead fetch must not steal the
+  // latch or the foreground read would complete before Close().
+  auto gate = std::make_shared<RangeGate>();
+  auto target_calls = std::make_shared<std::atomic<int>>(0);
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault(
+          [gate, target_calls](ContextSPtr, RangeReq req, StatusCallback cb) {
+            bool is_target = (req.offset == 0 && req.length == 4096);
+            if (is_target && target_calls->fetch_add(1) == 0) {
+              gate->EnterAndWait();
+            }
+            if (req.dst.base != nullptr && req.length > 0) {
+              std::memset(req.dst.data(), 0, req.length);
+            }
+            cb(Status::OK());
+          });
+
+  auto* r = MakeOpenReader();
+
+  DataBuffer buf;
+  uint64_t rsize = 0;
+  Status read_status;
+  std::thread reader(
+      [&] { read_status = r->Read(ctx_, &buf, 4096, 0, &rsize); });
+
+  if (!gate->WaitEntered()) {
+    gate->Release();
+    reader.join();
+    CloseAndRelease(r);
+    FAIL() << "foreground request did not enter RangeAsync";
+  }
+  r->Close();
+  gate->Release();  // completion fires, sees closing_, invalidates
+
+  reader.join();
+  EXPECT_TRUE(read_status.IsAbort()) << read_status.ToString();
+
+  r->ReleaseRef();
+}
+
+// 19. Invalidate() on a kReady request that is still owned by a foreground
+// read must retain the request, move it back to kNew, and refill it before the
+// foreground read is allowed to consume that range.
+TEST_F(FileReaderTest, Invalidate_ReadyRequestWithReader_Rereads) {
+  InstallFullSlice(mock_meta_system_);
+  ON_CALL(*mock_hub_, GetFsInfo())
+      .WillByDefault(Return(test::MakeTestFsInfo(4 * 1024 * 1024, 4096)));
+
+  auto first_gate = std::make_shared<RangeGate>();
+  auto second_block_calls = std::make_shared<std::atomic<int>>(0);
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault([first_gate, second_block_calls](ContextSPtr, RangeReq req,
+                                                      StatusCallback cb) {
+        const std::string key = req.handle.Filename();
+        if (key.rfind("1_0_", 0) == 0) {
+          first_gate->EnterAndWait();
+        } else if (key.rfind("1_1_", 0) == 0) {
+          second_block_calls->fetch_add(1);
+        }
+        if (req.dst.base != nullptr && req.length > 0) {
+          std::memset(req.dst.data(), 0, req.length);
+        }
+        cb(Status::OK());
+      });
+
+  auto* r = MakeOpenReader();
+  DataBuffer buf;
+  uint64_t rsize = 0;
+  Status read_status;
+  std::thread reader(
+      [&] { read_status = r->Read(ctx_, &buf, 8192, 0, &rsize); });
+
+  if (!first_gate->WaitEntered()) {
+    first_gate->Release();
+    reader.join();
+    CloseAndRelease(r);
+    FAIL() << "first block did not enter RangeAsync";
+  }
+  // The foreground Read waits on block 0 while block 1 has already completed,
+  // leaving block 1 in kReady with its reader reference still registered.
+  if (!FileReaderTestPeer::WaitForRequest(
+          r, /*offset=*/4096, ReadRequestState::kReady, /*min_readers=*/1)) {
+    first_gate->Release();
+    reader.join();
+    CloseAndRelease(r);
+    FAIL() << "second block did not reach kReady with a reader";
+  }
+
+  r->Invalidate(/*offset=*/4096, /*size=*/4096);
+  if (!FileReaderTestPeer::WaitForRequest(
+          r, /*offset=*/4096, ReadRequestState::kReady, /*min_readers=*/1)) {
+    first_gate->Release();
+    reader.join();
+    CloseAndRelease(r);
+    FAIL() << "invalidated second block did not become ready again";
+  }
+  first_gate->Release();
+
+  reader.join();
+  EXPECT_TRUE(read_status.ok()) << read_status.ToString();
+  EXPECT_EQ(rsize, 8192u);
+  EXPECT_EQ(second_block_calls->load(), 2);
+
+  CloseAndRelease(r);
+}
+
+// 20. Bounded chaos test for the public concurrency surface. Multiple readers
+// and invalidators operate on one FileReader until Close races all of them.
+// Fixed per-thread seeds keep failures reproducible; the test accepts only a
+// complete read before Close or Abort while/after Close.
+TEST_F(FileReaderTest, ConcurrentReadInvalidateClose_Chaos) {
+  InstallFullSlice(mock_meta_system_);
+  ON_CALL(*mock_hub_, GetFsInfo())
+      .WillByDefault(Return(test::MakeTestFsInfo(4 * 1024 * 1024, 64 * 1024)));
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault([](ContextSPtr, RangeReq req, StatusCallback cb) {
+        if (req.dst.base != nullptr && req.length > 0) {
+          std::memset(req.dst.data(), 0, req.length);
+        }
+        cb(Status::OK());
+      });
+
+  auto* r = MakeOpenReader();
+  std::atomic<bool> stop{false};
+  std::atomic<uint64_t> successful_reads{0};
+  std::atomic<uint64_t> aborted_reads{0};
+  std::atomic<uint64_t> invalidations{0};
+  std::mutex error_mu;
+  std::vector<std::string> errors;
+
+  auto record_error = [&](std::string error) {
+    std::lock_guard<std::mutex> lk(error_mu);
+    errors.push_back(std::move(error));
+  };
+
+  constexpr int kReaderThreads = 8;
+  constexpr int kInvalidatorThreads = 2;
+  constexpr int64_t kReadSize = 4096;
+  constexpr int64_t kMaxOffset = 4 * 1024 * 1024 - kReadSize;
+  std::vector<std::thread> workers;
+  workers.reserve(kReaderThreads + kInvalidatorThreads);
+
+  for (int thread_id = 0; thread_id < kReaderThreads; ++thread_id) {
+    workers.emplace_back([&, thread_id] {
+      std::mt19937 rng(0x52454144u + static_cast<uint32_t>(thread_id));
+      std::uniform_int_distribution<int64_t> offset_dist(0, kMaxOffset / 4096);
+      while (!stop.load(std::memory_order_acquire)) {
+        int64_t offset = offset_dist(rng) * 4096;
+        DataBuffer buf;
+        uint64_t rsize = 0;
+        Status s = r->Read(ctx_, &buf, kReadSize, offset, &rsize);
+        if (s.ok()) {
+          successful_reads.fetch_add(1, std::memory_order_relaxed);
+          if (rsize != kReadSize) {
+            record_error(
+                fmt::format("successful read returned {} bytes at offset {}",
+                            rsize, offset));
+          }
+        } else if (s.IsAbort()) {
+          aborted_reads.fetch_add(1, std::memory_order_relaxed);
+        } else {
+          record_error(fmt::format("unexpected read status at offset {}: {}",
+                                   offset, s.ToString()));
+        }
+      }
+    });
+  }
+
+  for (int thread_id = 0; thread_id < kInvalidatorThreads; ++thread_id) {
+    workers.emplace_back([&, thread_id] {
+      std::mt19937 rng(0x494e5641u + static_cast<uint32_t>(thread_id));
+      std::uniform_int_distribution<int64_t> offset_dist(0, kMaxOffset / 4096);
+      while (!stop.load(std::memory_order_acquire)) {
+        r->Invalidate(offset_dist(rng) * 4096, kReadSize);
+        invalidations.fetch_add(1, std::memory_order_relaxed);
+        std::this_thread::yield();
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  r->Close();
+  // Let already-running and newly-entering reads observe closing_ before
+  // asking workers to stop.
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  stop.store(true, std::memory_order_release);
+
+  for (auto& worker : workers) {
+    worker.join();
+  }
+
+  EXPECT_TRUE(errors.empty()) << (errors.empty() ? "" : errors.front());
+  EXPECT_GT(successful_reads.load(), 0u);
+  EXPECT_GT(aborted_reads.load(), 0u);
+  EXPECT_GT(invalidations.load(), 0u);
+
+  r->ReleaseRef();
+}
+
+// 21. The per-read CleanUpRequest keeps the request table bounded: once more
+// than kMaxReadRequests(64) unprotected requests accumulate, old ones are
+// evicted and a later read of the same range fetches again.
+TEST_F(FileReaderTest, ManySmallReads_EvictionBounded) {
+  InstallFullSlice(mock_meta_system_);
+  // 64 KiB blocks: with the default 4 MiB block the whole file is one block
+  // and IsProtectedReq's window (>= one block around the last offset) would
+  // always cover offset 0, so nothing could ever be evicted.
+  ON_CALL(*mock_hub_, GetFsInfo())
+      .WillByDefault(Return(test::MakeTestFsInfo(4 * 1024 * 1024, 64 * 1024)));
+
+  // Count fetches of the file-offset-0 request only: slice 1 block 0 at
+  // in-block offset 0 (strided reads below alias in-block offset 0 in OTHER
+  // blocks, so match the block identity too).
+  auto offset0_calls = std::make_shared<std::atomic<int>>(0);
+  ON_CALL(*mock_block_store_, RangeAsync)
+      .WillByDefault(
+          [offset0_calls](ContextSPtr, RangeReq req, StatusCallback cb) {
+            if (req.handle.Filename().rfind("1_0_", 0) == 0 &&
+                req.offset == 0 && req.length == 4096) {
+              offset0_calls->fetch_add(1);
+            }
+            if (req.dst.base != nullptr && req.length > 0) {
+              std::memset(req.dst.data(), 0, req.length);
+            }
+            cb(Status::OK());
+          });
+
+  auto* r = MakeOpenReader();
+  DataBuffer first;
+  uint64_t rsize = 0;
+  ASSERT_TRUE(r->Read(ctx_, &first, 4096, /*offset=*/0, &rsize).ok());
+  EXPECT_EQ(offset0_calls->load(), 1);
+
+  // Disjoint 4 KiB reads alternating between a low ([64K, ~1M)) and a high
+  // ([3M, ~4M)) region: every jump exceeds kSeqAccessWindowSize (2 MiB), so
+  // the readahead policy degrades to level 0 after the first hops — no big
+  // readahead request swallows the strides (each read creates its own
+  // request) and IsProtectedReq() protects nothing. That pushes the table
+  // past kMaxReadRequests(64) and lets eviction reclaim the offset-0 entry.
+  for (int i = 0; i < 112; ++i) {
+    DataBuffer buf;
+    int64_t base = (i % 2 == 0) ? 64 * 1024 : 3 * 1024 * 1024;
+    int64_t offset = base + static_cast<int64_t>(i / 2) * 16 * 1024;
+    ASSERT_TRUE(r->Read(ctx_, &buf, 4096, offset, &rsize).ok()) << i;
+  }
+
+  // The offset-0 request was evicted, so this read must fetch again.
+  DataBuffer again;
+  ASSERT_TRUE(r->Read(ctx_, &again, 4096, /*offset=*/0, &rsize).ok());
+  EXPECT_EQ(offset0_calls->load(), 2);
+
+  CloseAndRelease(r);
 }
 
 }  // namespace vfs


### PR DESCRIPTION
## What

Follow-up to #1017 (`8906bab99` fixed the request birth-window race). This closes the remaining concurrency findings from a full field-by-field audit of `FileReader`, and adds the concurrency test coverage that module previously lacked entirely.

## Fixes

- **Unlocked reads of `ReadRequest::state`** (`SplitRange`/`MakeReadahead`): completion threads write `state` under `req->mutex` only, while these scans read it holding just `mutex_` — no happens-before edge, a standard C++ data race (TSan would flag it). Both loops now take `req->mutex` (and switch the adjacent VLOG to `ToStringUnlock()` to avoid self-deadlock on the non-recursive mutex — same idiom as `ShrinkMem`). Lock order stays `mutex_` → `req->mutex`. Business impact was benign (stale snapshots are tolerated by design; `PrepareRequests` re-checks under the lock), so this is a memory-model conformance fix.
- **Intime-warmup watermark race** (`CheckPrefetch`): runs before `Read` takes `mutex_`, so concurrent reads raced the check-and-advance of two plain `uint64_t` watermarks — UB plus duplicate warmup submissions. A dedicated `intime_warmup_mutex_` now makes check+advance one atomic step (single winner, `SubmitTask` stays outside the lock). An mtime regression now triggers explicitly instead of via unsigned-subtraction wraparound.
- **`HandleManager::NewHandle` open-fail path**: released the reader without `Close()`, which would trip the destructor's `CHECK(closing_)` the moment `FileReader::Open` ever becomes fallible. The dead error path is replaced with `CHECK(Open().ok())` documenting the infallible contract, forcing whoever makes Open fallible to implement real cleanup.
- Cleanups: stale/misspelled lock annotations in `file_reader.h` corrected to the real contracts (`DoReadRequst`/`OnReadRequestComplete` run WITHOUT `mutex_` — the structural reason behind the birth-window race), unused `FileReaderUPtr` typedef removed, `[&, req]` capture made explicit.

## Tests (+7, all deterministic)

Gated-mock methodology: the mock BlockStore blocks a targeted `RangeAsync` callback on a test-controlled latch, turning racy windows into deterministic interleavings without touching production code. A read-only `FileReaderTestPeer` waits for precise request states instead of sleeping.

- birth-window regression (repeated inline-error reads)
- `Invalidate` on kBusy → kRefresh re-read; `Invalidate` on kReady-with-reader → rerun
- two concurrent reads share one in-flight request (single fetch)
- `Close()` while a read waits → Abort
- request-table eviction bound (kMaxReadRequests)
- chaos: 8 readers × 2 invalidators × mid-run Close, fixed seeds, strict status accounting

## Verification

clang-format clean; full client unit suite 404 tests, 403 passed (1 pre-existing skip); `taskset -c 0,1 --gtest_repeat=200` on the FileReader suite: zero failures.