### PR TITLE
[feat][client] Add fuse_subtype mount option flag

### DIFF
--- a/src/client/fuse/fuse_server.cc
+++ b/src/client/fuse/fuse_server.cc
@@ -49,6 +49,10 @@ namespace fuse {
 DEFINE_string(fuse_mount_options, "default_permissions",
               "mount options for libfuse");
 
+DEFINE_string(fuse_subtype, "dingofs",
+              "fuse subtype mount option; empty mounts as plain 'fuse' "
+              "(required by xfstests, which expects fstype == FSTYP=fuse)");
+
 DEFINE_bool(fuse_use_single_thread, false, "use single thread for libfuse");
 DEFINE_validator(fuse_use_single_thread, brpc::PassValidate);
 
@@ -134,7 +138,10 @@ int FuseServer::AddMountOptions() {
 
   //  Values shown in "df -T" and friends first column "Filesystem",DindoFS +
   //  filesystem name
-  if (FuseAddOpts(&args_, (const char*)"subtype=dingofs") != 0) return 1;
+  if (!FLAGS_fuse_subtype.empty()) {
+    std::string subtype_opt = fmt::format("subtype={}", FLAGS_fuse_subtype);
+    if (FuseAddOpts(&args_, subtype_opt.c_str()) != 0) return 1;
+  }
 
   std::string arg_value =
       fmt::format("fsname=DingoFS:{}", mount_option_->fs_name);


### PR DESCRIPTION
## What

Add one mount-option gflag to dingo-client:

- `--fuse_subtype` (default `dingofs`): value of the fuse `subtype` mount option; setting it empty mounts as plain fstype `fuse`.

The default keeps current mount behavior byte-identical for all existing deployments.

## Why

Running xfstests against DingoFS requires the kernel-reported filesystem type to equal `FSTYP=fuse`: with the previously hardcoded `subtype=dingofs` the kernel reports `fuse.dingofs`, which xfstests' `_fs_type` check rejects at startup. There is no way to drop the subtype from outside the client: appending an empty `subtype=` through mount options makes the kernel type string invalid (`fuse.`, mount fails with EINVAL), so a flag is the minimal change. This mirrors libfuse's own xfstests adapter, whose passthrough examples also mount without a subtype.

No flag is needed for the mount source: the client appends `--fuse_mount_options` after its hardcoded `fsname=DingoFS:<fs>` and libfuse resolves duplicate options last-one-wins, so the xfstests mount helper passes `--fuse_mount_options='default_permissions,fsname=<device>'` to make the reported source match the device string.

The xfstests adapter scripts will be submitted separately.