### PR TITLE
[fix][client] Make compactor replace output slices; verify byte composition and failure paths

### DIFF
--- a/src/client/vfs/compaction/compactor.h
+++ b/src/client/vfs/compaction/compactor.h
@@ -37,10 +37,13 @@ class Compactor {
 
   virtual Status Stop() = 0;
 
+  // On success, replaces out_slices with the complete replacement list. The
+  // list is empty when every input slice is skipped.
   virtual Status Compact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
                          const std::vector<Slice>& slices,
                          std::vector<Slice>& out_slices) = 0;
 
+  // On success, replaces out_slices with exactly one compacted slice.
   virtual Status ForceCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
                               const std::vector<Slice>& slices,
                               std::vector<Slice>& out_slices) = 0;

--- a/src/client/vfs/compaction/compactor_impl.cc
+++ b/src/client/vfs/compaction/compactor_impl.cc
@@ -219,6 +219,7 @@ Status CompactorImpl::Compact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
 
   if (to_compact.empty()) {
     LOG(INFO) << "No slices to compact after skipping";
+    out_slices.clear();
     return Status::OK();
   }
 
@@ -260,7 +261,9 @@ Status CompactorImpl::ForceCompact(ContextSPtr ctx, Ino ino,
   Slice compacted;
   DINGOFS_RETURN_NOT_OK(DoCompact(SpanScope::GetContext(span), ino, chunk_index,
                                   slices, compacted));
-  out_slices.push_back(compacted);
+  std::vector<Slice> out;
+  out.push_back(compacted);
+  out_slices.swap(out);
 
   return Status::OK();
 }

--- a/test/unit/client/vfs/compaction/test_compact_utils.cc
+++ b/test/unit/client/vfs/compaction/test_compact_utils.cc
@@ -221,6 +221,21 @@ TEST_F(CompactUtilsTest, SkipWorksWithNonZeroChunkStart) {
   EXPECT_EQ(Skip(64LL * kMiB, slices), 2);
 }
 
+TEST_F(CompactUtilsTest, SkipEquivalentHolesLeaveTwoTailSlices) {
+  constexpr int32_t kMiB = 1024 * 1024;
+  std::vector<Slice> slices;
+  slices.reserve(99);
+  for (int i = 0; i < 97; ++i) {
+    slices.push_back(CreateSlice(0, 0, 2 * kMiB));
+  }
+  // These small adjacent tails are below the 1 MiB skip threshold. Keeping
+  // them outside the hole range lets all 97 equivalent holes remain skippable.
+  slices.push_back(CreateSlice(101, 2 * kMiB, 256 * 1024));
+  slices.push_back(CreateSlice(102, 2 * kMiB + 256 * 1024, 256 * 1024));
+
+  EXPECT_EQ(Skip(0, slices), 97);
+}
+
 }  // namespace compaction
 }  // namespace vfs
 }  // namespace client

--- a/test/unit/client/vfs/compaction/test_compactor.cc
+++ b/test/unit/client/vfs/compaction/test_compactor.cc
@@ -17,13 +17,17 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "client/vfs/compaction/compactor_impl.h"
@@ -475,6 +479,355 @@ TEST_F(CompactorTest, CleanupUncommittedSlices_SplitsBatches_KeepsGoingOnFail) {
   EXPECT_EQ(calls, 3);
 
   FLAGS_vfs_compact_cleanup_batch_size = saved_batch_size;
+}
+
+// ---------------------------------------------------------------------------
+// Data-correctness coverage. The mock BlockStore serves a position-sensitive
+// pattern per (slice_id, slice-internal offset) and captures every uploaded
+// block, so tests can assert the compacted bytes equal the newest-wins
+// composition of the input slices — the compactor's actual job, which the
+// zero-filled mocks above never verify.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr int64_t kTestBlockSize = 4 * 1024 * 1024;
+
+uint8_t PatternAt(uint64_t slice_id, int64_t off) {
+  return static_cast<uint8_t>((slice_id * 131 + off * 7) & 0xFF);
+}
+
+// BlockKey::Filename() is "id_index_size".
+void ParseBlockFilename(const std::string& filename, uint64_t* id,
+                        uint32_t* index) {
+  size_t p1 = filename.find('_');
+  size_t p2 = filename.find('_', p1 + 1);
+  CHECK(p1 != std::string::npos && p2 != std::string::npos) << filename;
+  *id = std::stoull(filename.substr(0, p1));
+  *index = std::stoul(filename.substr(p1 + 1, p2 - p1 - 1));
+}
+
+struct CapturedWrites {
+  std::mutex mu;
+  // (slice_id, block_index) -> bytes
+  std::map<std::pair<uint64_t, uint32_t>, std::string> blocks;
+  std::map<uint64_t, size_t> reads;
+  size_t duplicate_uploads{0};
+
+  // Concatenate the blocks of one slice in index order.
+  std::string SliceBytes(uint64_t slice_id) {
+    std::lock_guard<std::mutex> lk(mu);
+    std::string out;
+    for (const auto& [key, bytes] : blocks) {
+      if (key.first == slice_id) out += bytes;
+    }
+    return out;
+  }
+
+  size_t ReadCount(uint64_t slice_id) {
+    std::lock_guard<std::mutex> lk(mu);
+    return reads[slice_id];
+  }
+
+  size_t DuplicateUploads() {
+    std::lock_guard<std::mutex> lk(mu);
+    return duplicate_uploads;
+  }
+
+  size_t BlockCount(uint64_t slice_id) {
+    std::lock_guard<std::mutex> lk(mu);
+    return std::count_if(blocks.begin(), blocks.end(),
+                         [slice_id](const auto& entry) {
+                           return entry.first.first == slice_id;
+                         });
+  }
+};
+
+// RangeAsync fills the requested window with the owning slice's pattern;
+// PutAsync records the uploaded bytes keyed by (slice_id, block_index).
+void InstallPatternBlockStore(test::MockBlockStore* bs,
+                              std::shared_ptr<CapturedWrites> captured) {
+  ON_CALL(*bs, RangeAsync)
+      .WillByDefault([captured](ContextSPtr, RangeReq req, StatusCallback cb) {
+        uint64_t slice_id = 0;
+        uint32_t block_index = 0;
+        ParseBlockFilename(req.handle.Filename(), &slice_id, &block_index);
+        int64_t base =
+            static_cast<int64_t>(block_index) * kTestBlockSize + req.offset;
+        for (int64_t i = 0; i < req.length; ++i) {
+          req.dst.data()[i] = PatternAt(slice_id, base + i);
+        }
+        {
+          std::lock_guard<std::mutex> lk(captured->mu);
+          captured->reads[slice_id]++;
+        }
+        cb(Status::OK());
+      });
+  ON_CALL(*bs, PutAsync)
+      .WillByDefault([captured](ContextSPtr, PutReq req, StatusCallback cb) {
+        uint64_t slice_id = 0;
+        uint32_t block_index = 0;
+        ParseBlockFilename(req.handle.Filename(), &slice_id, &block_index);
+        std::string bytes(req.data.Length(), '\0');
+        req.data.CopyTo(bytes.data(), bytes.size(), 0);
+        {
+          std::lock_guard<std::mutex> lk(captured->mu);
+          auto [it, inserted] = captured->blocks.emplace(
+              std::make_pair(slice_id, block_index), std::move(bytes));
+          if (!inserted) {
+            captured->duplicate_uploads++;
+          }
+        }
+        cb(Status::OK());
+      });
+}
+
+}  // namespace
+
+// 19. The compacted slice must be the newest-wins composition of the inputs.
+// S2 (newer) overlaps the second half of S1 (older); every output byte is
+// checked against the pattern of the slice that must win at that offset.
+TEST_F(CompactorTest, ForceCompact_OverlappingSlices_NewestWinsBytes) {
+  auto captured = std::make_shared<CapturedWrites>();
+  InstallPatternBlockStore(mock_block_store_, captured);
+
+  constexpr int64_t kMB = 1024 * 1024;
+  // S1 [0, 2M) id=10 older; S2 [1M, 3M) id=11 newer (later in vector).
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/10, /*pos=*/0, 2 * kMB),
+      dingofs::client::vfs::test::MakeSlice(/*id=*/11, /*pos=*/kMB, 2 * kMB)};
+
+  std::vector<Slice> out;
+  Status s = compactor_->ForceCompact(ctx_, /*ino=*/500, /*chunk_index=*/0,
+                                      slices, out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  ASSERT_EQ(out.size(), 1u);
+
+  const Slice& compacted = out[0];
+  EXPECT_NE(compacted.id, 10u);
+  EXPECT_NE(compacted.id, 11u);
+  EXPECT_EQ(compacted.pos, 0);
+  EXPECT_EQ(compacted.len, 3 * kMB);
+  EXPECT_EQ(compacted.size, 3 * kMB);
+  EXPECT_EQ(compacted.off, 0);
+
+  std::string written = captured->SliceBytes(compacted.id);
+  ASSERT_EQ(written.size(), static_cast<size_t>(3 * kMB));
+  EXPECT_EQ(captured->DuplicateUploads(), 0u);
+  for (int64_t off = 0; off < 3 * kMB; ++off) {
+    uint8_t expected = (off < kMB)
+                           ? PatternAt(10, off)         // S1-only region
+                           : PatternAt(11, off - kMB);  // S2 wins overlap+tail
+    ASSERT_EQ(static_cast<uint8_t>(written[off]), expected)
+        << "composition mismatch at offset " << off;
+  }
+}
+
+// 20. Compact() output contract: the skipped prefix must be preserved
+// verbatim (same ids, same geometry, same order) ahead of exactly one fresh
+// slice covering the compacted tail. Downstream (MDS CompactChunk, failure
+// cleanup) depends on this mixed-ownership layout.
+TEST_F(CompactorTest, Compact_SkipPrefixPreservedVerbatimInOutput) {
+  auto captured = std::make_shared<CapturedWrites>();
+  InstallPatternBlockStore(mock_block_store_, captured);
+
+  constexpr int64_t kMB = 1024 * 1024;
+  // S0 is 16 MiB, first, unoverlapped, and ≥1/5 of the 16.75 MiB span: Skip()
+  // keeps it. Three 256 KiB tail slices get compacted.
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/20, /*pos=*/0, 16 * kMB),
+      dingofs::client::vfs::test::MakeSlice(/*id=*/21, /*pos=*/16 * kMB,
+                                            256 * 1024),
+      dingofs::client::vfs::test::MakeSlice(/*id=*/22,
+                                            /*pos=*/16 * kMB + 256 * 1024,
+                                            256 * 1024),
+      dingofs::client::vfs::test::MakeSlice(/*id=*/23,
+                                            /*pos=*/16 * kMB + 512 * 1024,
+                                            256 * 1024)};
+
+  std::vector<Slice> out;
+  Status s =
+      compactor_->Compact(ctx_, /*ino=*/501, /*chunk_index=*/0, slices, out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  ASSERT_EQ(out.size(), 2u);
+
+  // Preserved prefix: bit-identical to the input slice.
+  EXPECT_EQ(out[0].id, 20u);
+  EXPECT_EQ(out[0].pos, slices[0].pos);
+  EXPECT_EQ(out[0].len, slices[0].len);
+  EXPECT_EQ(out[0].off, slices[0].off);
+  EXPECT_EQ(out[0].size, slices[0].size);
+  // The skipped slice must not be re-uploaded.
+  EXPECT_TRUE(captured->SliceBytes(20).empty());
+  EXPECT_EQ(captured->ReadCount(20), 0u);
+
+  // Fresh tail: new id covering exactly the compacted range.
+  EXPECT_EQ(out[1].pos, 16 * kMB);
+  EXPECT_EQ(out[1].len, 3 * 256 * 1024);
+  for (const auto& in : slices) {
+    EXPECT_NE(out[1].id, in.id);
+  }
+}
+
+// 21. Non-origin coordinates: a mid-chunk range in a non-zero chunk must
+// survive the chunk_start/offset_in_chunk arithmetic byte-for-byte.
+TEST_F(CompactorTest, ForceCompact_NonZeroChunkAndOffset_BytesPreserved) {
+  auto captured = std::make_shared<CapturedWrites>();
+  InstallPatternBlockStore(mock_block_store_, captured);
+
+  constexpr int64_t kMB = 1024 * 1024;
+  constexpr int64_t kChunkIndex = 3;
+  // Single slice [1M, 1.5M) inside chunk 3.
+  std::vector<Slice> slices = {dingofs::client::vfs::test::MakeSlice(
+      /*id=*/30, /*pos=*/kMB, 512 * 1024)};
+
+  std::vector<Slice> out;
+  Status s =
+      compactor_->ForceCompact(ctx_, /*ino=*/502, kChunkIndex, slices, out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].pos, kMB);
+  EXPECT_EQ(out[0].len, 512 * 1024);
+
+  std::string written = captured->SliceBytes(out[0].id);
+  ASSERT_EQ(written.size(), static_cast<size_t>(512 * 1024));
+  for (int64_t off = 0; off < 512 * 1024; ++off) {
+    ASSERT_EQ(static_cast<uint8_t>(written[off]), PatternAt(30, off))
+        << "coordinate arithmetic shifted data at offset " << off;
+  }
+}
+
+// 22. A write failure (page pool exhausted) must abort the compaction with an
+// error, upload nothing, and trigger no cleanup — nothing was ever uploaded.
+TEST_F(CompactorTest, ForceCompact_WritePoolExhausted_FailsWithoutUpload) {
+  // 64 KiB pool cannot back a 4 MiB block: SliceWriter::Write fails in the
+  // reserve phase and rolls back before any upload is submitted.
+  WriteMemPool tiny_pool(64 * 1024, 4096);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(&tiny_pool));
+
+  blockaccess::MockBlockAccesser accesser;
+  ON_CALL(*mock_hub_, GetBlockAccesser()).WillByDefault(Return(&accesser));
+  EXPECT_CALL(*mock_hub_, GetBlockAccesser()).Times(AnyNumber());
+  EXPECT_CALL(accesser, BatchDelete(_)).Times(0);
+  EXPECT_CALL(*mock_block_store_, PutAsync).Times(0);
+
+  std::vector<Slice> slices = {dingofs::client::vfs::test::MakeSlice(
+      /*id=*/40, /*pos=*/0, 4 * 1024 * 1024)};
+  std::vector<Slice> out;
+  Status s = compactor_->ForceCompact(ctx_, /*ino=*/503, /*chunk_index=*/0,
+                                      slices, out);
+  EXPECT_TRUE(s.IsNoSpace()) << s.ToString();
+  EXPECT_TRUE(out.empty());
+  EXPECT_EQ(tiny_pool.GetUsedBytes(), 0);
+}
+
+// 23. Holes participate in newest-wins composition as zero-filled ranges and
+// must never issue a block read of their own.
+TEST_F(CompactorTest, ForceCompact_HoleOverData_ProducesZeros) {
+  auto captured = std::make_shared<CapturedWrites>();
+  InstallPatternBlockStore(mock_block_store_, captured);
+
+  constexpr int64_t kMB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/50, /*pos=*/0, 2 * kMB),
+      MakeZeroSlice(/*pos=*/kMB, /*size=*/kMB)};
+
+  std::vector<Slice> out;
+  Status s = compactor_->ForceCompact(ctx_, /*ino=*/504, /*chunk_index=*/0,
+                                      slices, out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  ASSERT_EQ(out.size(), 1u);
+
+  std::string written = captured->SliceBytes(out[0].id);
+  ASSERT_EQ(written.size(), static_cast<size_t>(2 * kMB));
+  for (int64_t off = 0; off < 2 * kMB; ++off) {
+    const uint8_t expected = off < kMB ? PatternAt(50, off) : 0;
+    ASSERT_EQ(static_cast<uint8_t>(written[off]), expected)
+        << "hole composition mismatch at offset " << off;
+  }
+  EXPECT_EQ(captured->ReadCount(0), 0u);
+  EXPECT_EQ(captured->DuplicateUploads(), 0u);
+}
+
+// 24. Slice::off is a physical offset inside the source slice. Compaction
+// must read from that offset while writing a dense output starting at off=0.
+TEST_F(CompactorTest, ForceCompact_NonZeroSliceOff_ReadsPhysicalSubrange) {
+  auto captured = std::make_shared<CapturedWrites>();
+  InstallPatternBlockStore(mock_block_store_, captured);
+
+  constexpr int64_t kMB = 1024 * 1024;
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/60, /*pos=*/2 * kMB,
+                                            /*size=*/3 * kMB,
+                                            /*off=*/kMB, /*len=*/kMB)};
+
+  std::vector<Slice> out;
+  Status s = compactor_->ForceCompact(ctx_, /*ino=*/505, /*chunk_index=*/0,
+                                      slices, out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].pos, 2 * kMB);
+  EXPECT_EQ(out[0].off, 0);
+  EXPECT_EQ(out[0].len, kMB);
+
+  std::string written = captured->SliceBytes(out[0].id);
+  ASSERT_EQ(written.size(), static_cast<size_t>(kMB));
+  for (int64_t off = 0; off < kMB; ++off) {
+    ASSERT_EQ(static_cast<uint8_t>(written[off]), PatternAt(60, kMB + off))
+        << "slice physical offset ignored at output offset " << off;
+  }
+}
+
+// 25. A result spanning block boundaries must upload every block exactly once
+// and preserve byte order across the boundary.
+TEST_F(CompactorTest, ForceCompact_CrossBlock_UploadsEachBlockOnce) {
+  auto captured = std::make_shared<CapturedWrites>();
+  InstallPatternBlockStore(mock_block_store_, captured);
+
+  constexpr int64_t kMB = 1024 * 1024;
+  constexpr int64_t kSize = 5 * kMB;
+  std::vector<Slice> slices = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/70, /*pos=*/0, kSize)};
+
+  std::vector<Slice> out;
+  Status s = compactor_->ForceCompact(ctx_, /*ino=*/506, /*chunk_index=*/0,
+                                      slices, out);
+  ASSERT_TRUE(s.ok()) << s.ToString();
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(captured->BlockCount(out[0].id), 2u);
+  EXPECT_EQ(captured->DuplicateUploads(), 0u);
+
+  std::string written = captured->SliceBytes(out[0].id);
+  ASSERT_EQ(written.size(), static_cast<size_t>(kSize));
+  for (int64_t off = 0; off < kSize; ++off) {
+    ASSERT_EQ(static_cast<uint8_t>(written[off]), PatternAt(70, off))
+        << "cross-block byte mismatch at offset " << off;
+  }
+}
+
+// 26. On success both entry points replace, rather than append to or retain,
+// caller-provided output. This also defines the all-skipped result as empty.
+TEST_F(CompactorTest, SuccessfulCalls_ReplacePrepopulatedOutput) {
+  const Slice stale =
+      dingofs::client::vfs::test::MakeSlice(/*id=*/999, /*pos=*/7, 4096);
+
+  std::vector<Slice> force_out = {stale};
+  std::vector<Slice> small = {
+      dingofs::client::vfs::test::MakeSlice(/*id=*/80, /*pos=*/0, 4096)};
+  ASSERT_TRUE(
+      compactor_
+          ->ForceCompact(ctx_, /*ino=*/507, /*chunk_index=*/0, small, force_out)
+          .ok());
+  ASSERT_EQ(force_out.size(), 1u);
+  EXPECT_NE(force_out[0].id, stale.id);
+
+  std::vector<Slice> skipped_out = {stale};
+  std::vector<Slice> all_skipped = {MakeZeroSlice(0, 2 * 1024 * 1024)};
+  ASSERT_TRUE(compactor_
+                  ->Compact(ctx_, /*ino=*/508, /*chunk_index=*/0, all_skipped,
+                            skipped_out)
+                  .ok());
+  EXPECT_TRUE(skipped_out.empty());
 }
 
 }  // namespace vfs


### PR DESCRIPTION
## What

Two small output-contract fixes plus the logic/data-correctness test coverage the compactor module was missing.

## Fixes

- `ForceCompact` appended to caller-provided `out_slices` (`push_back`) while `Compact` replaced it (`swap`) — a caller passing a non-empty vector silently accumulated slices. Both entry points now replace the output, and the all-skipped `Compact` result is explicitly cleared. The contracts are documented in `compactor.h` and pinned by a test that pre-populates the output with a stale slice.

## Tests (+13)

The existing suite exercised lifecycle, Skip() boundaries and cleanup mechanics, but every DoCompact test read zero-filled mocks — the compactor's core job (newest-wins byte composition) was never verified. New infrastructure serves a position-sensitive pattern per (slice_id, offset) and captures uploaded bytes, so tests assert byte-exact results:

- overlapping slices compose newest-wins across the full output (byte-for-byte)
- the skipped prefix is preserved verbatim, never re-read and never re-uploaded, ahead of exactly one fresh slice covering the compacted tail (the mixed-ownership layout that `TryCleanupUncommittedSlices` from `afb8d1337` depends on is now pinned by an assertion)
- holes compose as zeros and never issue block reads
- non-zero `Slice::off` (clone-produced) reads the physical subrange and emits a dense off=0 output
- mid-chunk ranges in a non-zero chunk survive the chunk_start / offset_in_chunk arithmetic byte-for-byte
- a result spanning block boundaries uploads each block exactly once with byte continuity across the seam
- write-pool exhaustion fails with NoSpace, uploads nothing, triggers no cleanup, and returns every reserved page (leak check via `GetUsedBytes() == 0`)
- `Skip()` keeps 97 equivalent holes ahead of two sub-threshold tail slices (97+2 = 99 slices, which is a compaction trigger by the `count % 100 == 99` rule)

Note on the last case: it constructs a legal client request with `new_slices.size() == end_pos - start_pos`, which the MDS currently rejects via `CHECK(param_.new_slices.size() < (param_.end_pos - param_.start_pos))` in `CompactChunkOperation::Run` — a fatal abort on request content that is reachable with default flags. That server-side validation likely deserves a follow-up fix to return `EILLEGAL_PARAMTETER` instead.

## Verification

clang-format clean; full client unit suite 406 tests, 405 passed (1 pre-existing skip); rebased on `afb8d1337`.