### PR TITLE
[fix][client] Enforce max file size at VFS entries; return EFBIG instead of crashing

### DIFF
--- a/src/client/vfs/common/file_size.h
+++ b/src/client/vfs/common/file_size.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_CLIENT_VFS_COMMON_FILE_SIZE_H_
+#define DINGOFS_SRC_CLIENT_VFS_COMMON_FILE_SIZE_H_
+
+#include <cstdint>
+
+#include "common/file_size.h"
+#include "common/status.h"
+#include "fmt/format.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+inline Status ValidateFileSize(uint64_t chunk_size, uint64_t size) {
+  uint64_t max_file_size = 0;
+  if (!TryGetMaxFileSize(chunk_size, &max_file_size)) {
+    return Status::Internal(fmt::format("invalid chunk size({})", chunk_size));
+  }
+  if (!IsValidFileSize(size, max_file_size)) {
+    return Status::FileTooLarge(
+        fmt::format("file size({}) exceeds max({})", size, max_file_size));
+  }
+  return Status::OK();
+}
+
+inline Status ValidateFileRange(uint64_t chunk_size, uint64_t offset,
+                                uint64_t length) {
+  uint64_t max_file_size = 0;
+  if (!TryGetMaxFileSize(chunk_size, &max_file_size)) {
+    return Status::Internal(fmt::format("invalid chunk size({})", chunk_size));
+  }
+  if (!IsValidFileRange(offset, length, max_file_size)) {
+    return Status::FileTooLarge(fmt::format(
+        "file range([{},+{})) exceeds max({})", offset, length, max_file_size));
+  }
+  return Status::OK();
+}
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_CLIENT_VFS_COMMON_FILE_SIZE_H_

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "client/common/const.h"
+#include "client/vfs/common/file_size.h"
 #include "client/vfs/common/helper.h"
 #include "client/vfs/components/uid_gid_mapper.h"
 #include "client/vfs/components/warmup_manager.h"
@@ -315,6 +316,8 @@ Status VFSImpl::SetAttr(ContextSPtr ctx, Ino ino, int set, const Attr& in_attr,
   // write still buffered here could land *after* the truncate and re-expose the
   // bytes the truncate was meant to drop.
   if (set & kSetAttrSize) {
+    DINGOFS_RETURN_NOT_OK(
+        ValidateFileSize(vfs_hub_->GetFsInfo().chunk_size, in_attr.length));
     Status s = handle_manager_->FlushByIno(ino);
     if (!s.ok()) return s;
   }
@@ -342,6 +345,9 @@ Status VFSImpl::Fallocate(ContextSPtr ctx, Ino ino, int mode, uint64_t offset,
   if (BAIDU_UNLIKELY(ino == kStatsIno)) {
     return Status::NoPermitted("fallocate on internal node");
   }
+
+  DINGOFS_RETURN_NOT_OK(
+      ValidateFileRange(vfs_hub_->GetFsInfo().chunk_size, offset, length));
 
   // Same ordering requirement as truncate: PUNCH_HOLE / ZERO_RANGE write zero
   // slices that must shadow already-written data, so flush buffered writes
@@ -378,6 +384,11 @@ Status VFSImpl::CopyFileRange(ContextSPtr ctx, Ino src_ino, uint64_t src_off,
     return Status::InvalidParam("unsupported copy_file_range flags");
   }
   if (len == 0) return Status::OK();
+
+  DINGOFS_RETURN_NOT_OK(
+      ValidateFileRange(vfs_hub_->GetFsInfo().chunk_size, src_off, len));
+  DINGOFS_RETURN_NOT_OK(
+      ValidateFileRange(vfs_hub_->GetFsInfo().chunk_size, dst_off, len));
 
   // Same-file overlap is undefined by POSIX; reject before touching MDS.
   if (src_ino == dst_ino) {
@@ -634,6 +645,9 @@ Status VFSImpl::Read(ContextSPtr ctx, Ino ino, DataBuffer* data_buffer,
     return Status::OK();
   }
 
+  DINGOFS_RETURN_NOT_OK(
+      ValidateFileRange(vfs_hub_->GetFsInfo().chunk_size, offset, size));
+
   if (handle->resources.reader == nullptr) {
     LOG(ERROR) << "reader is null in handle, ino: " << ino << ", fh: " << fh;
     s = Status::BadFd(fmt::format("bad fh:{}", fh));
@@ -691,6 +705,9 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
     s = Status::BadFd(fmt::format("read-only fh:{}", fh));
     return s;
   }
+
+  DINGOFS_RETURN_NOT_OK(
+      ValidateFileRange(vfs_hub_->GetFsInfo().chunk_size, offset, size));
 
   s = handle->resources.writer->Write(SpanScope::GetContext(span), buf, size,
                                       offset, out_wsize);

--- a/src/common/file_size.h
+++ b/src/common/file_size.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_COMMON_FILE_SIZE_H_
+#define DINGOFS_SRC_COMMON_FILE_SIZE_H_
+
+#include <cstdint>
+#include <limits>
+
+namespace dingofs {
+
+// Chunk indexes are uint32. Reserve the upper half of the index space.
+constexpr uint64_t kMaxFileChunkCount = uint64_t{1} << 31;
+
+inline bool TryGetMaxFileSize(uint64_t chunk_size, uint64_t* max_file_size) {
+  if (max_file_size == nullptr || chunk_size == 0 ||
+      chunk_size > std::numeric_limits<uint64_t>::max() / kMaxFileChunkCount) {
+    return false;
+  }
+
+  *max_file_size = chunk_size * kMaxFileChunkCount;
+  return true;
+}
+
+inline bool IsValidFileSize(uint64_t size, uint64_t max_file_size) {
+  return size <= max_file_size;
+}
+
+inline bool IsValidFileRange(uint64_t offset, uint64_t length,
+                             uint64_t max_file_size) {
+  if (length == 0) return true;
+  return offset < max_file_size && length <= max_file_size - offset;
+}
+
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_COMMON_FILE_SIZE_H_

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -200,6 +200,8 @@ class Status {
         return EIO;
       case kNotFound:
         return ENOENT;
+      case kFileTooLarge:
+        return EFBIG;
       case kStop:
         return EIO;
       case kNotFit:

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -27,9 +27,11 @@
 #include "client/vfs/components/uid_gid_mapper.h"
 #include "client/vfs/data/writer_table.h"
 #include "client/vfs/data_buffer.h"
+#include "client/vfs/metasystem/mds/rpc.h"
 #include "client/vfs/vfs_impl.h"
 #include "common/blockaccess/accesser_common.h"
 #include "common/const.h"
+#include "common/file_size.h"
 #include "common/status.h"
 #include "common/trace/trace_manager.h"
 #include "common/writemempool/write_mem_pool.h"
@@ -152,6 +154,74 @@ TEST_F(VFSImplTest, GetAttr_DelegatesToMetaSystem) {
   Status s = vfs_->GetAttr(ctx_, 55u, &out);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(out.ino, 55u);
+}
+
+TEST_F(VFSImplTest, SetAttr_RejectsFileSizeAboveLimitBeforeMetaCall) {
+  Attr in;
+  Attr out;
+  ASSERT_TRUE(TryGetMaxFileSize(mock_hub_->GetFsInfo().chunk_size, &in.length));
+  ++in.length;
+
+  EXPECT_CALL(*mock_meta_system_, SetAttr(_, _, _, _, _)).Times(0);
+  Status s = vfs_->SetAttr(ctx_, 55, kSetAttrSize, in, &out);
+
+  EXPECT_TRUE(s.IsFileTooLarge()) << s.ToString();
+  EXPECT_EQ(s.ToSysErrNo(), EFBIG);
+}
+
+TEST_F(VFSImplTest, Fallocate_RejectsRangeAboveLimit) {
+  uint64_t max_file_size = 0;
+  ASSERT_TRUE(
+      TryGetMaxFileSize(mock_hub_->GetFsInfo().chunk_size, &max_file_size));
+
+  Status s = vfs_->Fallocate(ctx_, 55, 0, max_file_size - 1, 2);
+
+  EXPECT_TRUE(s.IsFileTooLarge()) << s.ToString();
+  EXPECT_EQ(s.ToSysErrNo(), EFBIG);
+}
+
+TEST_F(VFSImplTest, CopyFileRange_RejectsDestinationAboveLimit) {
+  uint64_t max_file_size = 0;
+  ASSERT_TRUE(
+      TryGetMaxFileSize(mock_hub_->GetFsInfo().chunk_size, &max_file_size));
+  uint64_t copied = 123;
+
+  Status s = vfs_->CopyFileRange(ctx_, 55, 0, 0, 56, max_file_size - 1, 0, 2, 0,
+                                 &copied);
+
+  EXPECT_TRUE(s.IsFileTooLarge()) << s.ToString();
+  EXPECT_EQ(s.ToSysErrNo(), EFBIG);
+  EXPECT_EQ(copied, 0);
+}
+
+TEST_F(VFSImplTest, Write_RejectsOffsetAtLimitBeforeBuffering) {
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+
+  constexpr Ino kIno = 57;
+  ON_CALL(*mock_meta_system_, Open(_, kIno, _, _))
+      .WillByDefault(Return(Status::OK()));
+  ON_CALL(*mock_meta_system_, Close(_, kIno, _))
+      .WillByDefault(Return(Status::OK()));
+
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, kIno, O_WRONLY, &fh).ok());
+
+  uint64_t max_file_size = 0;
+  ASSERT_TRUE(
+      TryGetMaxFileSize(mock_hub_->GetFsInfo().chunk_size, &max_file_size));
+  EXPECT_CALL(*mock_meta_system_, Write(_, _, _, _, _, _)).Times(0);
+
+  char byte = 'x';
+  uint64_t written = 123;
+  Status s = vfs_->Write(ctx_, kIno, &byte, 1, max_file_size, fh, &written);
+
+  EXPECT_TRUE(s.IsFileTooLarge()) << s.ToString();
+  EXPECT_EQ(s.ToSysErrNo(), EFBIG);
+  EXPECT_EQ(written, 0);
+  vfs_->Release(ctx_, kIno, fh);
 }
 
 // --- 4b. Write short-write: metadata gets out_wsize, not the requested size.

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(writemempool)
 add_executable(test_common
   main.cc
   test_read_mem_pool.cc
+  test_file_size.cc
   test_status.cc
   test_string_slice.cc
   test_helper.cc

--- a/test/unit/common/test_file_size.cc
+++ b/test/unit/common/test_file_size.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "common/file_size.h"
+
+namespace dingofs {
+
+TEST(FileSizeTest, ComputesMaxFileSize) {
+  constexpr uint64_t kChunkSize = uint64_t{64} * 1024 * 1024;
+  uint64_t max_file_size = 0;
+
+  ASSERT_TRUE(TryGetMaxFileSize(kChunkSize, &max_file_size));
+  EXPECT_EQ(max_file_size, uint64_t{1} << 57);
+  EXPECT_FALSE(TryGetMaxFileSize(0, &max_file_size));
+  EXPECT_FALSE(TryGetMaxFileSize(kChunkSize, nullptr));
+}
+
+TEST(FileSizeTest, ValidatesExactSizeBoundary) {
+  constexpr uint64_t kMax = uint64_t{1} << 57;
+
+  EXPECT_TRUE(IsValidFileSize(kMax, kMax));
+  EXPECT_FALSE(IsValidFileSize(kMax + 1, kMax));
+}
+
+TEST(FileSizeTest, ValidatesRangesWithoutOverflow) {
+  constexpr uint64_t kMax = uint64_t{1} << 57;
+
+  EXPECT_TRUE(IsValidFileRange(kMax - 1, 1, kMax));
+  EXPECT_FALSE(IsValidFileRange(kMax - 1, 2, kMax));
+  EXPECT_FALSE(IsValidFileRange(kMax, 1, kMax));
+  EXPECT_FALSE(IsValidFileRange(std::numeric_limits<uint64_t>::max(), 1, kMax));
+  EXPECT_TRUE(IsValidFileRange(std::numeric_limits<uint64_t>::max(), 0, kMax));
+}
+
+}  // namespace dingofs

--- a/test/unit/common/test_status.cc
+++ b/test/unit/common/test_status.cc
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include "common/status.h"
-
 #include <gtest/gtest.h>
 
 #include <cerrno>
+
+#include "common/status.h"
 
 namespace dingofs {
 
@@ -107,6 +107,7 @@ TEST(StatusTest, ToSysErrNoMapsEachCodeToExpectedErrno) {
   EXPECT_EQ(Status::Exist("").ToSysErrNo(), EEXIST);
   EXPECT_EQ(Status::NotFound("").ToSysErrNo(), ENOENT);
   EXPECT_EQ(Status::Deleted("").ToSysErrNo(), ENOENT);
+  EXPECT_EQ(Status::FileTooLarge("").ToSysErrNo(), EFBIG);
 }
 
 TEST(StatusTest, ToStringNamesEachRemainingErrorCode) {


### PR DESCRIPTION
## Problem

A plain user command crashes the client and kills the whole mount:

```bash
dd if=/dev/zero of=$MNT/f bs=1 count=1 seek=9223372036854775806 conv=notrunc
# → CHECK-FATAL in ChunkWriter::Write, mount dies with Transport endpoint is not connected
```

Root cause: `Chunk::chunk_end = chunk_start + chunk_size` overflows int64 for the last representable chunk, and no VFS entry validates user-supplied file ranges. `truncate -s $((2**63-1))` also silently succeeds today, persisting an absurd length. POSIX requires EFBIG for ranges beyond the implementation limit.

## What

Introduce a single-file size limit and validate it at the five VFS entries (Read / Write / SetAttr-truncate / Fallocate / CopyFileRange), rejecting with `EFBIG` before any side effect (flush, buffer allocation, metasystem call):

```text
max_file_size = fs.chunk_size × 2^31        (128 PiB with the default 64 MiB chunk)
```

- The hard protocol ceiling is the `uint32` chunk index in `pb::mds::Chunk` (2^32); 2^31 keeps one bit of headroom so indexes stay safe in signed 32-bit too, and legal offsets stay 64× away from INT64_MAX so internal range arithmetic cannot overflow. Same formula as JuiceFS (`ChunkSize << 31`), computed from the fs's actual chunk_size rather than hardcoded.
- `common/file_size.h`: overflow-safe helpers (`TryGetMaxFileSize` / `IsValidFileSize` / `IsValidFileRange`, subtract-then-compare, no `offset + length`).
- `client/vfs/common/file_size.h`: Status adapters.
- `Status::ToSysErrNo()`: map `kFileTooLarge` → `EFBIG` (previously fell through to EIO).
- Boundary semantics: length ≤ max valid; last legal byte at max−1 writable/readable; zero-length ops remain no-ops. Internal invariants (e.g. the ChunkWriter CHECK) are kept as-is — with entries validated they are unreachable from user input.

## Verification

- Unit tests: boundary/overflow matrix for the helpers, EFBIG errno mapping, and VFS-entry rejection tests asserting no metasystem/writer call happens on the reject path.
- Local-mode mount, end to end: the dd above returns `File too large` with the mount alive; `truncate -s 2^57` succeeds while `2^57+1` returns EFBIG; a byte written at max−1 reads back correctly; write at offset max returns EFBIG.