### PR TITLE
[chore][client] Adjust vfs_meta_rpc_retry_times flag.

### DIFF
--- a/src/common/options/client.cc
+++ b/src/common/options/client.cc
@@ -171,7 +171,7 @@ DEFINE_uint32(vfs_meta_read_dir_batch_size, 1024, "read dir batch size.");
 DEFINE_uint32(vfs_meta_rpc_timeout_ms, 10000, "rpc timeout ms");
 DEFINE_validator(vfs_meta_rpc_timeout_ms, brpc::PassValidate);
 
-DEFINE_int32(vfs_meta_rpc_retry_times, 8, "rpc retry time");
+DEFINE_int32(vfs_meta_rpc_retry_times, 7, "rpc retry time");
 DEFINE_validator(vfs_meta_rpc_retry_times, brpc::PassValidate);
 
 DEFINE_bool(vfs_meta_batch_operation_enable, false,


### PR DESCRIPTION
<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

The client metadata RPC retry count is higher than the intended setting.

### What is changed and how it works?

What's Changed:

- Reduce `vfs_meta_rpc_retry_times` from 8 to 7.

How it Works:

The client uses the updated flag default when initializing metadata RPC retry behavior.

Side effects(Breaking backward compatibility? Performance regression?):

No known breaking changes. Failed metadata RPCs receive one fewer retry by default.

### Check List

- [ ] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Copilot](https://img.shields.io/badge/GPT_5.6_Luna-D97757?logo=githubcopilot&logoColor=white)
