### PR TITLE
[fix][client] Flush writer before closing file session

### DIFF
--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -760,7 +760,6 @@ Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
     return Status::OK();
   }
 
-  Status s;
   auto handle = handle_manager_->FindHandlerForRelease(fh);
   if (!handle) {
     VLOG(1) << "Release ignored, fh not found, ino: " << ino << ", fh: " << fh;
@@ -780,13 +779,28 @@ Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
   if (handle->resources.reader != nullptr) {
     handle->resources.reader->Close();
   }
+
+  // Drain dirty data while the metadata file session is still alive.  The
+  // last writer holder is released below by ReleaseHandler(), which may call
+  // FileWriter::Close() and perform a final flush.  Closing the metadata
+  // session first would make that flush's WriteSlice() fail because its
+  // FileSession had already been removed.
+  Status flush_status;
+  if (handle->resources.writer != nullptr) {
+    flush_status = handle->resources.writer->Flush();
+  }
+
+  Status close_status;
   if (!resources_detached) {
-    s = meta_system_->Close(ctx, ino, fh);
+    close_status = meta_system_->Close(ctx, ino, fh);
   }
 
   handle_manager_->ReleaseHandler(fh);
 
-  return s;
+  // Always complete Close and release the handle, even if flushing fails.
+  // Prefer the data-flush error because it describes a possible writeback
+  // failure; otherwise return the metadata close result.
+  return !flush_status.ok() ? flush_status : close_status;
 }
 
 // TODO: seperate data flush with metadata flush

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -47,6 +47,7 @@ namespace vfs {
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::DoAll;
+using ::testing::InSequence;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::SaveArg;
@@ -367,6 +368,107 @@ TEST_F(VFSImplTest, Release_StatsHandle_RemovesHandle) {
 
   Status s = vfs_->Release(ctx_, kStatsIno, fh);
   EXPECT_TRUE(s.ok());
+}
+
+TEST_F(VFSImplTest, Release_WritableHandle_FlushesBeforeMetaClose) {
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+
+  constexpr Ino kReleaseIno = 401;
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, kReleaseIno, O_WRONLY, &fh, nullptr).ok());
+
+  const char data[] = "dirty data";
+  uint64_t written = 0;
+  EXPECT_CALL(*mock_meta_system_, Write(_, kReleaseIno, _, 0, sizeof(data), fh))
+      .WillOnce(Return(Status::OK()));
+  ASSERT_TRUE(
+      vfs_->Write(ctx_, kReleaseIno, data, sizeof(data), 0, fh, &written).ok());
+  ASSERT_EQ(written, sizeof(data));
+
+  {
+    InSequence sequence;
+    EXPECT_CALL(*mock_meta_system_, WriteSlice(_, kReleaseIno, _, 0, _))
+        .WillOnce(Return(Status::OK()));
+    EXPECT_CALL(*mock_meta_system_, Close(_, kReleaseIno, fh))
+        .WillOnce(Return(Status::OK()));
+  }
+
+  Status s = vfs_->Release(ctx_, kReleaseIno, fh);
+  EXPECT_TRUE(s.ok()) << s.ToString();
+  EXPECT_FALSE(handle_manager_->FindHandlerForRelease(fh));
+}
+
+TEST_F(VFSImplTest, Release_SharedWriter_FlushesBeforeClosingEachSession) {
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+
+  constexpr Ino kReleaseIno = 402;
+  uint64_t first_fh = 0;
+  uint64_t second_fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, kReleaseIno, O_WRONLY, &first_fh, nullptr).ok());
+  ASSERT_TRUE(
+      vfs_->Open(ctx_, kReleaseIno, O_WRONLY, &second_fh, nullptr).ok());
+
+  const char data[] = "shared writer dirty data";
+  uint64_t written = 0;
+  EXPECT_CALL(*mock_meta_system_,
+              Write(_, kReleaseIno, _, 0, sizeof(data), first_fh))
+      .WillOnce(Return(Status::OK()));
+  ASSERT_TRUE(
+      vfs_->Write(ctx_, kReleaseIno, data, sizeof(data), 0, first_fh, &written)
+          .ok());
+
+  {
+    InSequence sequence;
+    EXPECT_CALL(*mock_meta_system_, WriteSlice(_, kReleaseIno, _, 0, _))
+        .WillOnce(Return(Status::OK()));
+    EXPECT_CALL(*mock_meta_system_, Close(_, kReleaseIno, first_fh))
+        .WillOnce(Return(Status::OK()));
+    EXPECT_CALL(*mock_meta_system_, Close(_, kReleaseIno, second_fh))
+        .WillOnce(Return(Status::OK()));
+  }
+
+  EXPECT_TRUE(vfs_->Release(ctx_, kReleaseIno, first_fh).ok());
+  EXPECT_EQ(writer_table->Size(), 1u);
+  EXPECT_TRUE(vfs_->Release(ctx_, kReleaseIno, second_fh).ok());
+  EXPECT_EQ(writer_table->Size(), 0u);
+}
+
+TEST_F(VFSImplTest, Release_FlushFailureStillClosesAndReleasesHandle) {
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+
+  constexpr Ino kReleaseIno = 403;
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, kReleaseIno, O_WRONLY, &fh, nullptr).ok());
+
+  const char data[] = "writeback failure";
+  uint64_t written = 0;
+  EXPECT_CALL(*mock_meta_system_, Write(_, kReleaseIno, _, 0, sizeof(data), fh))
+      .WillOnce(Return(Status::OK()));
+  ASSERT_TRUE(
+      vfs_->Write(ctx_, kReleaseIno, data, sizeof(data), 0, fh, &written).ok());
+
+  {
+    InSequence sequence;
+    EXPECT_CALL(*mock_meta_system_, WriteSlice(_, kReleaseIno, _, 0, _))
+        .WillOnce(Return(Status::Internal("write slice failed")));
+    EXPECT_CALL(*mock_meta_system_, Close(_, kReleaseIno, fh))
+        .WillOnce(Return(Status::OK()));
+  }
+
+  Status s = vfs_->Release(ctx_, kReleaseIno, fh);
+  EXPECT_FALSE(s.ok());
+  EXPECT_NE(s.ToString().find("write slice failed"), std::string::npos);
+  EXPECT_FALSE(handle_manager_->FindHandlerForRelease(fh));
+  EXPECT_EQ(writer_table->Size(), 0u);
 }
 
 // --- 10. Unlink internal file returns EPERM ---


### PR DESCRIPTION
## What changed

- flush writable handles before closing their metadata file session
- always close the session and release the handle when writeback fails
- prefer the writeback error over the metadata close error
- add coverage for single-handle, shared-writer, and flush-failure release paths

## Why

`VFSImpl::Release()` closed the metadata session before releasing the last writer holder. Releasing that holder calls `FileWriter::Close()`, whose final flush commits slices through `WriteSlice()`. When this was the last file session, `FileSessionMap::Delete()` had already removed the inode session and `WriteSlice()` hit `CHECK(file_session != nullptr)`.

The release path now drains dirty writer data while the file session is still alive, restoring the ordering that existed before the per-inode shared writer refactor.

## Tests

- `./build/bin/test/test_client --gtest_filter=VFSImplTest.Release_*`
- `./build/bin/test/test_client --gtest_filter=VFSImplTest.*`
- `./build/bin/test/test_client` (427 passed, 1 existing Debug-only test skipped under RelWithDebInfo)