### PR TITLE
[WIP][fix][client] Propagate file writer close errors

### DIFF
--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -98,7 +98,13 @@ Status ApplyWriteBufferThrottle(WriteMemPool* bm) {
 
 }  // namespace
 
-FileWriter::~FileWriter() { Close(); }
+FileWriter::~FileWriter() {
+  Status s = Close();
+  if (!s.ok()) {
+    LOG(ERROR) << fmt::format("{} FileWriter destroyed with close error: {}",
+                              uuid_, s.ToString());
+  }
+}
 
 Status FileWriter::Open() {
   VLOG(9) << fmt::format("{} FileWriter opened", uuid_);
@@ -106,11 +112,11 @@ Status FileWriter::Open() {
   return Status::OK();
 }
 
-void FileWriter::Close() {
+Status FileWriter::Close() {
   std::unique_lock<std::mutex> lg(mutex_);
   if (closed_) {
     LOG(INFO) << fmt::format("{} FileWriter already closed", uuid_);
-    return;
+    return close_status_;
   }
 
   closed_ = true;
@@ -135,6 +141,7 @@ void FileWriter::Close() {
     sync.Wait();
 
     if (!s.ok()) {
+      SetStatusIfBroken(s);
       LOG(ERROR) << fmt::format("{} Failed to close file, flush error: {}",
                                 uuid_, s.ToString());
     }
@@ -145,6 +152,11 @@ void FileWriter::Close() {
     chunk_writer->Stop();
     delete chunk_writer;
   }
+
+  // Preserve the first writeback failure, including one observed by an
+  // earlier Flush(), and return it to the lifecycle caller.
+  close_status_ = GetStatus();
+  return close_status_;
 }
 
 void FileWriter::AcquireRef() {

--- a/src/client/vfs/data/writer/file_writer.h
+++ b/src/client/vfs/data/writer/file_writer.h
@@ -44,7 +44,9 @@ class FileWriter {
 
   Status Open();
 
-  void Close();
+  // Drain pending writes and stop the writer. The first close result is
+  // cached, so repeated calls are idempotent and report the same failure.
+  Status Close();
 
   Status Write(ContextSPtr ctx, const char* buf, uint64_t size, uint64_t offset,
                uint64_t* out_wsize);
@@ -87,6 +89,7 @@ class FileWriter {
   mutable std::mutex mutex_;
   std::condition_variable cv_;
   bool closed_{false};
+  Status close_status_;
   int64_t writers_count_{0};
 
   // chunk_index -> chunk

--- a/src/client/vfs/data/writer_table.cc
+++ b/src/client/vfs/data/writer_table.cc
@@ -123,8 +123,8 @@ FileWriter* WriterTable::PeekWriter(uint64_t ino) {
   return it->second.writer;
 }
 
-void WriterTable::ReleaseWriter(FileWriter* writer) {
-  if (writer == nullptr) return;
+Status WriterTable::ReleaseWriter(FileWriter* writer) {
+  if (writer == nullptr) return Status::OK();
 
   uint64_t ino = writer->Ino();
   bool need_close = false;
@@ -152,10 +152,14 @@ void WriterTable::ReleaseWriter(FileWriter* writer) {
   //     would block all other Acquire/Release.
   //   - ReleaseRef may transitively call delete-this; doing it outside
   //     also keeps the table mutex's critical section short.
+  Status close_status;
   if (need_close) {
-    writer->Close();   // flips closed_ so SchedulePeriodicFlush stops arming
+    // Flips closed_ so SchedulePeriodicFlush stops arming. Keep the result
+    // before ReleaseRef(), which may delete the writer.
+    close_status = writer->Close();
   }
   writer->ReleaseRef();   // may delete-this once refs_ reaches 0
+  return close_status;
 }
 
 }  // namespace vfs

--- a/src/client/vfs/data/writer_table.h
+++ b/src/client/vfs/data/writer_table.h
@@ -86,7 +86,8 @@ class WriterTable {
   // the map, Close() is called on the writer (so its self-managed
   // periodic flush stops re-arming), and finally ReleaseRef() is invoked
   // (which may delete-this once refs_ reaches 0).
-  void ReleaseWriter(FileWriter* writer);
+  // Returns the final Close() result when this drops the last holder.
+  Status ReleaseWriter(FileWriter* writer);
 
   // Number of live entries (best-effort, for metrics / tests).
   size_t Size() const;

--- a/src/client/vfs/handle/handle_manager.cc
+++ b/src/client/vfs/handle/handle_manager.cc
@@ -123,7 +123,12 @@ void HandleManager::ReleaseHandleResources(HandleResources resources) {
   }
 
   if (resources.writer != nullptr) {
-    vfs_hub_->GetWriterTable()->ReleaseWriter(resources.writer);
+    const Ino ino = resources.writer->Ino();
+    Status s = vfs_hub_->GetWriterTable()->ReleaseWriter(resources.writer);
+    if (!s.ok()) {
+      LOG(ERROR) << fmt::format("Release writer failed, ino: {}, status: {}",
+                                ino, s.ToString());
+    }
   }
 }
 
@@ -295,7 +300,10 @@ Status HandleManager::FlushByIno(Ino ino) {
     return Status::OK();  // no writer for this ino → nothing to flush
   }
   Status s = writer->Flush();
-  vfs_hub_->GetWriterTable()->ReleaseWriter(writer);
+  Status release_status = vfs_hub_->GetWriterTable()->ReleaseWriter(writer);
+  if (s.ok() && !release_status.ok()) {
+    s = release_status;
+  }
   if (!s.ok()) {
     LOG(WARNING) << fmt::format("FlushByIno failed, ino: {}, status: {}", ino,
                                 s.ToString());

--- a/test/unit/client/vfs/data/test_file_writer.cc
+++ b/test/unit/client/vfs/data/test_file_writer.cc
@@ -346,6 +346,26 @@ TEST_F(FileWriterTest, FlushError_BecomesStickyAndBlocksWrites) {
   w->ReleaseRef();
 }
 
+// Close is the last synchronous writeback boundary. It must return the final
+// flush failure and retain it for idempotent callers instead of only logging.
+TEST_F(FileWriterTest, Close_FlushErrorIsReturnedAndCached) {
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault(Return(Status::Internal("close flush error")));
+
+  auto* w = MakeOpenWriter();
+  const char buf[] = "data";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  Status first = w->Close();
+  ASSERT_FALSE(first.ok());
+  EXPECT_THAT(first.ToString(), ::testing::HasSubstr("close flush error"));
+
+  Status second = w->Close();
+  EXPECT_EQ(second.ToString(), first.ToString());
+  w->ReleaseRef();
+}
+
 }  // namespace vfs
 }  // namespace client
 }  // namespace dingofs

--- a/test/unit/client/vfs/data/test_writer_table.cc
+++ b/test/unit/client/vfs/data/test_writer_table.cc
@@ -28,6 +28,7 @@ namespace vfs {
 
 using dingofs::client::vfs::test::VFSTestBase;
 using ::testing::AnyNumber;
+using ::testing::Return;
 
 class WriterTableTest : public VFSTestBase {
  protected:
@@ -172,6 +173,28 @@ TEST_F(WriterTableTest, ReleaseAfterStop_StillEvicts) {
   table_->ReleaseWriter(w);
   EXPECT_EQ(table_->Size(), 0u)
       << "ReleaseWriter after Stop must still return the writer";
+}
+
+// The last holder owns the synchronous Close and must receive its writeback
+// failure. Earlier holder releases have no close work and return OK.
+TEST_F(WriterTableTest, LastRelease_PropagatesCloseFailure) {
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault(Return(Status::Internal("last release flush error")));
+
+  auto* w1 = table_->AcquireWriter(600);
+  ASSERT_NE(w1, nullptr);
+  auto* w2 = table_->AcquireWriter(600);
+  ASSERT_EQ(w2, w1);
+
+  const char buf[] = "data";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w1->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  EXPECT_TRUE(table_->ReleaseWriter(w1).ok());
+  Status s = table_->ReleaseWriter(w2);
+  EXPECT_FALSE(s.ok());
+  EXPECT_THAT(s.ToString(), ::testing::HasSubstr("last release flush error"));
+  EXPECT_EQ(table_->Size(), 0u);
 }
 
 }  // namespace vfs


### PR DESCRIPTION
## What problem does this PR solve?

`FileWriter::Close()` currently returns `void`. When its final data flush fails, the error is only logged and cannot be observed by lifecycle callers. `WriterTable::ReleaseWriter()` consequently drops the final close result as well.

The normal FUSE release path already performs an explicit `FileWriter::Flush()` before closing the metadata file session, and returns that status through `VFSImpl::Release()`. This change addresses the remaining close lifecycle boundary without pretending that an RAII destructor can return an error.

## What is changed?

- Change `FileWriter::Close()` to return `Status`.
- Promote a final close-flush failure into the writer sticky status.
- Cache the first close result so repeated calls are idempotent.
- Change `WriterTable::ReleaseWriter()` to return the final Close result when it drops the last holder.
- Consume the result where a synchronous return channel exists; log it on Handle destruction paths where RAII provides no return channel.
- Add tests for close error propagation, cached/idempotent Close, and last-holder propagation.

## Error propagation boundary

- FUSE `Flush` / `Release`: the existing explicit `writer->Flush()` remains the application-visible propagation point.
- `FileWriter::Close` / `WriterTable::ReleaseWriter`: final writeback errors are now returned to synchronous lifecycle callers.
- `HandleGuard` or object destructors: errors cannot be returned from destructors and are logged.

## Tests

- Targeted FileWriter, WriterTable and VFS Release tests: 31/31 passed.
- Full `test_client`: 429 passed, 1 existing Debug-only test skipped in the current RelWithDebInfo build.
- `git diff --check` passed.

Draft/WIP: requesting early review of the lifecycle API and propagation boundary.