### PR TITLE
[fix][client] Drain operations before writer teardown

### DIFF
--- a/src/client/fuse/fs_context.h
+++ b/src/client/fuse/fs_context.h
@@ -17,8 +17,11 @@
 #ifndef DINGOFS_SRC_CLIENT_FUSE_FS_CONTEXT_H_
 #define DINGOFS_SRC_CLIENT_FUSE_FS_CONTEXT_H_
 
+#include <memory>
+
 #include "client/fuse/fuse_common.h"
 #include "client/fuse/fuse_server.h"
+#include "client/vfs/vfs_wrapper.h"
 
 namespace dingofs {
 namespace client {
@@ -27,6 +30,10 @@ namespace fuse {
 struct FsContext {
   struct MountOption* mount_option;
   FuseServer* fuse_server;
+  // Own the VFS until after fuse_session_loop has stopped and all workers have
+  // been joined. FUSE destroy callbacks may run inline on a worker, so they
+  // must Stop this object but never delete it.
+  std::unique_ptr<VFSWrapper> vfs;
 };
 
 }  // namespace fuse

--- a/src/client/fuse/fuse_op.cc
+++ b/src/client/fuse/fuse_op.cc
@@ -392,7 +392,9 @@ void FuseOpInit(void* userdata, struct fuse_conn_info* conn) {
             << ", fs name: " << config.fs_name
             << ", meta_url: " << mount_option->meta_url;
 
-  g_vfs = new dingofs::client::VFSWrapper();
+  CHECK(fs_context->vfs == nullptr) << "VFS already initialized";
+  fs_context->vfs = std::make_unique<dingofs::client::VFSWrapper>();
+  g_vfs = fs_context->vfs.get();
   int upgrade_from_pid = 0;
   if (UpgradeStateStore::GetInstance().GetFuseState() ==
       FuseUpgradeState::kFuseUpgradeNew) {
@@ -437,7 +439,6 @@ void FuseOpDestroy(void* userdata) {
     const bool handover = (UpgradeStateStore::GetInstance().GetFuseState() ==
                            FuseUpgradeState::kFuseUpgradeOld);
     g_vfs->Stop(handover);
-    delete g_vfs;
   }
 }
 

--- a/src/client/main.cc
+++ b/src/client/main.cc
@@ -244,7 +244,12 @@ int main(int argc, char* argv[]) {
   FsContext fs_context{
       .mount_option = &mount_option,
       .fuse_server = fuse_server,
+      .vfs = nullptr,
   };
+
+  // fs_context is declared before the session cleanup below, so reverse
+  // destruction order guarantees DestroySession() has joined every FUSE
+  // worker before fs_context.vfs is destroyed.
 
   // create fuse session
   if (fuse_server->CreateSession(&fs_context) == 1) return EXIT_FAILURE;

--- a/src/client/vfs/data/CMakeLists.txt
+++ b/src/client/vfs/data/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(vfs_data
     reader/chunk_req_reader.cc
     reader/chunk_req.cc
     reader/file_reader.cc
+    reader/reader_registry.cc
     reader/read_request.cc
     reader/readahead_policy.cc
     writer/file_writer.cc

--- a/src/client/vfs/data/reader/file_reader.h
+++ b/src/client/vfs/data/reader/file_reader.h
@@ -60,6 +60,8 @@ class FileReader {
   // caller should ensure ReleaseRef called outside of lock
   void ReleaseRef();
 
+  Ino GetIno() const { return ino_; }
+
  private:
   friend class FileReaderTestPeer;
 

--- a/src/client/vfs/data/reader/reader_registry.cc
+++ b/src/client/vfs/data/reader/reader_registry.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/vfs/data/reader/reader_registry.h"
+
+#include <glog/logging.h>
+
+#include <vector>
+
+#include "client/vfs/data/reader/file_reader.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+void ReaderRegistry::Register(FileReader* reader) {
+  CHECK_NOTNULL(reader);
+  const Ino ino = reader->GetIno();
+  std::lock_guard<std::mutex> lock(mutex_);
+  CHECK(readers_[ino].insert(reader).second)
+      << "FileReader registered more than once, ino: " << ino;
+}
+
+void ReaderRegistry::Unregister(FileReader* reader) {
+  CHECK_NOTNULL(reader);
+  const Ino ino = reader->GetIno();
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = readers_.find(ino);
+  CHECK(it != readers_.end()) << "FileReader inode is not registered: " << ino;
+  CHECK_EQ(it->second.erase(reader), 1)
+      << "FileReader is not registered for inode: " << ino;
+  if (it->second.empty()) {
+    readers_.erase(it);
+  }
+}
+
+void ReaderRegistry::InvalidateByIno(Ino ino, int64_t offset, int64_t size) {
+  std::vector<FileReader*> readers;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = readers_.find(ino);
+    if (it == readers_.end()) {
+      return;
+    }
+    readers.reserve(it->second.size());
+    for (auto* reader : it->second) {
+      reader->AcquireRef();
+      readers.push_back(reader);
+    }
+  }
+
+  for (auto* reader : readers) {
+    reader->Invalidate(offset, size);
+    reader->ReleaseRef();
+  }
+}
+
+size_t ReaderRegistry::Size() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  size_t size = 0;
+  for (const auto& entry : readers_) {
+    size += entry.second.size();
+  }
+  return size;
+}
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/vfs/data/reader/reader_registry.h
+++ b/src/client/vfs/data/reader/reader_registry.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_CLIENT_VFS_DATA_READER_READER_REGISTRY_H_
+#define DINGOFS_CLIENT_VFS_DATA_READER_READER_REGISTRY_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "client/vfs/vfs_meta.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+class FileReader;
+
+// Non-owning per-inode index of open FileReaders. HandleResources remains the
+// owner of each reader. Registry snapshots pin readers with their intrusive
+// refcount and never call FileReader methods while holding mutex_.
+class ReaderRegistry {
+ public:
+  void Register(FileReader* reader);
+  void Unregister(FileReader* reader);
+
+  void InvalidateByIno(Ino ino, int64_t offset, int64_t size);
+
+  size_t Size() const;
+
+ private:
+  mutable std::mutex mutex_;
+  std::unordered_map<Ino, std::unordered_set<FileReader*>> readers_;
+};
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_CLIENT_VFS_DATA_READER_READER_REGISTRY_H_

--- a/src/client/vfs/data/writer/chunk_writer.cc
+++ b/src/client/vfs/data/writer/chunk_writer.cc
@@ -563,6 +563,11 @@ void ChunkWriter::FlushAsync(StatusCallback cb) {
   DoFlushAsync(cb, chunk_flush_id);
 }
 
+Status ChunkWriter::GetErrorStatus() const {
+  std::lock_guard<std::mutex> lg(flush_mutex_);
+  return error_status_;
+}
+
 void ChunkWriter::TriggerFlush() {
   CHECK(!stopped_.load(std::memory_order_relaxed));
   uint64_t chunk_flush_id =

--- a/src/client/vfs/data/writer/chunk_writer.cc
+++ b/src/client/vfs/data/writer/chunk_writer.cc
@@ -29,6 +29,7 @@
 
 #include "client/vfs/common/async_util.h"
 #include "client/vfs/common/helper.h"
+#include "client/vfs/data/reader/reader_registry.h"
 #include "client/vfs/hub/vfs_hub.h"
 #include "client/vfs/vfs_meta.h"
 #include "common/callback.h"
@@ -436,7 +437,7 @@ void ChunkWriter::TryCommitFlushTasks(ContextSPtr ctx) {
             uuid, commit_ctx->commit_seq, commit_ctx->flush_tasks.size(),
             commit_ctx->commit_slices.size(), commit.ToString());
 
-        auto* manager = hub_->GetHandleManager();
+        auto* reader_registry = hub_->GetReaderRegistry();
         for (const Slice& slice : commit_ctx->commit_slices) {
           VLOG(9) << fmt::format(
               "{} TryCommitFlushTasks invalidate commit_seq: {} committed "
@@ -445,8 +446,8 @@ void ChunkWriter::TryCommitFlushTasks(ContextSPtr ctx) {
           // Shared writer model: a commit batch may aggregate slices from
           // multiple fhs. Invalidate by inode rather than by single fh so
           // every reader on this inode sees a fresh chunk_set.
-          manager->InvalidateByIno(chunk_.ino, chunk_.chunk_start + slice.pos,
-                                   slice.len);
+          reader_registry->InvalidateByIno(
+              chunk_.ino, chunk_.chunk_start + slice.pos, slice.len);
         }
       }
     }  // end if commit_slices not empty

--- a/src/client/vfs/data/writer/chunk_writer.h
+++ b/src/client/vfs/data/writer/chunk_writer.h
@@ -144,14 +144,11 @@ class ChunkWriter {
 
   void TryCommitFlushTasks(ContextSPtr ctx);
 
+  Status GetErrorStatus() const;
+
   int64_t WritersCount() const {
     std::lock_guard<std::mutex> lg(writer_mutex_);
     return writers_.size();
-  }
-
-  Status GetErrorStatus() const {
-    std::lock_guard<std::mutex> lg(flush_mutex_);
-    return error_status_;
   }
 
   // This is used to mark the chunk as error when some operation fails,
@@ -187,7 +184,8 @@ class ChunkWriter {
 
   mutable std::mutex flush_mutex_;
   std::deque<FlushTask*> flush_queue_;
-  // guarded by write_flush_mutex_
+  // Guarded by flush_mutex_. Never invoke a completion callback while holding
+  // this mutex; callbacks may enter higher-level writer objects.
   // when this not ok, all write and flush should return error
   Status error_status_;
 };

--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -58,6 +58,8 @@ namespace {
 // (usage already past soft_ratio), so the normal write path never touches them.
 bvar::Adder<int64_t> g_throttle_num("vfs_write_throttle_num");
 bvar::Adder<int64_t> g_throttle_timeout_num("vfs_write_throttle_timeout_num");
+bvar::Adder<int64_t> g_close_after_flush_failure_num(
+    "vfs_file_writer_close_after_flush_failure_num");
 
 // Memory-pressure throttle (pool-backed WriteMemPool, usage is hard-capped at
 // 100% so the old `used > total` / `> 2*total` thresholds never fire). Now
@@ -124,20 +126,16 @@ void FileWriter::Close() {
     cv_.wait(lg);
   }
 
-  if (!chunk_writers_.empty()) {
-    uint64_t file_flush_id = file_flush_id_gen.fetch_add(1);
-    auto flush_task =
-        std::make_unique<FileFlushTask>(ino_, file_flush_id, chunk_writers_);
-
-    Status s;
-    Synchronizer sync;
-    flush_task->RunAsync(sync.AsStatusCallBack(s));
-    sync.Wait();
-
-    if (!s.ok()) {
-      LOG(ERROR) << fmt::format("{} Failed to close file, flush error: {}",
-                                uuid_, s.ToString());
-    }
+  Status flush_status = GetStatus();
+  if (flush_status.ok()) {
+    CHECK_EQ(write_generation_, flushed_generation_)
+        << fmt::format("{} Close found unflushed data", uuid_);
+  } else {
+    g_close_after_flush_failure_num << 1;
+    LOG(ERROR) << fmt::format(
+        "{} Close after flush failure, write_generation: {}, "
+        "flushed_generation: {}, status: {}",
+        uuid_, write_generation_, flushed_generation_, flush_status.ToString());
   }
 
   for (auto& pair : chunk_writers_) {
@@ -238,6 +236,9 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
+    if (written_size > 0) {
+      ++write_generation_;
+    }
     writers_count_--;
     if (writers_count_ == 0) {
       cv_.notify_all();
@@ -274,8 +275,13 @@ ChunkWriter* FileWriter::GetOrCreateChunkWriter(int64_t chunk_index) {
   }
 }
 
-void FileWriter::FileFlushTaskDone(uint64_t file_flush_id, StatusCallback cb,
-                                   Status status) {
+void FileWriter::FileFlushTaskDone(uint64_t file_flush_id,
+                                   uint64_t target_generation,
+                                   StatusCallback cb, Status status) {
+  if (!status.ok()) {
+    SetStatusIfBroken(status);
+  }
+
   {
     std::lock_guard<std::mutex> lock(mutex_);
     auto iter = inflight_flush_tasks_.find(file_flush_id);
@@ -285,6 +291,10 @@ void FileWriter::FileFlushTaskDone(uint64_t file_flush_id, StatusCallback cb,
                    << ", file_flush_id: " << file_flush_id
                    << ", flush_task: " << iter->second->ToString()
                    << ", status: " << status.ToString();
+    }
+
+    if (status.ok()) {
+      flushed_generation_ = std::max(flushed_generation_, target_generation);
     }
 
     inflight_flush_tasks_.erase(iter);
@@ -304,10 +314,14 @@ void FileWriter::AsyncFlush(StatusCallback cb) {
 
   FileFlushTask* flush_task{nullptr};
   uint64_t chunk_count = 0;
+  uint64_t target_generation = 0;
+  bool closed = false;
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
+    target_generation = write_generation_;
     if (closed_) {
+      closed = true;
       LOG(INFO) << fmt::format(
           "{} File::AsyncFlush skip becaue file already closed", uuid_);
     } else {
@@ -326,11 +340,19 @@ void FileWriter::AsyncFlush(StatusCallback cb) {
     }
   }
 
+  if (closed) {
+    cb(Status::BadFd("file already closed"));
+    return;
+  }
+
   if (flush_task == nullptr) {
     VLOG(3) << fmt::format(
         "{} File::AsyncFlush end file_flush_id: {}, chunk_count: {} calling "
         "callback directly",
         uuid_, file_flush_id, chunk_count);
+    // chunk_writers_ only grows after a successful write reaches a chunk.
+    // Therefore an empty writer has no generation that needs flushing.
+    DCHECK_EQ(target_generation, 0);
     cb(Status::OK());
     return;
   }
@@ -338,14 +360,14 @@ void FileWriter::AsyncFlush(StatusCallback cb) {
   CHECK_NOTNULL(flush_task);
 
   AcquireRef();
-  flush_task->RunAsync(
-      [this, file_flush_id, rcb = std::move(cb)](Status status) {
-        VLOG(3) << "File::AsyncFlush end ino: " << ino_
-                << ", file_flush_id: " << file_flush_id
-                << ", status: " << status.ToString();
-        FileFlushTaskDone(file_flush_id, rcb, std::move(status));
-        ReleaseRef();
-      });
+  flush_task->RunAsync([this, file_flush_id, target_generation,
+                        rcb = std::move(cb)](Status status) {
+    VLOG(3) << "File::AsyncFlush end ino: " << ino_
+            << ", file_flush_id: " << file_flush_id
+            << ", status: " << status.ToString();
+    FileFlushTaskDone(file_flush_id, target_generation, rcb, std::move(status));
+    ReleaseRef();
+  });
 }
 
 Status FileWriter::Flush() {
@@ -353,9 +375,6 @@ Status FileWriter::Flush() {
   Synchronizer sync;
   AsyncFlush(sync.AsStatusCallBack(s));
   sync.Wait();
-  if (!s.ok()) {
-    SetStatusIfBroken(s);
-  }
   return s;
 }
 

--- a/src/client/vfs/data/writer/file_writer.h
+++ b/src/client/vfs/data/writer/file_writer.h
@@ -73,8 +73,8 @@ class FileWriter {
 
   ChunkWriter* GetOrCreateChunkWriter(int64_t chunk_index);
 
-  void FileFlushTaskDone(uint64_t file_flush_id, StatusCallback cb,
-                         Status status);
+  void FileFlushTaskDone(uint64_t file_flush_id, uint64_t target_generation,
+                         StatusCallback cb, Status status);
   VFSHub* vfs_hub_;
   const uint64_t ino_;
   const std::string uuid_;
@@ -88,6 +88,11 @@ class FileWriter {
   std::condition_variable cv_;
   bool closed_{false};
   int64_t writers_count_{0};
+  // Generations are a final-close invariant, not an exact account of what an
+  // arbitrary concurrent Flush happened to include. Lifecycle owners must
+  // quiesce writes, complete one final explicit Flush, and only then Close.
+  uint64_t write_generation_{0};
+  uint64_t flushed_generation_{0};
 
   // chunk_index -> chunk
   // chunk is used by file/file_flush_task/chunk_flush_task

--- a/src/client/vfs/data/writer_table.cc
+++ b/src/client/vfs/data/writer_table.cc
@@ -52,14 +52,16 @@ void WriterTable::Stop() {
 }
 
 Status WriterTable::FlushAll() {
-  // Snapshot live writers (transient AcquireRef on each), flush outside lock.
-  // The transient ref does NOT touch holders — it is an internal hold.
+  // Snapshot live writers and pin each entry with a transient holder. A plain
+  // FileWriter ref would prevent UAF but would still allow the last external
+  // holder to erase the entry and Close() the writer before Flush() starts.
   std::vector<FileWriter*> snap;
   {
     std::lock_guard<std::mutex> lg(mutex_);
     snap.reserve(writers_.size());
     for (auto& [ino, e] : writers_) {
       e.writer->AcquireRef();
+      ++e.holders;
       snap.push_back(e.writer);
     }
   }
@@ -72,9 +74,9 @@ Status WriterTable::FlushAll() {
       LOG(WARNING) << fmt::format("FlushAll: writer flush failed: {}",
                                   s.ToString());
     }
-    // Release the transient ref directly via FileWriter — the snap path
-    // never touched holders, so it must not call ReleaseWriter.
-    w->ReleaseRef();
+    // Drop the transient holder. If all external holders were concurrently
+    // released, this is now the last holder and performs Close after Flush.
+    ReleaseWriter(w);
   }
   return final_status;
 }

--- a/src/client/vfs/data/writer_table.h
+++ b/src/client/vfs/data/writer_table.h
@@ -41,9 +41,9 @@ class FileWriter;
 //   - FileWriter::refs_ remains the single source of truth for "is the
 //     object alive". `FileWriter::ReleaseRef()` is the sole place that
 //     calls `delete this` (when refs_ hits 0).
-//   - WriterTable maintains a *separate* `holders` counter per entry —
-//     it only counts outstanding AcquireWriter / PeekWriter callers. It
-//     does NOT count internal FileWriter lambdas (e.g. async flush
+//   - WriterTable maintains a *separate* `holders` counter per entry. It counts
+//     outstanding AcquireWriter / PeekWriter callers and short-lived FlushAll
+//     pins. It does NOT count internal FileWriter lambdas (e.g. async flush
 //     callbacks that AcquireRef/ReleaseRef themselves).
 //   - When `holders` drops to 0, the entry is removed from the map BEFORE
 //     the matching `Close()` and `ReleaseRef()` calls. Any lingering
@@ -55,8 +55,9 @@ class FileWriter;
 //     latency until refs_ actually hits 0 and the writer is destroyed).
 //
 // FlushAll vs Stop:
-//   - FlushAll() synchronously flushes every live writer; idempotent, can
-//     be called any time, no state change.
+//   - FlushAll() synchronously flushes every live writer; its transient holder
+//     pins prevent a concurrent last external release from closing a
+//     snapshotted writer before that writer's Flush completes.
 //   - Stop() marks stopped_ to refuse new acquires. It does NOT flush.
 //     Callers that need both should call FlushAll() first.
 class WriterTable {
@@ -94,7 +95,7 @@ class WriterTable {
  private:
   struct Entry {
     FileWriter* writer{nullptr};
-    int64_t holders{0};   // tracked by WriterTable, NOT FileWriter
+    int64_t holders{0};  // external holders + transient WriterTable pins
   };
 
   VFSHub* vfs_hub_{nullptr};

--- a/src/client/vfs/handle/handle_manager.cc
+++ b/src/client/vfs/handle/handle_manager.cc
@@ -45,7 +45,11 @@ std::string Handle::ToString() const {
 }
 
 HandleManager::~HandleManager() {
-  Stop();
+  Status s = Stop();
+  if (!s.ok()) {
+    LOG(ERROR) << fmt::format("HandleManager destructor flush failed: {}",
+                              s.ToString());
+  }
   std::vector<Handle*> handles;
   {
     std::unique_lock<std::mutex> lock(mutex_);
@@ -129,14 +133,15 @@ void HandleManager::ReleaseHandleResources(HandleResources resources) {
 
 Status HandleManager::Start() { return Status::OK(); }
 
-void HandleManager::Stop() {
+Status HandleManager::Stop() {
   std::vector<HandleResources> resources_to_release;
   std::vector<Handle*> stop_refs;
+  bool has_writer = false;
   {
     std::unique_lock<std::mutex> lock(mutex_);
     if (stopped_) {
       LOG(INFO) << "HandleManager already stopped";
-      return;
+      return Status::OK();
     }
 
     stopped_ = true;
@@ -159,14 +164,25 @@ void HandleManager::Stop() {
 
       auto resources = DetachHandleResourcesLocked(handle);
       if (resources.reader != nullptr || resources.writer != nullptr) {
+        has_writer = has_writer || resources.writer != nullptr;
         resources_to_release.push_back(resources);
       }
     }
   }
 
-  // Release resources outside mutex_: FileWriter::Close() can synchronously
-  // wait for callbacks that may call back into
-  // HandleManager::InvalidateByIno().
+  // resources_to_release owns the detached writer holders, so every writer is
+  // still present in WriterTable here. Flush while metadata, BlockStore, and
+  // writer executors are alive, before the loop below can drop the last holder
+  // and close the writer. FlushAll deliberately visits every writer and returns
+  // the first error without stopping early.
+  Status flush_status = Status::OK();
+  if (has_writer) {
+    flush_status = vfs_hub_->GetWriterTable()->FlushAll();
+  }
+
+  // Release resources outside mutex_: dropping the last writer holder may
+  // block while FileWriter::Close() waits for already in-flight tasks and then
+  // destroys nested writer resources.
   for (auto& resources : resources_to_release) {
     ReleaseHandleResources(resources);
   }
@@ -174,6 +190,8 @@ void HandleManager::Stop() {
   for (auto* handle : stop_refs) {
     ReleaseRefHandle(handle);
   }
+
+  return flush_status;
 }
 
 Handle* HandleManager::NewHandle(uint64_t fh, Ino ino, int flags) {

--- a/src/client/vfs/handle/handle_manager.cc
+++ b/src/client/vfs/handle/handle_manager.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "client/vfs/data/reader/file_reader.h"
+#include "client/vfs/data/reader/reader_registry.h"
 #include "client/vfs/data/writer/file_writer.h"
 #include "client/vfs/data/writer_table.h"
 #include "client/vfs/hub/vfs_hub.h"
@@ -122,6 +123,7 @@ HandleResources HandleManager::DetachHandleResourcesLocked(Handle* h) {
 
 void HandleManager::ReleaseHandleResources(HandleResources resources) {
   if (resources.reader != nullptr) {
+    vfs_hub_->GetReaderRegistry()->Unregister(resources.reader);
     resources.reader->Close();
     resources.reader->ReleaseRef();
   }
@@ -136,7 +138,6 @@ Status HandleManager::Start() { return Status::OK(); }
 Status HandleManager::Stop() {
   std::vector<HandleResources> resources_to_release;
   std::vector<Handle*> stop_refs;
-  bool has_writer = false;
   {
     std::unique_lock<std::mutex> lock(mutex_);
     if (stopped_) {
@@ -164,7 +165,6 @@ Status HandleManager::Stop() {
 
       auto resources = DetachHandleResourcesLocked(handle);
       if (resources.reader != nullptr || resources.writer != nullptr) {
-        has_writer = has_writer || resources.writer != nullptr;
         resources_to_release.push_back(resources);
       }
     }
@@ -175,10 +175,7 @@ Status HandleManager::Stop() {
   // writer executors are alive, before the loop below can drop the last holder
   // and close the writer. FlushAll deliberately visits every writer and returns
   // the first error without stopping early.
-  Status flush_status = Status::OK();
-  if (has_writer) {
-    flush_status = vfs_hub_->GetWriterTable()->FlushAll();
-  }
+  Status flush_status = vfs_hub_->GetWriterTable()->FlushAll();
 
   // Release resources outside mutex_: dropping the last writer holder may
   // block while FileWriter::Close() waits for already in-flight tasks and then
@@ -205,7 +202,6 @@ Handle* HandleManager::NewHandle(uint64_t fh, Ino ino, int flags) {
   handle->resources.reader->AcquireRef();
   CHECK(handle->resources.reader->Open().ok())
       << "FileReader::Open is currently infallible";
-
   // Writer only for writable opens. Borrowed from WriterTable.
   if ((flags & O_ACCMODE) != O_RDONLY) {
     handle->resources.writer = vfs_hub_->GetWriterTable()->AcquireWriter(ino);
@@ -218,6 +214,11 @@ Handle* HandleManager::NewHandle(uint64_t fh, Ino ino, int flags) {
       return nullptr;
     }
   }
+
+  // Publish the reader in the per-inode index only after all Handle resources
+  // have been acquired successfully. AddHandle failure is cleaned up through
+  // DestroyHandle, which unregisters it via ReleaseHandleResources.
+  vfs_hub_->GetReaderRegistry()->Register(handle->resources.reader);
 
   if (!AddHandle(handle)) {
     DestroyHandle(handle);
@@ -285,27 +286,6 @@ HandleGuard HandleManager::FindHandlerForRelease(uint64_t fh) {
   return HandleGuard(this, it->second);
 }
 
-void HandleManager::Invalidate(uint64_t fh, int64_t offset, int64_t size) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (stopped_) {
-    LOG(WARNING) << "HandleManager already stopped";
-    return;
-  }
-
-  auto it = handles_.find(fh);
-  if (it == handles_.end()) {
-    LOG(WARNING) << "Invalidate failed, fh not found:" << fh;
-    return;
-  }
-
-  auto* handle = it->second;
-  if (handle->resources.reader != nullptr) {
-    handle->resources.reader->Invalidate(offset, size);
-  } else {
-    LOG(WARNING) << "Invalidate failed, reader is nullptr, fh:" << fh;
-  }
-}
-
 Status HandleManager::FlushByIno(Ino ino) {
   // O(1) hash lookup via WriterTable.
   auto* writer = vfs_hub_->GetWriterTable()->PeekWriter(ino);
@@ -319,27 +299,6 @@ Status HandleManager::FlushByIno(Ino ino) {
                                 s.ToString());
   }
   return s;
-}
-
-void HandleManager::InvalidateByIno(Ino ino, int64_t offset, int64_t size) {
-  std::vector<Handle*> handles_to_invalidate;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (stopped_) {
-      return;
-    }
-    for (auto& [fh, handle] : handles_) {
-      if (handle->ino == ino && handle->resources.reader != nullptr) {
-        AcquireRefHandle(handle);
-        handles_to_invalidate.push_back(handle);
-      }
-    }
-  }
-
-  for (auto* handle : handles_to_invalidate) {
-    handle->resources.reader->Invalidate(offset, size);
-    ReleaseRefHandle(handle);
-  }
 }
 
 void HandleManager::Summary(Json::Value& value) {

--- a/src/client/vfs/handle/handle_manager.h
+++ b/src/client/vfs/handle/handle_manager.h
@@ -123,15 +123,9 @@ class HandleManager {
 
   void ReleaseHandler(uint64_t fh);
 
-  void Invalidate(uint64_t fh, int64_t offset, int64_t size);
-
   // Flush dirty data for the given inode. After WriterTable adoption this
   // is O(1): a single PeekWriter lookup + Flush.
   Status FlushByIno(Ino ino);
-
-  // Invalidate read cache for all handles of the given inode in the given
-  // range (per-inode).
-  void InvalidateByIno(Ino ino, int64_t offset, int64_t size);
 
   void Summary(Json::Value& value);
   bool Dump(Json::Value& value);

--- a/src/client/vfs/handle/handle_manager.h
+++ b/src/client/vfs/handle/handle_manager.h
@@ -103,7 +103,7 @@ class HandleManager {
 
   Status Start();
 
-  void Stop();
+  Status Stop();
 
   // Build a new Handle for (fh, ino, flags). Allocates FileReader
   // unconditionally and acquires a writer from WriterTable for any

--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -29,6 +29,7 @@
 #include "client/vfs/compaction/compactor_impl.h"
 #include "client/vfs/components/prefetch_manager.h"
 #include "client/vfs/components/warmup_manager.h"
+#include "client/vfs/data/reader/reader_registry.h"
 #include "client/vfs/data/writer_table.h"
 #include "client/vfs/metasystem/local/metasystem.h"
 #include "client/vfs/metasystem/mds/metasystem.h"
@@ -263,6 +264,10 @@ Status VFSHubImpl::Start(bool skip_mount) {
     CHECK(writer_table_ != nullptr) << "writer table is nullptr.";
     DINGOFS_RETURN_NOT_OK(writer_table_->Start());
   }
+
+  // ReaderRegistry is a non-owning index. It must exist before handles can
+  // register readers and outlive HandleManager teardown.
+  reader_registry_ = std::make_unique<ReaderRegistry>();
 
   // handle manager
   {

--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -435,15 +435,23 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
     compactor_->Stop();
   }
 
+  Status handle_stop_status;
   if (handle_manager_ != nullptr) {
-    handle_manager_->Stop();
+    handle_stop_status = handle_manager_->Stop();
   }
 
-  // HandleManager::Stop releases handle-owned reader/writer resources while
-  // preserving handle identities for handover Dump. Drain residual dirty data
-  // and stop the writer table before tearing down executors/meta/block-store.
+  // A handover must never publish state after dirty data failed to flush. The
+  // old process is already quiesced at this point, so treat this as an
+  // unrecoverable handover failure rather than letting VFSWrapper dump state.
+  if (skip_unmount && !handle_stop_status.ok()) {
+    LOG(FATAL) << fmt::format("Handover writer flush failed: {}",
+                              handle_stop_status.ToString());
+  }
+
+  // HandleManager::Stop has already flushed all writers before releasing its
+  // detached resources. Stop new writer acquires before tearing down
+  // executors/meta/block-store.
   if (writer_table_ != nullptr) {
-    (void)writer_table_->FlushAll();
     writer_table_->Stop();
   }
 
@@ -523,7 +531,7 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
   // Stop() would CHECK-fail (SIGABRT) such a late caller mid-teardown.
   started_.store(false, std::memory_order_relaxed);
 
-  return Status::OK();
+  return handle_stop_status;
 }
 
 }  // namespace vfs

--- a/src/client/vfs/hub/vfs_hub.h
+++ b/src/client/vfs/hub/vfs_hub.h
@@ -47,6 +47,7 @@ namespace client {
 namespace vfs {
 
 class WriterTable;  // forward decl; full include lives in vfs_hub.cc
+class ReaderRegistry;
 
 class VFSHub {
  public:
@@ -63,6 +64,8 @@ class VFSHub {
   virtual MetaWrapper* GetMetaSystem() = 0;
 
   virtual HandleManager* GetHandleManager() = 0;
+
+  virtual ReaderRegistry* GetReaderRegistry() = 0;
 
   virtual WriterTable* GetWriterTable() = 0;
 
@@ -121,6 +124,11 @@ class VFSHubImpl : public VFSHub {
   HandleManager* GetHandleManager() override {
     CHECK_NOTNULL(handle_manager_);
     return handle_manager_.get();
+  }
+
+  ReaderRegistry* GetReaderRegistry() override {
+    CHECK_NOTNULL(reader_registry_);
+    return reader_registry_.get();
   }
 
   WriterTable* GetWriterTable() override;  // out-of-line (see vfs_hub.cc)
@@ -232,7 +240,20 @@ class VFSHubImpl : public VFSHub {
   std::unique_ptr<TraceManager> trace_manager_;
   std::unique_ptr<Compactor> compactor_;
   std::unique_ptr<MetaWrapper> meta_wrapper_;
+
+  // Destruction order is load-bearing. C++ destroys members in reverse
+  // declaration order, so keep these declarations in this order:
+  //
+  //   declared:  WriterTable -> ReaderRegistry -> HandleManager
+  //   destroyed: HandleManager -> ReaderRegistry -> WriterTable
+  //
+  // HandleManager::~HandleManager() may call Stop(), which flushes writers,
+  // invalidates and unregisters readers, and releases writer holders. Both
+  // ReaderRegistry and WriterTable must therefore remain alive until
+  // HandleManager has been destroyed, including partial-Start/error paths
+  // where the normal explicit Stop() sequence may not have completed.
   std::unique_ptr<WriterTable> writer_table_;
+  std::unique_ptr<ReaderRegistry> reader_registry_;
   std::unique_ptr<HandleManager> handle_manager_;
   std::unique_ptr<blockaccess::BlockAccesser> block_accesser_;
   std::unique_ptr<BlockStore> block_store_;

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -31,6 +31,7 @@
 #include "client/vfs/components/uid_gid_mapper.h"
 #include "client/vfs/components/warmup_manager.h"
 #include "client/vfs/data/reader/file_reader.h"
+#include "client/vfs/data/reader/reader_registry.h"
 #include "client/vfs/data/writer/file_writer.h"
 #include "client/vfs/data_buffer.h"
 #include "client/vfs/handle/handle_manager.h"
@@ -99,12 +100,21 @@ VFSImpl::VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id)
     : client_id_(client_id),
       mount_root_path_(
           vfs_conf.mount_root_path.empty() ? "/" : vfs_conf.mount_root_path),
-      vfs_hub_(std::make_unique<VFSHubImpl>(vfs_conf, client_id_)) {};
+      vfs_hub_(std::make_unique<VFSHubImpl>(vfs_conf, client_id_)){};
+
+VFSImpl::~VFSImpl() {
+  Status s = StopBrpcServer();
+  if (!s.ok()) {
+    LOG(ERROR) << "stop brpc server during VFS destruction failed: "
+               << s.ToString();
+  }
+}
 
 VFSImpl::VFSImpl(std::unique_ptr<VFSHub> hub)
     : client_id_(), vfs_hub_(std::move(hub)) {
   meta_system_ = vfs_hub_->GetMetaSystem();
   handle_manager_ = vfs_hub_->GetHandleManager();
+  reader_registry_ = vfs_hub_->GetReaderRegistry();
 }
 
 Status VFSImpl::Start(bool skip_mount) {
@@ -113,6 +123,7 @@ Status VFSImpl::Start(bool skip_mount) {
   DINGOFS_RETURN_NOT_OK(vfs_hub_->Start(skip_mount));
   meta_system_ = vfs_hub_->GetMetaSystem();
   handle_manager_ = vfs_hub_->GetHandleManager();
+  reader_registry_ = vfs_hub_->GetReaderRegistry();
 
   DINGOFS_RETURN_NOT_OK(ResolveMountRoot());
 
@@ -161,7 +172,10 @@ Status VFSImpl::ResolveMountRoot() {
   return Status::OK();
 }
 
-Status VFSImpl::Stop(bool skip_unmount) { return vfs_hub_->Stop(skip_unmount); }
+Status VFSImpl::Stop(bool skip_unmount) {
+  DINGOFS_RETURN_NOT_OK(StopBrpcServer());
+  return vfs_hub_->Stop(skip_unmount);
+}
 
 bool VFSImpl::Dump(ContextSPtr ctx, Json::Value& value) {
   CHECK(handle_manager_ != nullptr) << "handle_manager is null";
@@ -334,8 +348,8 @@ Status VFSImpl::SetAttr(ContextSPtr ctx, Ino ino, int set, const Attr& in_attr,
   // buffers in FileReader::requests_ are indexed by (ino, frange) and would
   // otherwise serve stale data after the inode shrinks/grows.
   if (s.ok() && (set & kSetAttrSize)) {
-    handle_manager_->InvalidateByIno(ino, 0,
-                                     std::numeric_limits<int64_t>::max());
+    reader_registry_->InvalidateByIno(ino, 0,
+                                      std::numeric_limits<int64_t>::max());
   }
 
   return s;
@@ -362,8 +376,8 @@ Status VFSImpl::Fallocate(ContextSPtr ctx, Ino ino, int mode, uint64_t offset,
   // buffers in FileReader::requests_ on the same fd would otherwise serve
   // stale bytes for the affected range.
   if (s.ok()) {
-    handle_manager_->InvalidateByIno(ino, static_cast<int64_t>(offset),
-                                     static_cast<int64_t>(length));
+    reader_registry_->InvalidateByIno(ino, static_cast<int64_t>(offset),
+                                      static_cast<int64_t>(length));
   }
 
   return s;
@@ -416,8 +430,8 @@ Status VFSImpl::CopyFileRange(ContextSPtr ctx, Ino src_ino, uint64_t src_off,
 
   // Invalidate any in-flight reader caches for the rewritten dst range.
   if (*bytes_copied > 0) {
-    handle_manager_->InvalidateByIno(dst_ino, static_cast<int64_t>(dst_off),
-                                     static_cast<int64_t>(*bytes_copied));
+    reader_registry_->InvalidateByIno(dst_ino, static_cast<int64_t>(dst_off),
+                                      static_cast<int64_t>(*bytes_copied));
   }
 
   return s;
@@ -723,8 +737,8 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
                             *out_wsize, fh);
     // Invalidate read cache for all handles of this inode in the written range,
     // so that no other open file descriptor can serve stale cached data.
-    handle_manager_->InvalidateByIno(ino, static_cast<int64_t>(offset),
-                                     static_cast<int64_t>(*out_wsize));
+    reader_registry_->InvalidateByIno(ino, static_cast<int64_t>(offset),
+                                      static_cast<int64_t>(*out_wsize));
   }
 
   // No status logging here: VFSImpl returns Status without logging per-op
@@ -1160,6 +1174,23 @@ Status VFSImpl::StartBrpcServer() {
         fmt::format("Get local ip failed, please check network configuration");
     LOG(ERROR) << error_msg;
     return Status::Unknown(error_msg);
+  }
+
+  return Status::OK();
+}
+
+Status VFSImpl::StopBrpcServer() {
+  const brpc::Server::Status status = brpc_server_.status();
+  if (status == brpc::Server::UNINITIALIZED || status == brpc::Server::READY) {
+    return Status::OK();
+  }
+
+  if (status == brpc::Server::RUNNING && brpc_server_.Stop(0) != 0) {
+    return Status::Internal("stop brpc server failed");
+  }
+
+  if (brpc_server_.Join() != 0) {
+    return Status::Internal("join brpc server failed");
   }
 
   return Status::OK();

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -780,11 +780,10 @@ Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
     handle->resources.reader->Close();
   }
 
-  // Drain dirty data while the metadata file session is still alive.  The
-  // last writer holder is released below by ReleaseHandler(), which may call
-  // FileWriter::Close() and perform a final flush.  Closing the metadata
-  // session first would make that flush's WriteSlice() fail because its
-  // FileSession had already been removed.
+  // Drain dirty data while the metadata file session is still alive. Dropping
+  // the last writer holder below may call FileWriter::Close(), but Close only
+  // validates the final-flush invariant and cleans up resources; it must not
+  // perform persistence I/O after this explicit Flush.
   Status flush_status;
   if (handle->resources.writer != nullptr) {
     flush_status = handle->resources.writer->Flush();
@@ -805,19 +804,21 @@ Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
 
 // TODO: seperate data flush with metadata flush
 Status VFSImpl::Fsync(ContextSPtr ctx, Ino ino, int datasync, uint64_t fh) {
-  Status s;
   auto handle = handle_manager_->FindHandlerGuard(fh);
   VFS_CHECK_HANDLE(handle.get(), ino, fh);
 
   if (handle->resources.writer != nullptr) {
-    s = handle->resources.writer->Flush();
+    Status s = handle->resources.writer->Flush();
+    if (!s.ok()) {
+      return s;
+    }
   }
 
   if (datasync == 0) {
-    s = meta_system_->Flush(ctx, ino, fh);
+    return meta_system_->Flush(ctx, ino, fh);
   }
 
-  return s;
+  return Status::OK();
 }
 
 Status VFSImpl::SetXattr(ContextSPtr ctx, Ino ino, const std::string& name,

--- a/src/client/vfs/vfs_impl.h
+++ b/src/client/vfs/vfs_impl.h
@@ -41,7 +41,7 @@ class VFSImpl : public VFS {
  public:
   VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id);
 
-  ~VFSImpl() override = default;
+  ~VFSImpl() override;
 
   Status Start(bool skip_mount) override;
 
@@ -158,6 +158,8 @@ class VFSImpl : public VFS {
 
   Status StartBrpcServer();
 
+  Status StopBrpcServer();
+
   // Resolve `mount_root_path_` to a real directory inode by walking the
   // filesystem. Must be called after `vfs_hub_->Start()` so that
   // `meta_system_` is available. On success, sets `mount_root_ino_`.
@@ -208,11 +210,14 @@ class VFSImpl : public VFS {
   std::unique_ptr<VFSHub> vfs_hub_;
   MetaWrapper* meta_system_{nullptr};
   HandleManager* handle_manager_{nullptr};
+  ReaderRegistry* reader_registry_{nullptr};
 
-  brpc::Server brpc_server_;
+  // Services are non-owned by brpc_server_. Declare the server last so it is
+  // destroyed first and drains callbacks before either the services or hub.
   InodeBlocksServiceImpl inode_blocks_service_;
   CompactServiceImpl compact_service_;
   ClientStatServiceImpl client_stat_service_;
+  brpc::Server brpc_server_;
 };
 
 }  // namespace vfs

--- a/src/client/vfs/vfs_wrapper.cc
+++ b/src/client/vfs/vfs_wrapper.cc
@@ -16,9 +16,11 @@
 
 #include "client/vfs/vfs_wrapper.h"
 
+#include <bvar/bvar.h>
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -72,6 +74,16 @@ using vfs::StrAttr;
 using vfs::StrMode;
 
 static auto& g_rw_metric = VFSRWMetric::GetInstance();
+static bvar::Adder<int64_t> g_active_public_operations(
+    "vfs_active_public_operations");
+static bvar::Adder<uint64_t> g_rejected_public_operations(
+    "vfs_rejected_public_operations_total");
+
+#define VFS_WRAPPER_OPERATION_GUARD()                              \
+  auto operation = TryAcquireOperation();                          \
+  if (!operation.has_value()) {                                    \
+    return Status::Stop("VFS is not accepting public operations"); \
+  }
 
 static std::string DescribeSetAttr(int set) {
   const uint32_t value = static_cast<uint32_t>(set);
@@ -282,14 +294,71 @@ static Status NormalizeMountRootPath(const std::string& in, std::string& out) {
   return Status::OK();
 }
 
+VFSWrapper::OperationLease::~OperationLease() {
+  if (owner_ != nullptr) owner_->ReleaseOperation();
+}
+
+std::optional<VFSWrapper::OperationLease> VFSWrapper::TryAcquireOperation() {
+  {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (lifecycle_state_ != LifecycleState::kRunning) {
+      g_rejected_public_operations << 1;
+      return std::nullopt;
+    }
+
+    ++active_public_operations_;
+  }
+
+  g_active_public_operations << 1;
+  return OperationLease(this);
+}
+
+void VFSWrapper::ReleaseOperation() {
+  g_active_public_operations << -1;
+
+  std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+  CHECK_GT(active_public_operations_, 0);
+  --active_public_operations_;
+  if (active_public_operations_ == 0 &&
+      lifecycle_state_ == LifecycleState::kQuiescing) {
+    lifecycle_cv_.notify_all();
+  }
+}
+
+Status VFSWrapper::FinishStartFailure(const Status& status) {
+  if (vfs_ != nullptr) {
+    Status cleanup_status = vfs_->Stop(/*skip_unmount=*/false);
+    if (!cleanup_status.ok()) {
+      LOG(ERROR) << "cleanup after VFS start failure failed: "
+                 << cleanup_status.ToString();
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    stop_status_ = status;
+    lifecycle_state_ = LifecycleState::kStopped;
+  }
+  lifecycle_cv_.notify_all();
+  return status;
+}
+
 Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
   LOG(INFO) << "vfs start";
 
+  {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (lifecycle_state_ != LifecycleState::kCreated) {
+      return Status::InvalidParam("VFS can only be started once");
+    }
+    lifecycle_state_ = LifecycleState::kStarting;
+  }
+
   if (config.fs_name.empty()) {
-    return Status::InvalidParam("fs_name is empty");
+    return FinishStartFailure(Status::InvalidParam("fs_name is empty"));
   }
   if (config.mount_point.empty()) {
-    return Status::InvalidParam("mount_point is empty");
+    return FinishStartFailure(Status::InvalidParam("mount_point is empty"));
   }
 
   // Propagate mds_addrs to the cache layer's own MDS client so that
@@ -303,22 +372,21 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
   vfs_conf.metasystem_type = ParseMetaSystemType(config.metasystem_type);
   vfs_conf.storage_info = config.storage_info;
 
-  DINGOFS_RETURN_NOT_OK(
-      NormalizeMountRootPath(config.subdir, vfs_conf.mount_root_path));
+  Status s = NormalizeMountRootPath(config.subdir, vfs_conf.mount_root_path);
+  if (!s.ok()) return FinishStartFailure(s);
   LOG(INFO) << "vfs mount_root_path: " << vfs_conf.mount_root_path;
 
   if (vfs_conf.metasystem_type != MetaSystemType::MDS &&
       vfs_conf.metasystem_type != MetaSystemType::LOCAL &&
       vfs_conf.metasystem_type != MetaSystemType::MEMORY) {
-    return Status::InvalidParam(
-        "unsupported metasystem_type " +
-        MetaSystemTypeToString(vfs_conf.metasystem_type));
+    return FinishStartFailure(
+        Status::InvalidParam("unsupported metasystem_type " +
+                             MetaSystemTypeToString(vfs_conf.metasystem_type)));
   }
 
   LOG(INFO) << "use vfs type: "
             << MetaSystemTypeToString(vfs_conf.metasystem_type);
 
-  Status s;
   AccessLogGuard log(
       [&]() { return absl::StrFormat("start: %s", s.ToString()); });
 
@@ -326,7 +394,8 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
     FLAGS_log_dir = "/tmp";
   }
 
-  DINGOFS_RETURN_NOT_OK(InitLog());
+  s = InitLog();
+  if (!s.ok()) return FinishStartFailure(s);
 
   if (FLAGS_vfs_bthread_worker_num > 0) {
     bthread_setconcurrency(FLAGS_vfs_bthread_worker_num);
@@ -341,11 +410,13 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
 
   Json::Value root;
   if (is_upgrade && !LoadStateFile(upgrade_from_pid, root)) {
-    return Status::InvalidParam("load vfs state fail");
+    return FinishStartFailure(Status::InvalidParam("load vfs state fail"));
   }
 
   const std::string hostname = dingofs::Helper::GetHostName();
-  if (hostname.empty()) return Status::Internal("get hostname fail");
+  if (hostname.empty()) {
+    return FinishStartFailure(Status::Internal("get hostname fail"));
+  }
 
   vfs::ClientId client_id(utils::GenerateUUID(), hostname,
                           FLAGS_vfs_dummy_server_port, vfs_conf.mount_point);
@@ -355,11 +426,12 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
   LOG(INFO) << "client id: " << client_id.Description();
 
   vfs_ = std::make_unique<vfs::VFSImpl>(vfs_conf, client_id);
-  DINGOFS_RETURN_NOT_OK(vfs_->Start(/*skip_mount=*/is_upgrade));
+  s = vfs_->Start(/*skip_mount=*/is_upgrade);
+  if (!s.ok()) return FinishStartFailure(s);
 
   if (is_upgrade) {
     if (!Load(root)) {
-      return Status::InvalidParam("load vfs state fail");
+      return FinishStartFailure(Status::InvalidParam("load vfs state fail"));
     }
     // Remove the old process's state file now that we've consumed it.
     const std::string state_path =
@@ -370,14 +442,64 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
   uid_ = dingofs::Helper::GetOriginalUid();
   gid_ = dingofs::Helper::GetOriginalGid();
 
-  started_.store(true);
+  attr_timeout_ = vfs_->GetAttrTimeout(FileType::kFile);
+  entry_timeout_ = vfs_->GetEntryTimeout(FileType::kFile);
+  fs_id_ = vfs_->GetFsId();
+  max_name_length_ = vfs_->GetMaxNameLength();
+  immutable_values_published_.store(true, std::memory_order_release);
+
+  {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    lifecycle_state_ = LifecycleState::kRunning;
+    stop_status_ = Status::OK();
+  }
+  lifecycle_cv_.notify_all();
   return Status::OK();
 }
 
 Status VFSWrapper::Stop(bool handover) {
-  if (!started_.load()) {
-    LOG(INFO) << "vfs not started, no need to stop.";
-    return Status::OK();
+  {
+    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+    while (lifecycle_state_ == LifecycleState::kStarting) {
+      if (lifecycle_cv_.wait_for(lock, std::chrono::seconds(30)) ==
+          std::cv_status::timeout) {
+        LOG(ERROR) << "VFS Stop still waiting for Start to finish";
+      }
+    }
+
+    if (lifecycle_state_ == LifecycleState::kCreated) {
+      lifecycle_state_ = LifecycleState::kStopped;
+      stop_status_ = Status::OK();
+      return stop_status_;
+    }
+
+    if (lifecycle_state_ == LifecycleState::kStopped) {
+      return stop_status_;
+    }
+
+    if (lifecycle_state_ == LifecycleState::kQuiescing) {
+      const bool same_stop_mode = stop_handover_ == handover;
+      lifecycle_cv_.wait(lock, [this]() {
+        return lifecycle_state_ == LifecycleState::kStopped;
+      });
+      if (!same_stop_mode) {
+        return Status::InvalidParam(
+            "concurrent VFS Stop requested with conflicting handover mode");
+      }
+      return stop_status_;
+    }
+
+    CHECK(lifecycle_state_ == LifecycleState::kRunning);
+    lifecycle_state_ = LifecycleState::kQuiescing;
+    stop_handover_ = handover;
+    while (active_public_operations_ != 0) {
+      if (lifecycle_cv_.wait_for(lock, std::chrono::seconds(30)) ==
+          std::cv_status::timeout) {
+        LOG(ERROR) << fmt::format(
+            "VFS Stop still waiting for {} public operation(s) to drain",
+            active_public_operations_);
+      }
+    }
   }
 
   LOG(INFO) << fmt::format("stopping vfs, handover({}).", handover);
@@ -387,25 +509,22 @@ Status VFSWrapper::Stop(bool handover) {
       [&]() { return absl::StrFormat("stop: %s", s.ToString()); });
   s = vfs_->Stop(/*skip_unmount=*/handover);
 
-  // The VFS teardown has run; mark stopped so a second Stop() (e.g. the
-  // post-exit FuseOpDestroy after a successful handover gate) is a no-op and
-  // does not stop/dump twice.
-  started_.store(false);
-
   LOG(INFO) << fmt::format("stopped vfs, handover({}).", handover);
 
   // Handover teardown: dump after vfs_->Stop() so the persisted state reflects
   // the same stop -> dump order used by normal teardown. This is currently past
   // the clean rollback point; callers treat a non-OK return here as an
   // unrecoverable handover fault after the pre-teardown flush has succeeded.
-  if (handover && !s.ok()) {
-    return s;
+  if (handover && s.ok() && !Dump()) {
+    s = Status::InvalidParam("dump vfs state fail");
   }
 
-  if (handover && !Dump()) {
-    return Status::InvalidParam("dump vfs state fail");
+  {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    stop_status_ = s;
+    lifecycle_state_ = LifecycleState::kStopped;
   }
-
+  lifecycle_cv_.notify_all();
   return s;
 }
 
@@ -460,32 +579,42 @@ bool VFSWrapper::Load(const Json::Value& value) {
 }
 
 Status VFSWrapper::GetInfo(std::string* info) {
+  VFS_WRAPPER_OPERATION_GUARD();
   CHECK(vfs_ != nullptr) << "vfs_ is nullptr";
   return vfs_->GetInfo(info);
 }
 
 double VFSWrapper::GetAttrTimeout(FileType type) {
-  return vfs_->GetAttrTimeout(type);
+  (void)type;
+  CHECK(immutable_values_published_.load(std::memory_order_acquire))
+      << "GetAttrTimeout called before VFS Start completed";
+  return attr_timeout_;
 }
 
 double VFSWrapper::GetEntryTimeout(FileType type) {
-  return vfs_->GetEntryTimeout(type);
+  (void)type;
+  CHECK(immutable_values_published_.load(std::memory_order_acquire))
+      << "GetEntryTimeout called before VFS Start completed";
+  return entry_timeout_;
 }
 
 uint64_t VFSWrapper::GetFsId() {
-  uint64_t fs_id = vfs_->GetFsId();
-  VLOG(6) << "fs_id: " << fs_id;
-  return fs_id;
+  CHECK(immutable_values_published_.load(std::memory_order_acquire))
+      << "GetFsId called before VFS Start completed";
+  VLOG(6) << "fs_id: " << fs_id_;
+  return fs_id_;
 }
 
 uint64_t VFSWrapper::GetMaxNameLength() {
-  uint64_t max_name_length = vfs_->GetMaxNameLength();
-  VLOG(6) << "max name length: " << max_name_length;
-  return max_name_length;
+  CHECK(immutable_values_published_.load(std::memory_order_acquire))
+      << "GetMaxNameLength called before VFS Start completed";
+  VLOG(6) << "max name length: " << max_name_length_;
+  return max_name_length_;
 }
 
 Status VFSWrapper::Lookup(const Context& ctx, Ino parent,
                           const std::string& name, Attr* attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSLookup parent: " << parent << " name: " << name;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Lookup");
@@ -522,6 +651,7 @@ Status VFSWrapper::Lookup(const Context& ctx, Ino parent,
 }
 
 Status VFSWrapper::GetAttr(const Context& ctx, Ino ino, Attr* attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSGetAttr ino: " << ino;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::GetAttr");
@@ -553,6 +683,7 @@ Status VFSWrapper::GetAttr(const Context& ctx, Ino ino, Attr* attr) {
 
 Status VFSWrapper::SetAttr(const Context& ctx, Ino ino, int set,
                            const Attr& in_attr, Attr* out_attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSSetAttr ino: " << ino << " set: " << set;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::SetAttr");
@@ -576,6 +707,7 @@ Status VFSWrapper::SetAttr(const Context& ctx, Ino ino, int set,
 
 Status VFSWrapper::Fallocate(const Context& ctx, Ino ino, int mode,
                              uint64_t offset, uint64_t length) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << fmt::format(
       "VFSFallocate ino: {} mode: 0x{:X} offset: {} length: {}", ino, mode,
       offset, length);
@@ -604,6 +736,7 @@ Status VFSWrapper::CopyFileRange(const Context& ctx, Ino src_ino,
                                  uint64_t dst_off, uint64_t dst_fh,
                                  uint64_t len, uint32_t flags,
                                  uint64_t* bytes_copied) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << fmt::format(
       "VFSCopyFileRange src_ino: {} src_off: {} src_fh: {} dst_ino: {} "
       "dst_off: {} dst_fh: {} len: {} flags: 0x{:x}",
@@ -634,6 +767,7 @@ Status VFSWrapper::CopyFileRange(const Context& ctx, Ino src_ino,
 }
 
 Status VFSWrapper::ReadLink(const Context& ctx, Ino ino, std::string* link) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSReadLink ino: " << ino;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::ReadLink");
@@ -657,6 +791,7 @@ Status VFSWrapper::ReadLink(const Context& ctx, Ino ino, std::string* link) {
 Status VFSWrapper::MkNod(const Context& ctx, Ino parent,
                          const std::string& name, uint32_t mode, uint64_t dev,
                          Attr* attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSMknod parent: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " mode: " << mode
           << " dev: " << dev;
@@ -688,6 +823,7 @@ Status VFSWrapper::MkNod(const Context& ctx, Ino parent,
 
 Status VFSWrapper::Unlink(const Context& ctx, Ino parent,
                           const std::string& name) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSUnlink parent: " << parent << " name: " << name;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Unlink");
@@ -718,6 +854,7 @@ Status VFSWrapper::Unlink(const Context& ctx, Ino parent,
 Status VFSWrapper::Symlink(const Context& ctx, Ino parent,
                            const std::string& name, const std::string& link,
                            Attr* attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSSymlink parent: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " link: " << link;
 
@@ -748,6 +885,7 @@ Status VFSWrapper::Symlink(const Context& ctx, Ino parent,
 Status VFSWrapper::Rename(const Context& ctx, Ino old_parent,
                           const std::string& old_name, Ino new_parent,
                           const std::string& new_name) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSRename old_parent: " << old_parent << " old_name: " << old_name
           << " new_parent: " << new_parent << " new_name: " << new_name;
 
@@ -781,6 +919,7 @@ Status VFSWrapper::Rename(const Context& ctx, Ino old_parent,
 
 Status VFSWrapper::Link(const Context& ctx, Ino ino, Ino new_parent,
                         const std::string& new_name, Attr* attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSLink ino: " << ino << " new_parent: " << new_parent
           << " new_name: " << new_name;
 
@@ -814,6 +953,7 @@ Status VFSWrapper::Link(const Context& ctx, Ino ino, Ino new_parent,
 
 Status VFSWrapper::Open(const Context& ctx, Ino ino, int flags, uint64_t* fh,
                         bool* keep_cache) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSOpen ino: " << ino << " octal flags: " << std::oct << flags;
   CHECK(fh != nullptr) << "fh is nullptr";
   CHECK(keep_cache != nullptr) << "keep_cache is nullptr";
@@ -844,6 +984,7 @@ Status VFSWrapper::Open(const Context& ctx, Ino ino, int flags, uint64_t* fh,
 Status VFSWrapper::Create(const Context& ctx, Ino parent,
                           const std::string& name, uint32_t mode, int flags,
                           uint64_t* fh, Attr* attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSCreate parent: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " mode: " << mode
           << " octal flags: " << std::oct << flags;
@@ -876,6 +1017,7 @@ Status VFSWrapper::Create(const Context& ctx, Ino parent,
 Status VFSWrapper::Read(const Context& ctx, Ino ino, DataBuffer* data_buffer,
                         uint64_t size, uint64_t offset, uint64_t fh,
                         uint64_t* out_rsize) {
+  VFS_WRAPPER_OPERATION_GUARD();
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Read");
   std::string session_id = dingofs::SpanScope::GetSessionID(span);
 
@@ -910,6 +1052,7 @@ Status VFSWrapper::Read(const Context& ctx, Ino ino, DataBuffer* data_buffer,
 Status VFSWrapper::Write(const Context& ctx, Ino ino, const char* buf,
                          uint64_t size, uint64_t offset, uint64_t fh,
                          uint64_t* out_wsize) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSWrite ino: " << ino
           << ", buf: " << dingofs::Helper::Char2Addr(buf) << ", size: " << size
           << " offset: " << offset << " fh: " << fh;
@@ -936,6 +1079,7 @@ Status VFSWrapper::Write(const Context& ctx, Ino ino, const char* buf,
 }
 
 Status VFSWrapper::Flush(const Context& ctx, Ino ino, uint64_t fh) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSFlush ino: " << ino << " fh: " << fh;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Flush");
@@ -960,6 +1104,7 @@ Status VFSWrapper::Flush(const Context& ctx, Ino ino, uint64_t fh) {
 }
 
 Status VFSWrapper::Release(const Context& ctx, Ino ino, uint64_t fh) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSRelease ino: " << ino << " fh: " << fh;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Release");
@@ -985,6 +1130,7 @@ Status VFSWrapper::Release(const Context& ctx, Ino ino, uint64_t fh) {
 
 Status VFSWrapper::Fsync(const Context& ctx, Ino ino, int datasync,
                          uint64_t fh) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSFsync ino: " << ino << " datasync: " << datasync
           << " fh: " << fh;
 
@@ -1010,6 +1156,7 @@ Status VFSWrapper::Fsync(const Context& ctx, Ino ino, int datasync,
 Status VFSWrapper::SetXattr(const Context& ctx, Ino ino,
                             const std::string& name, const std::string& value,
                             int flags) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSSetXattr ino: " << ino << " name: " << name
           << " value: " << value << " octal flags: " << std::oct << flags;
 
@@ -1039,6 +1186,7 @@ Status VFSWrapper::SetXattr(const Context& ctx, Ino ino,
 
 Status VFSWrapper::GetXattr(const Context& ctx, Ino ino,
                             const std::string& name, std::string* value) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSGetXattr ino: " << ino << " name: " << name;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::GetXattr");
@@ -1072,6 +1220,7 @@ Status VFSWrapper::GetXattr(const Context& ctx, Ino ino,
 
 Status VFSWrapper::RemoveXattr(const Context& ctx, Ino ino,
                                const std::string& name) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSRemoveXattr ino: " << ino << " name: " << name;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::RemoveXattr");
@@ -1100,6 +1249,7 @@ Status VFSWrapper::RemoveXattr(const Context& ctx, Ino ino,
 
 Status VFSWrapper::ListXattr(const Context& ctx, Ino ino,
                              std::vector<std::string>* xattrs) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSListXattr ino: " << ino;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::ListXattr");
@@ -1122,6 +1272,7 @@ Status VFSWrapper::ListXattr(const Context& ctx, Ino ino,
 
 Status VFSWrapper::MkDir(const Context& ctx, Ino parent,
                          const std::string& name, uint32_t mode, Attr* attr) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSMkDir parent ino: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " mode: " << mode;
 
@@ -1152,6 +1303,7 @@ Status VFSWrapper::MkDir(const Context& ctx, Ino parent,
 
 Status VFSWrapper::OpenDir(const Context& ctx, Ino ino, uint64_t* fh,
                            bool& need_cache) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSOpendir ino: " << ino;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::OpenDir");
@@ -1176,6 +1328,7 @@ Status VFSWrapper::OpenDir(const Context& ctx, Ino ino, uint64_t* fh,
 Status VFSWrapper::ReadDir(const Context& ctx, Ino ino, uint64_t fh,
                            uint64_t offset, bool with_attr,
                            ReadDirHandler handler) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSReaddir ino: " << ino << " fh: " << fh << " offset: " << offset
           << " with_attr: " << (with_attr ? "true" : "false");
 
@@ -1193,13 +1346,15 @@ Status VFSWrapper::ReadDir(const Context& ctx, Ino ino, uint64_t fh,
       {&client_op_metric_->opReadDir, &client_op_metric_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
-  s = vfs_->ReadDir(span_ctx, ino, fh, offset, with_attr, handler, count);
+  s = vfs_->ReadDir(span_ctx, ino, fh, offset, with_attr, std::move(handler),
+                    count);
   if (!s.ok()) op_metric.FailOp();
 
   return s;
 }
 
 Status VFSWrapper::ReleaseDir(const Context& ctx, Ino ino, uint64_t fh) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSReleaseDir ino: " << ino << " fh: " << fh;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::ReleaseDir");
@@ -1222,6 +1377,7 @@ Status VFSWrapper::ReleaseDir(const Context& ctx, Ino ino, uint64_t fh) {
 
 Status VFSWrapper::RmDir(const Context& ctx, Ino parent,
                          const std::string& name) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSRmdir parent: " << parent << " name: " << name;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::RmDir");
@@ -1250,6 +1406,7 @@ Status VFSWrapper::RmDir(const Context& ctx, Ino parent,
 }
 
 Status VFSWrapper::StatFs(const Context& ctx, Ino ino, FsStat* fs_stat) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSStatFs ino: " << ino;
 
   auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::StatFs");
@@ -1273,6 +1430,7 @@ Status VFSWrapper::StatFs(const Context& ctx, Ino ino, FsStat* fs_stat) {
 Status VFSWrapper::Ioctl(const Context& ctx, Ino ino, unsigned int cmd,
                          unsigned flags, const void* in_buf, size_t in_bufsz,
                          char* out_buf, size_t out_bufsz) {
+  VFS_WRAPPER_OPERATION_GUARD();
   VLOG(2) << "VFSIoctl ino: " << ino << " cmd: " << cmd << " flags: " << flags
           << " in_bufsz: " << in_bufsz << " out_bufsz: " << out_bufsz;
 
@@ -1291,6 +1449,8 @@ Status VFSWrapper::Ioctl(const Context& ctx, Ino ino, unsigned int cmd,
 
   return s;
 }
+
+#undef VFS_WRAPPER_OPERATION_GUARD
 
 }  // namespace client
 }  // namespace dingofs

--- a/src/client/vfs/vfs_wrapper.h
+++ b/src/client/vfs/vfs_wrapper.h
@@ -18,9 +18,13 @@
 #define DINGOFS_CLIENT_VFS_VFS_WRAPPER_H_
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "client/vfs/vfs.h"
@@ -151,6 +155,9 @@ class VFSWrapper {
 
   Status OpenDir(const Context& ctx, Ino ino, uint64_t* fh, bool& need_cache);
 
+  // The handler is invoked synchronously and must not re-enter a public method
+  // on this VFSWrapper. This contract is intentionally not enforced with C++
+  // thread_local state because callers may execute on migratable bthreads.
   Status ReadDir(const Context& ctx, Ino ino, uint64_t fh, uint64_t offset,
                  bool with_attr, ReadDirHandler handler);
 
@@ -165,17 +172,62 @@ class VFSWrapper {
                size_t out_bufsz);
 
  private:
+  friend class VFSWrapperLifecycleTest;
+
+  enum class LifecycleState {
+    kCreated,
+    kStarting,
+    kRunning,
+    kQuiescing,
+    kStopped,
+  };
+
+  class OperationLease {
+   public:
+    OperationLease(const OperationLease&) = delete;
+    OperationLease& operator=(const OperationLease&) = delete;
+
+    OperationLease(OperationLease&& other) noexcept
+        : owner_(std::exchange(other.owner_, nullptr)) {}
+
+    ~OperationLease();
+
+   private:
+    friend class VFSWrapper;
+    explicit OperationLease(VFSWrapper* owner) : owner_(owner) {}
+
+    VFSWrapper* owner_;
+  };
+
+  std::optional<OperationLease> TryAcquireOperation();
+
+  void ReleaseOperation();
+
+  Status FinishStartFailure(const Status& status);
+
   bool Dump();
 
   bool Load(const Json::Value& value);
 
-  std::atomic<bool> started_{false};
+  mutable std::mutex lifecycle_mutex_;
+  std::condition_variable lifecycle_cv_;
+  LifecycleState lifecycle_state_{LifecycleState::kCreated};
+  uint64_t active_public_operations_{0};
+  Status stop_status_;
+  bool stop_handover_{false};
+  std::atomic<bool> immutable_values_published_{false};
+
   std::unique_ptr<vfs::VFS> vfs_;
 
   std::unique_ptr<metrics::client::ClientOpMetric> client_op_metric_;
 
   uint32_t uid_{0};
   uint32_t gid_{0};
+
+  double attr_timeout_{0.0};
+  double entry_timeout_{0.0};
+  uint64_t fs_id_{0};
+  uint64_t max_name_length_{0};
 };
 
 }  // namespace client

--- a/test/unit/client/fuse/test_handover_controller.cc
+++ b/test/unit/client/fuse/test_handover_controller.cc
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "client/fuse/upgrade/handover_controller.h"
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -23,6 +21,7 @@
 #include <chrono>
 #include <future>
 
+#include "client/fuse/upgrade/handover_controller.h"
 #include "client/fuse/upgrade/handover_peer.h"
 #include "client/fuse/upgrade/handover_session.h"
 #include "client/fuse/upgrade/state_store.h"
@@ -177,14 +176,13 @@ TEST_F(HandoverControllerTest, DrainTimeout_DoesNotJoinBlockedStatfsWakeup) {
   std::atomic<bool> wakeup_entered_once{false};
 
   HandoverOptions options = Options();
-  options.statfs_wakeup_fn =
-      [&](const std::string&, const std::atomic<bool>&) {
-        if (!wakeup_entered_once.exchange(true)) {
-          wakeup_entered.set_value();
-        }
-        release_wakeup_future.wait();
-        wakeup_returned.set_value();
-      };
+  options.statfs_wakeup_fn = [&](const std::string&, const std::atomic<bool>&) {
+    if (!wakeup_entered_once.exchange(true)) {
+      wakeup_entered.set_value();
+    }
+    release_wakeup_future.wait();
+    wakeup_returned.set_value();
+  };
 
   {
     InSequence seq;
@@ -221,8 +219,9 @@ TEST_F(HandoverControllerTest, DrainTimeout_DoesNotJoinBlockedStatfsWakeup) {
   EXPECT_EQ(State(), FuseUpgradeState::kFuseNormal);
 }
 
-// M1: a SIGHUP before the checkpoint is registered must NOT pause IO (no drain).
-// It aborts immediately (telling the new to back off) and keeps serving.
+// M1: a SIGHUP before the checkpoint is registered must NOT pause IO (no
+// drain). It aborts immediately (telling the new to back off) and keeps
+// serving.
 TEST_F(HandoverControllerTest, NoCheckpoint_AbortsWithoutDraining) {
   Latch done;
 

--- a/test/unit/client/vfs/CMakeLists.txt
+++ b/test/unit/client/vfs/CMakeLists.txt
@@ -20,7 +20,10 @@ add_subdirectory(handle)
 add_subdirectory(service)
 add_subdirectory(metasystem)
 
-add_library(test_vfs_impl test_vfs_impl.cc)
+add_library(test_vfs_impl
+  test_vfs_impl.cc
+  test_vfs_wrapper_lifecycle.cc
+)
 target_link_libraries(test_vfs_impl
   vfs_lib
   ${TEST_DEPS_WITHOUT_MAIN}

--- a/test/unit/client/vfs/data/test_chunk_writer.cc
+++ b/test/unit/client/vfs/data/test_chunk_writer.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <future>
 #include <thread>
 #include <vector>
@@ -286,22 +287,51 @@ TEST_F(ChunkWriterTest, ConcurrentWrites_NoDeadlock) {
 // 9. Stop() waits for any ongoing flush to finish before returning.
 //    After Stop(), the writer is destroyed cleanly.
 TEST_F(ChunkWriterTest, Stop_WaitsForFlush) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool write_slice_entered = false;
+  bool allow_write_slice = false;
+
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        std::unique_lock<std::mutex> lock(mutex);
+        write_slice_entered = true;
+        cv.notify_all();
+        cv.wait(lock, [&] { return allow_write_slice; });
+        return Status::OK();
+      });
+
   auto writer = MakeWriter();
 
   const char buf[] = "stop test";
-  writer->Write(ctx_, buf, sizeof(buf), 0);
+  ASSERT_TRUE(writer->Write(ctx_, buf, sizeof(buf), 0).ok());
 
-  // FlushAsync then Stop; Stop should block until flush completes.
   AsyncWaiter waiter;
   waiter.Expect(1);
   writer->FlushAsync([&](Status s) {
     EXPECT_TRUE(s.ok());
     waiter.Done();
   });
-  waiter.Wait();
 
-  // Stop must not crash.
-  writer->Stop();
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return write_slice_entered; }));
+  }
+
+  auto stop = std::async(std::launch::async, [&writer] { writer->Stop(); });
+  EXPECT_EQ(stop.wait_for(std::chrono::milliseconds(50)),
+            std::future_status::timeout);
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    allow_write_slice = true;
+  }
+  cv.notify_all();
+
+  waiter.Wait();
+  EXPECT_EQ(stop.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  stop.get();
 }
 
 // 10. TriggerFlush (called automatically when a slice fills up) does not crash

--- a/test/unit/client/vfs/data/test_file_writer.cc
+++ b/test/unit/client/vfs/data/test_file_writer.cc
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
+#include <gflags/gflags.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
+#include <future>
+#include <mutex>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "client/vfs/data/writer/file_writer.h"
+#include "common/options/client.h"
 #include "common/trace/trace_manager.h"
 #include "common/writemempool/write_mem_pool.h"
 #include "test/unit/client/vfs/test_base.h"
@@ -57,6 +63,12 @@ class FileWriterTest : public VFSTestBase {
     CHECK(w->Open().ok());
     return w;
   }
+
+  void FlushCloseAndRelease(FileWriter* w) {
+    ASSERT_TRUE(w->Flush().ok());
+    w->Close();
+    w->ReleaseRef();
+  }
 };
 
 // 1. Write() for a simple in-chunk write succeeds and returns the correct
@@ -70,8 +82,7 @@ TEST_F(FileWriterTest, Write_SingleChunk_CorrectSize) {
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(wsize, sizeof(buf));
 
-  w->Close();
-  w->ReleaseRef();
+  FlushCloseAndRelease(w);
 }
 
 // 2. Write() crossing a chunk boundary creates two chunk writers and writes
@@ -91,8 +102,7 @@ TEST_F(FileWriterTest, Write_CrossingChunkBoundary) {
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(wsize, kWriteSize);
 
-  w->Close();
-  w->ReleaseRef();
+  FlushCloseAndRelease(w);
 }
 
 // 2b. Cross-chunk pool exhaustion is a POSIX short write: chunk0 succeeds,
@@ -119,8 +129,7 @@ TEST_F(FileWriterTest, Write_CrossChunk_PoolExhaustion_ShortWrite) {
   EXPECT_TRUE(s.ok()) << s.ToString();
   EXPECT_EQ(wsize, 4u);
 
-  w->Close();
-  w->ReleaseRef();
+  FlushCloseAndRelease(w);
 }
 
 // 2c. First chunk itself exhausts the pool: zero bytes land, so the write is a
@@ -194,10 +203,9 @@ TEST_F(FileWriterTest, Flush_WriteSliceError_Propagated) {
   w->ReleaseRef();
 }
 
-// 6. Close() waits for all in-flight writes to complete.
-//    This test spawns a write thread and then immediately calls Close()
-//    from the main thread to verify Close doesn't race or deadlock.
-TEST_F(FileWriterTest, Close_WaitsForInflightWrites) {
+// 6. Concurrent writes followed by an explicit Flush and Close are safe.
+// Close itself is tested against an actually in-flight flush below.
+TEST_F(FileWriterTest, ConcurrentWrites_ThenFlushClose) {
   auto* w = MakeOpenWriter();
 
   constexpr int kThreads = 4;
@@ -220,8 +228,50 @@ TEST_F(FileWriterTest, Close_WaitsForInflightWrites) {
     t.join();
   }
 
-  // Close must complete without deadlock.
-  w->Close();
+  // Close only validates/cleans up; the lifecycle owner must flush first.
+  FlushCloseAndRelease(w);
+}
+
+TEST_F(FileWriterTest, Close_WaitsForInflightFlush) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool write_slice_entered = false;
+  bool allow_write_slice = false;
+
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        std::unique_lock<std::mutex> lock(mutex);
+        write_slice_entered = true;
+        cv.notify_all();
+        cv.wait(lock, [&] { return allow_write_slice; });
+        return Status::OK();
+      });
+
+  auto* w = MakeOpenWriter();
+  const char buf[] = "blocked flush";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  auto flush = std::async(std::launch::async, [w] { return w->Flush(); });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return write_slice_entered; }));
+  }
+
+  auto close = std::async(std::launch::async, [w] { w->Close(); });
+  EXPECT_EQ(close.wait_for(std::chrono::milliseconds(50)),
+            std::future_status::timeout);
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    allow_write_slice = true;
+  }
+  cv.notify_all();
+
+  ASSERT_TRUE(flush.get().ok());
+  EXPECT_EQ(close.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  close.get();
   w->ReleaseRef();
 }
 
@@ -342,6 +392,180 @@ TEST_F(FileWriterTest, FlushError_BecomesStickyAndBlocksWrites) {
   Status ws = w->Write(ctx_, buf, sizeof(buf), 4096, &wsize);
   EXPECT_FALSE(ws.ok());
 
+  w->Close();
+  w->ReleaseRef();
+}
+
+// Close is not a persistence operation. If no Flush error explains the state,
+// closing a writer whose latest write generation was never flushed is a
+// lifecycle bug and must fail fast.
+TEST_F(FileWriterTest, Close_UnflushedWrite_CheckFails) {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  auto* w = MakeOpenWriter();
+
+  const char buf[] = "unflushed";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  EXPECT_DEATH(w->Close(), "Close found unflushed data");
+
+  // EXPECT_DEATH runs in a child; clean up the unchanged parent-side writer.
+  FlushCloseAndRelease(w);
+}
+
+TEST_F(FileWriterTest, Flush_AfterClose_ReturnsBadFd) {
+  auto* w = MakeOpenWriter();
+  w->Close();
+
+  Status s = w->Flush();
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(s.ToSysErrNo(), EBADF);
+  w->ReleaseRef();
+}
+
+TEST_F(FileWriterTest, PeriodicFlushErrorBecomesStickyAndBlocksWrites) {
+  gflags::FlagSaver flag_saver;
+  FLAGS_vfs_periodic_flush_interval_ms = 1;
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool write_slice_called = false;
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          write_slice_called = true;
+        }
+        cv.notify_all();
+        return Status::Internal("periodic flush failed");
+      });
+
+  auto* w = MakeOpenWriter();
+  const char buf[] = "periodic";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return write_slice_called; }));
+  }
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (w->GetStatus().ok() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_FALSE(w->GetStatus().ok());
+
+  wsize = 12345;
+  Status s = w->Write(ctx_, buf, sizeof(buf), 4096, &wsize);
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(wsize, 0u);
+
+  w->Close();
+  w->ReleaseRef();
+}
+
+// A successful explicit Flush owns all writeback. Close must not submit a
+// second WriteSlice after metadata lifecycle code is free to close the session.
+TEST_F(FileWriterTest, Close_AfterFlush_DoesNotFlushAgain) {
+  int write_slice_calls = 0;
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        ++write_slice_calls;
+        return Status::OK();
+      });
+
+  auto* w = MakeOpenWriter();
+  const char buf[] = "data";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+  ASSERT_TRUE(w->Flush().ok());
+  const int calls_after_flush = write_slice_calls;
+
+  w->Close();
+  EXPECT_EQ(write_slice_calls, calls_after_flush);
+  w->ReleaseRef();
+}
+
+TEST_F(FileWriterTest, ConcurrentFlushesAdvanceToLatestGeneration) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool first_write_slice_entered = false;
+  bool allow_first_write_slice = false;
+  int write_slice_calls = 0;
+
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        std::unique_lock<std::mutex> lock(mutex);
+        if (++write_slice_calls == 1) {
+          first_write_slice_entered = true;
+          cv.notify_all();
+          cv.wait(lock, [&] { return allow_first_write_slice; });
+        }
+        return Status::OK();
+      });
+
+  auto* w = MakeOpenWriter();
+  const char first[] = "first";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, first, sizeof(first), 0, &wsize).ok());
+
+  auto first_flush = std::async(std::launch::async, [w] { return w->Flush(); });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return first_write_slice_entered; }));
+  }
+
+  const char second[] = "second";
+  const uint64_t second_offset = mock_hub_->GetFsInfo().chunk_size;
+  ASSERT_TRUE(
+      w->Write(ctx_, second, sizeof(second), second_offset, &wsize).ok());
+  auto second_flush =
+      std::async(std::launch::async, [w] { return w->Flush(); });
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    allow_first_write_slice = true;
+  }
+  cv.notify_all();
+
+  ASSERT_TRUE(first_flush.get().ok());
+  ASSERT_TRUE(second_flush.get().ok());
+  w->Close();
+  w->ReleaseRef();
+}
+
+TEST_F(FileWriterTest, MultiChunkFlushFailureStillVisitsEveryChunk) {
+  std::mutex mutex;
+  std::unordered_set<uint64_t> visited_chunks;
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, uint64_t chunk_index, auto, auto) {
+        std::lock_guard<std::mutex> lock(mutex);
+        visited_chunks.insert(chunk_index);
+        return chunk_index == 0 ? Status::Internal("chunk 0 flush failed")
+                                : Status::OK();
+      });
+
+  auto* w = MakeOpenWriter();
+  const uint64_t chunk_size = mock_hub_->GetFsInfo().chunk_size;
+  const char buf[] = "data";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), chunk_size, &wsize).ok());
+
+  Status s = w->Flush();
+  EXPECT_FALSE(s.ok());
+  EXPECT_FALSE(w->GetStatus().ok());
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    EXPECT_EQ(visited_chunks, (std::unordered_set<uint64_t>{0, 1}));
+  }
+
+  // The known flush error explains the generation mismatch; Close must clean
+  // up without converting the already-reported I/O failure into a CHECK.
   w->Close();
   w->ReleaseRef();
 }

--- a/test/unit/client/vfs/data/test_writer_table.cc
+++ b/test/unit/client/vfs/data/test_writer_table.cc
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-#include "client/vfs/data/writer_table.h"
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+
 #include "client/vfs/data/writer/file_writer.h"
+#include "client/vfs/data/writer_table.h"
 #include "test/unit/client/vfs/test_base.h"
 
 namespace dingofs {
@@ -28,6 +32,7 @@ namespace vfs {
 
 using dingofs::client::vfs::test::VFSTestBase;
 using ::testing::AnyNumber;
+using ::testing::Return;
 
 class WriterTableTest : public VFSTestBase {
  protected:
@@ -111,7 +116,8 @@ TEST_F(WriterTableTest, FlushAll_Empty_OK) {
 }
 
 // FlushAll over multiple live writers must succeed without evicting any —
-// it is read-only with respect to entries (transient AcquireRef snapshot).
+// it is read-only with respect to externally-held entries (transient holder
+// pins are released after each writer's Flush completes).
 TEST_F(WriterTableTest, FlushAll_WithWriters_PreservesEntries) {
   auto* w1 = table_->AcquireWriter(100);
   auto* w2 = table_->AcquireWriter(200);
@@ -124,6 +130,79 @@ TEST_F(WriterTableTest, FlushAll_WithWriters_PreservesEntries) {
 
   table_->ReleaseWriter(w1);
   table_->ReleaseWriter(w2);
+}
+
+// Shutdown writeback must attempt every writer even after one fails, while
+// returning the first observed error to the lifecycle owner.
+TEST_F(WriterTableTest, FlushAll_ErrorDoesNotSkipRemainingWriters) {
+  auto* w1 = table_->AcquireWriter(201);
+  auto* w2 = table_->AcquireWriter(202);
+  ASSERT_NE(w1, nullptr);
+  ASSERT_NE(w2, nullptr);
+
+  const char buf[] = "dirty";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w1->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+  ASSERT_TRUE(w2->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  int write_slice_calls = 0;
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        ++write_slice_calls;
+        return Status::Internal("flush all error");
+      });
+
+  Status s = table_->FlushAll();
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(write_slice_calls, 2)
+      << "FlushAll must not stop after the first writer failure";
+
+  table_->ReleaseWriter(w1);
+  table_->ReleaseWriter(w2);
+}
+
+TEST_F(WriterTableTest, FlushAllPinsWriterAgainstLastConcurrentRelease) {
+  auto* w = table_->AcquireWriter(203);
+  ASSERT_NE(w, nullptr);
+
+  const char buf[] = "dirty";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(w->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool write_slice_entered = false;
+  bool allow_write_slice = false;
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        std::unique_lock<std::mutex> lock(mutex);
+        write_slice_entered = true;
+        cv.notify_all();
+        cv.wait(lock, [&] { return allow_write_slice; });
+        return Status::OK();
+      });
+
+  auto flush_all =
+      std::async(std::launch::async, [&] { return table_->FlushAll(); });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return write_slice_entered; }));
+  }
+
+  // Drop the only external holder while FlushAll is blocked. Its transient
+  // holder must keep the entry open until the flush finishes.
+  table_->ReleaseWriter(w);
+  EXPECT_EQ(table_->Size(), 1u);
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    allow_write_slice = true;
+  }
+  cv.notify_all();
+
+  ASSERT_TRUE(flush_all.get().ok());
+  EXPECT_EQ(table_->Size(), 0u);
 }
 
 // Peek after Acquire must take an additional holder so the first Release

--- a/test/unit/client/vfs/handle/test_handle_manager.cc
+++ b/test/unit/client/vfs/handle/test_handle_manager.cc
@@ -52,6 +52,9 @@ class HandleManagerTest : public VFSTestBase {
   }
 
   void TearDown() override {
+    // HandleManager::Stop unconditionally calls FlushAll; keep the fixture's
+    // WriterTable alive until the manager has finished stopping.
+    handle_manager_->Stop();
     if (writer_table_) {
       writer_table_->Stop();
       writer_table_.reset();
@@ -122,9 +125,12 @@ TEST_F(HandleManagerTest, TwoFhsOnSameInoHaveDistinctReaders) {
   ASSERT_NE(h2->resources.reader, nullptr);
   EXPECT_NE(h1->resources.reader, h2->resources.reader)
       << "per-fh reader: each fh must own a distinct FileReader instance";
+  EXPECT_EQ(reader_registry_->Size(), 2u);
 
   handle_manager_->ReleaseHandler(10);
+  EXPECT_EQ(reader_registry_->Size(), 1u);
   handle_manager_->ReleaseHandler(11);
+  EXPECT_EQ(reader_registry_->Size(), 0u);
 }
 
 // Mixed-mode opens: O_RDONLY + O_WRONLY on the same inode produce exactly
@@ -322,6 +328,18 @@ TEST_F(HandleManagerTest, NewHandle_AfterStop_RejectedNoLeak) {
   EXPECT_EQ(h, nullptr) << "NewHandle must fail once HandleManager is stopped";
   EXPECT_EQ(writer_table_->Size(), 0u)
       << "rejected NewHandle must not leak the acquired writer";
+  EXPECT_EQ(reader_registry_->Size(), 0u)
+      << "rejected NewHandle must unregister its reader";
+}
+
+// A writer acquisition failure happens before the reader is published in the
+// registry, so the partially constructed Handle must leave no stale entry.
+TEST_F(HandleManagerTest, NewHandle_WriterAcquireFailure_NoReaderRegistryLeak) {
+  writer_table_->Stop();
+
+  auto* h = handle_manager_->NewHandle(/*fh*/ 530, /*ino*/ 9030, O_WRONLY);
+  EXPECT_EQ(h, nullptr);
+  EXPECT_EQ(reader_registry_->Size(), 0u);
 }
 
 // A late FUSE_RELEASE after Stop() already detached resources must be

--- a/test/unit/client/vfs/handle/test_handle_manager.cc
+++ b/test/unit/client/vfs/handle/test_handle_manager.cc
@@ -233,9 +233,48 @@ TEST_F(HandleManagerTest, Stop_ReleasesWriterResources) {
   ASSERT_NE(h, nullptr);
   EXPECT_EQ(writer_table_->Size(), 1u);
 
-  handle_manager_->Stop();
+  const char buf[] = "shutdown flush";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(
+      h->resources.writer->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  int write_slice_calls = 0;
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, auto) {
+        ++write_slice_calls;
+        EXPECT_EQ(writer_table_->Size(), 1u)
+            << "FlushAll must run before the last holder is released";
+        return Status::OK();
+      });
+
+  EXPECT_TRUE(handle_manager_->Stop().ok());
+  EXPECT_GE(write_slice_calls, 1);
   EXPECT_EQ(writer_table_->Size(), 0u)
       << "Stop must release the writer while executors are still alive";
+}
+
+// Stop must return the shutdown FlushAll failure, but still detach/release
+// resources. FileWriter Close observes the sticky error and must not turn the
+// external writeback failure into a second process-fatal invariant failure.
+TEST_F(HandleManagerTest, Stop_FlushFailureReturnedAndResourcesReleased) {
+  auto* h = handle_manager_->NewHandle(/*fh*/ 62, /*ino*/ 1002, O_WRONLY);
+  ASSERT_NE(h, nullptr);
+
+  const char buf[] = "fail shutdown flush";
+  uint64_t wsize = 0;
+  ASSERT_TRUE(
+      h->resources.writer->Write(ctx_, buf, sizeof(buf), 0, &wsize).ok());
+
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault(Return(Status::Internal("shutdown flush failed")));
+
+  Status s = handle_manager_->Stop();
+  EXPECT_FALSE(s.ok());
+  EXPECT_THAT(s.ToString(), ::testing::HasSubstr("shutdown flush failed"));
+  EXPECT_EQ(writer_table_->Size(), 0u);
+  auto guard = handle_manager_->FindHandlerForRelease(62);
+  ASSERT_TRUE(guard);
+  EXPECT_EQ(guard->resources.writer, nullptr);
 }
 
 // Stop() detaches resources but keeps the handle identity (fh/ino/flags) so

--- a/test/unit/client/vfs/mock/mock_vfs_hub.h
+++ b/test/unit/client/vfs/mock/mock_vfs_hub.h
@@ -33,6 +33,7 @@ class MockVFSHub : public VFSHub {
   MOCK_METHOD(ClientId, GetClientId, (), (override));
   MOCK_METHOD(MetaWrapper*, GetMetaSystem, (), (override));
   MOCK_METHOD(HandleManager*, GetHandleManager, (), (override));
+  MOCK_METHOD(ReaderRegistry*, GetReaderRegistry, (), (override));
   MOCK_METHOD(WriterTable*, GetWriterTable, (), (override));
   MOCK_METHOD(BlockStore*, GetBlockStore, (), (override));
   MOCK_METHOD(blockaccess::BlockAccesser*, GetBlockAccesser, (), (override));

--- a/test/unit/client/vfs/test_base.h
+++ b/test/unit/client/vfs/test_base.h
@@ -24,6 +24,8 @@
 #include <memory>
 
 #include "client/vfs/components/file_suffix_watcher.h"
+#include "client/vfs/data/reader/reader_registry.h"
+#include "client/vfs/data/writer_table.h"
 #include "client/vfs/handle/handle_manager.h"
 #include "client/vfs/metasystem/meta_wrapper.h"
 #include "common/options/client.h"
@@ -84,7 +86,10 @@ class VFSTestBase : public ::testing::Test {
     mock_compactor_ = cp.get();
     compactor_uptr_ = std::move(cp);
 
-    // --- 5. HandleManager ---
+    // --- 5. ReaderRegistry + WriterTable + HandleManager ---
+    reader_registry_ = std::make_unique<ReaderRegistry>();
+    writer_table_ = std::make_unique<WriterTable>(mock_hub_);
+    CHECK(writer_table_->Start().ok());
     handle_manager_ = std::make_unique<HandleManager>(mock_hub_);
     CHECK(handle_manager_->Start().ok());
 
@@ -107,6 +112,10 @@ class VFSTestBase : public ::testing::Test {
         .WillByDefault(Return(meta_wrapper_.get()));
     ON_CALL(*mock_hub_, GetHandleManager())
         .WillByDefault(Return(handle_manager_.get()));
+    ON_CALL(*mock_hub_, GetReaderRegistry())
+        .WillByDefault(Return(reader_registry_.get()));
+    ON_CALL(*mock_hub_, GetWriterTable())
+        .WillByDefault(Return(writer_table_.get()));
     ON_CALL(*mock_hub_, GetBlockStore())
         .WillByDefault(Return(mock_block_store_));
     ON_CALL(*mock_hub_, GetReadMemPool())
@@ -133,6 +142,8 @@ class VFSTestBase : public ::testing::Test {
 
     EXPECT_CALL(*mock_hub_, GetMetaSystem()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetHandleManager()).Times(AnyNumber());
+    EXPECT_CALL(*mock_hub_, GetReaderRegistry()).Times(AnyNumber());
+    EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetBlockStore()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetReadMemPool()).Times(AnyNumber());
     EXPECT_CALL(*mock_hub_, GetWriteMemPool()).Times(AnyNumber());
@@ -204,6 +215,7 @@ class VFSTestBase : public ::testing::Test {
 
   ~VFSTestBase() override {
     handle_manager_->Stop();
+    writer_table_->Stop();
     write_background_executor_->Stop();
     flush_executor_->Stop();
     read_executor_->Stop();
@@ -223,6 +235,8 @@ class VFSTestBase : public ::testing::Test {
   std::unique_ptr<MockCompactor> compactor_uptr_;
   std::unique_ptr<MetaWrapper> meta_wrapper_;
   std::unique_ptr<HandleManager> handle_manager_;
+  std::unique_ptr<ReaderRegistry> reader_registry_;
+  std::unique_ptr<WriterTable> writer_table_;
   std::unique_ptr<ReadMemPool> read_mem_pool_;
   std::unique_ptr<WriteMemPool> write_buf_mgr_;
   std::unique_ptr<FileSuffixWatcher> file_suffix_watcher_;

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -471,6 +471,67 @@ TEST_F(VFSImplTest, Release_FlushFailureStillClosesAndReleasesHandle) {
   EXPECT_EQ(writer_table->Size(), 0u);
 }
 
+TEST_F(VFSImplTest, Fsync_DataFlushFailureIsNotOverwrittenByMetaFlush) {
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+
+  constexpr Ino kFsyncIno = 404;
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, kFsyncIno, O_WRONLY, &fh, nullptr).ok());
+
+  const char data[] = "fsync failure";
+  uint64_t written = 0;
+  EXPECT_CALL(*mock_meta_system_, Write(_, kFsyncIno, _, 0, sizeof(data), fh))
+      .WillOnce(Return(Status::OK()));
+  ASSERT_TRUE(
+      vfs_->Write(ctx_, kFsyncIno, data, sizeof(data), 0, fh, &written).ok());
+
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault(Return(Status::Internal("data flush failed")));
+  EXPECT_CALL(*mock_meta_system_, Flush(_, kFsyncIno, fh)).Times(0);
+
+  Status s = vfs_->Fsync(ctx_, kFsyncIno, /*datasync=*/0, fh);
+  EXPECT_FALSE(s.ok());
+  EXPECT_NE(s.ToString().find("data flush failed"), std::string::npos);
+
+  EXPECT_CALL(*mock_meta_system_, Close(_, kFsyncIno, fh))
+      .WillOnce(Return(Status::OK()));
+  EXPECT_FALSE(vfs_->Release(ctx_, kFsyncIno, fh).ok());
+}
+
+TEST_F(VFSImplTest, Fsync_MetaFlushFailureReturnedAfterDataFlushSuccess) {
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
+
+  constexpr Ino kFsyncIno = 405;
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, kFsyncIno, O_WRONLY, &fh, nullptr).ok());
+
+  const char data[] = "fsync metadata";
+  uint64_t written = 0;
+  EXPECT_CALL(*mock_meta_system_, Write(_, kFsyncIno, _, 0, sizeof(data), fh))
+      .WillOnce(Return(Status::OK()));
+  ASSERT_TRUE(
+      vfs_->Write(ctx_, kFsyncIno, data, sizeof(data), 0, fh, &written).ok());
+
+  EXPECT_CALL(*mock_meta_system_, WriteSlice(_, kFsyncIno, _, 0, _))
+      .WillOnce(Return(Status::OK()));
+  EXPECT_CALL(*mock_meta_system_, Flush(_, kFsyncIno, fh))
+      .WillOnce(Return(Status::Internal("metadata flush failed")));
+
+  Status s = vfs_->Fsync(ctx_, kFsyncIno, /*datasync=*/0, fh);
+  EXPECT_FALSE(s.ok());
+  EXPECT_NE(s.ToString().find("metadata flush failed"), std::string::npos);
+
+  EXPECT_CALL(*mock_meta_system_, Close(_, kFsyncIno, fh))
+      .WillOnce(Return(Status::OK()));
+  EXPECT_TRUE(vfs_->Release(ctx_, kFsyncIno, fh).ok());
+}
+
 // --- 10. Unlink internal file returns EPERM ---
 TEST_F(VFSImplTest, Unlink_InternalFile_EPERM) {
   // Unlink ".stats" from root is blocked.

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -32,6 +32,7 @@
 #include "common/blockaccess/accesser_common.h"
 #include "common/const.h"
 #include "common/file_size.h"
+#include "common/options/client.h"
 #include "common/status.h"
 #include "common/trace/trace_manager.h"
 #include "common/writemempool/write_mem_pool.h"
@@ -39,6 +40,7 @@
 #include "test/unit/client/vfs/mock/mock_vfs_hub.h"
 #include "test/unit/client/vfs/test_base.h"
 #include "test/unit/client/vfs/test_common.h"
+#include "utils/scoped_cleanup.h"
 
 namespace dingofs {
 namespace client {
@@ -103,6 +105,18 @@ class VFSImplTest : public test::VFSTestBase {
     vfs_.reset(new VFSImpl(std::move(hub_uptr_)));
   }
 
+  void TearDown() override {
+    // HandleManager keeps a non-owning pointer to the hub now owned by vfs_.
+    // Stop it while that hub is still alive; the VFSTestBase destructor's
+    // later Stop is idempotent and will not dereference the destroyed hub.
+    // Some tests temporarily redirect GetWriterTable() to a function-local
+    // table; restore the fixture-owned table after those locals are gone.
+    ON_CALL(*mock_hub_, GetWriterTable())
+        .WillByDefault(Return(writer_table_.get()));
+    handle_manager_->Stop();
+    vfs_.reset();
+  }
+
   std::unique_ptr<VFSImpl> vfs_;
   std::unique_ptr<TraceManager> trace_manager_;
 
@@ -112,7 +126,31 @@ class VFSImplTest : public test::VFSTestBase {
     vfs_->mount_root_path_ = path;
     vfs_->mount_root_ino_ = ino;
   }
+
+  Status StartBrpcServer() { return vfs_->StartBrpcServer(); }
+
+  brpc::Server::Status BrpcServerStatus() const {
+    return vfs_->brpc_server_.status();
+  }
 };
+
+TEST_F(VFSImplTest, StopDrainsBrpcServerBeforeHub) {
+  const uint32_t previous_port = FLAGS_vfs_dummy_server_port;
+  FLAGS_vfs_dummy_server_port = 0;
+  auto restore_port =
+      MakeScopedCleanup([&]() { FLAGS_vfs_dummy_server_port = previous_port; });
+
+  ASSERT_TRUE(StartBrpcServer().ok());
+  ASSERT_EQ(BrpcServerStatus(), brpc::Server::RUNNING);
+
+  EXPECT_CALL(*mock_hub_, Stop(false)).WillOnce(Invoke([&](bool) {
+    EXPECT_EQ(BrpcServerStatus(), brpc::Server::READY);
+    return Status::OK();
+  }));
+
+  EXPECT_TRUE(vfs_->Stop(false).ok());
+  EXPECT_EQ(BrpcServerStatus(), brpc::Server::READY);
+}
 
 // --- 1. GetFsId ---
 TEST_F(VFSImplTest, GetFsId_ReturnsFromFsInfo) {

--- a/test/unit/client/vfs/test_vfs_wrapper_lifecycle.cc
+++ b/test/unit/client/vfs/test_vfs_wrapper_lifecycle.cc
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <thread>
+
+#include "client/vfs/vfs_wrapper.h"
+#include "common/options/client.h"
+
+namespace dingofs {
+namespace client {
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+
+namespace {
+
+class MockLifecycleVFS : public vfs::VFS {
+ public:
+  MOCK_METHOD(Status, Start, (bool), (override));
+  MOCK_METHOD(Status, Stop, (bool), (override));
+  MOCK_METHOD(bool, Dump, (ContextSPtr, Json::Value&), (override));
+  MOCK_METHOD(bool, Load, (ContextSPtr, const Json::Value&), (override));
+  MOCK_METHOD(Status, Lookup, (ContextSPtr, Ino, const std::string&, Attr*),
+              (override));
+  MOCK_METHOD(Status, GetAttr, (ContextSPtr, Ino, Attr*), (override));
+  MOCK_METHOD(Status, SetAttr, (ContextSPtr, Ino, int, const Attr&, Attr*),
+              (override));
+  MOCK_METHOD(Status, Fallocate, (ContextSPtr, Ino, int, uint64_t, uint64_t),
+              (override));
+  MOCK_METHOD(Status, CopyFileRange,
+              (ContextSPtr, Ino, uint64_t, uint64_t, Ino, uint64_t, uint64_t,
+               uint64_t, uint32_t, uint64_t*),
+              (override));
+  MOCK_METHOD(Status, ReadLink, (ContextSPtr, Ino, std::string*), (override));
+  MOCK_METHOD(Status, MkNod,
+              (ContextSPtr, Ino, const std::string&, uint32_t, uint32_t,
+               uint32_t, uint64_t, Attr*),
+              (override));
+  MOCK_METHOD(Status, Unlink, (ContextSPtr, Ino, const std::string&),
+              (override));
+  MOCK_METHOD(Status, Symlink,
+              (ContextSPtr, Ino, const std::string&, uint32_t, uint32_t,
+               const std::string&, Attr*),
+              (override));
+  MOCK_METHOD(Status, Rename,
+              (ContextSPtr, Ino, const std::string&, Ino, const std::string&),
+              (override));
+  MOCK_METHOD(Status, Link, (ContextSPtr, Ino, Ino, const std::string&, Attr*),
+              (override));
+  MOCK_METHOD(Status, Open, (ContextSPtr, Ino, int, uint64_t*, bool*),
+              (override));
+  MOCK_METHOD(Status, Create,
+              (ContextSPtr, Ino, const std::string&, uint32_t, uint32_t,
+               uint32_t, int, uint64_t*, Attr*),
+              (override));
+  MOCK_METHOD(Status, Read,
+              (ContextSPtr, Ino, DataBuffer*, uint64_t, uint64_t, uint64_t,
+               uint64_t*),
+              (override));
+  MOCK_METHOD(Status, Write,
+              (ContextSPtr, Ino, const char*, uint64_t, uint64_t, uint64_t,
+               uint64_t*),
+              (override));
+  MOCK_METHOD(Status, Flush, (ContextSPtr, Ino, uint64_t), (override));
+  MOCK_METHOD(Status, Release, (ContextSPtr, Ino, uint64_t), (override));
+  MOCK_METHOD(Status, Fsync, (ContextSPtr, Ino, int, uint64_t), (override));
+  MOCK_METHOD(Status, SetXattr,
+              (ContextSPtr, Ino, const std::string&, const std::string&, int),
+              (override));
+  MOCK_METHOD(Status, GetXattr,
+              (ContextSPtr, Ino, const std::string&, std::string*), (override));
+  MOCK_METHOD(Status, RemoveXattr, (ContextSPtr, Ino, const std::string&),
+              (override));
+  MOCK_METHOD(Status, ListXattr, (ContextSPtr, Ino, std::vector<std::string>*),
+              (override));
+  MOCK_METHOD(Status, MkDir,
+              (ContextSPtr, Ino, const std::string&, uint32_t, uint32_t,
+               uint32_t, Attr*),
+              (override));
+  MOCK_METHOD(Status, OpenDir, (ContextSPtr, Ino, uint64_t*, bool&),
+              (override));
+  MOCK_METHOD(Status, ReadDir,
+              (ContextSPtr, Ino, uint64_t, uint64_t, bool, ReadDirHandler,
+               uint32_t&),
+              (override));
+  MOCK_METHOD(Status, ReleaseDir, (ContextSPtr, Ino, uint64_t), (override));
+  MOCK_METHOD(Status, RmDir, (ContextSPtr, Ino, const std::string&),
+              (override));
+  MOCK_METHOD(Status, StatFs, (ContextSPtr, Ino, FsStat*), (override));
+  MOCK_METHOD(Status, Ioctl,
+              (ContextSPtr, Ino, uint32_t, unsigned int, unsigned, const void*,
+               size_t, char*, size_t),
+              (override));
+  MOCK_METHOD(uint64_t, GetFsId, (), (override));
+  MOCK_METHOD(double, GetAttrTimeout, (const FileType&), (override));
+  MOCK_METHOD(double, GetEntryTimeout, (const FileType&), (override));
+  MOCK_METHOD(uint64_t, GetMaxNameLength, (), (override));
+  MOCK_METHOD(TraceManager*, GetTraceManager, (), (override));
+  MOCK_METHOD(Status, GetInfo, (std::string*), (override));
+};
+
+}  // namespace
+
+class VFSWrapperLifecycleTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    previous_access_logging_ = FLAGS_vfs_access_logging;
+    FLAGS_vfs_access_logging = false;
+    auto core = std::make_unique<MockLifecycleVFS>();
+    core_ = core.get();
+    wrapper_.vfs_ = std::move(core);
+    wrapper_.lifecycle_state_ = VFSWrapper::LifecycleState::kRunning;
+    wrapper_.fs_id_ = 10;
+    wrapper_.max_name_length_ = 255;
+    wrapper_.attr_timeout_ = 1.0;
+    wrapper_.entry_timeout_ = 2.0;
+    wrapper_.immutable_values_published_.store(true, std::memory_order_release);
+  }
+
+  void TearDown() override {
+    FLAGS_vfs_access_logging = previous_access_logging_;
+  }
+
+  VFSWrapper wrapper_;
+  MockLifecycleVFS* core_{nullptr};
+  bool previous_access_logging_{true};
+};
+
+TEST_F(VFSWrapperLifecycleTest, StopWaitsForAdmittedOperation) {
+  std::promise<void> entered;
+  std::promise<void> release;
+  auto release_future = release.get_future();
+  std::atomic<bool> core_stopped{false};
+
+  EXPECT_CALL(*core_, GetInfo(_)).WillOnce(Invoke([&](std::string*) {
+    entered.set_value();
+    release_future.wait();
+    return Status::OK();
+  }));
+  EXPECT_CALL(*core_, Stop(false)).WillOnce(Invoke([&](bool) {
+    core_stopped.store(true);
+    return Status::OK();
+  }));
+
+  std::thread operation([&] {
+    std::string info;
+    EXPECT_TRUE(wrapper_.GetInfo(&info).ok());
+  });
+  ASSERT_EQ(entered.get_future().wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+
+  auto stop_future =
+      std::async(std::launch::async, [&] { return wrapper_.Stop(false); });
+  EXPECT_EQ(stop_future.wait_for(std::chrono::milliseconds(100)),
+            std::future_status::timeout);
+  EXPECT_FALSE(core_stopped.load());
+
+  release.set_value();
+  operation.join();
+  EXPECT_TRUE(stop_future.get().ok());
+  EXPECT_TRUE(core_stopped.load());
+}
+
+TEST_F(VFSWrapperLifecycleTest, ConcurrentStopRunsCoreStopOnce) {
+  std::promise<void> stop_entered;
+  std::promise<void> release_stop;
+  auto release_future = release_stop.get_future();
+
+  EXPECT_CALL(*core_, Stop(false)).WillOnce(Invoke([&](bool) {
+    stop_entered.set_value();
+    release_future.wait();
+    return Status::OK();
+  }));
+
+  auto first =
+      std::async(std::launch::async, [&] { return wrapper_.Stop(false); });
+  ASSERT_EQ(stop_entered.get_future().wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+  auto second =
+      std::async(std::launch::async, [&] { return wrapper_.Stop(false); });
+
+  EXPECT_EQ(second.wait_for(std::chrono::milliseconds(100)),
+            std::future_status::timeout);
+  release_stop.set_value();
+  EXPECT_TRUE(first.get().ok());
+  EXPECT_TRUE(second.get().ok());
+}
+
+TEST_F(VFSWrapperLifecycleTest, StoppedSessionRejectsBeforeCoreAccess) {
+  EXPECT_CALL(*core_, Stop(false)).WillOnce(Return(Status::OK()));
+  ASSERT_TRUE(wrapper_.Stop(false).ok());
+
+  EXPECT_CALL(*core_, GetInfo(_)).Times(0);
+  std::string info;
+  Status status = wrapper_.GetInfo(&info);
+  EXPECT_TRUE(status.IsStop());
+  EXPECT_EQ(status.ToSysErrNo(), EIO);
+
+  EXPECT_EQ(wrapper_.GetFsId(), 10u);
+  EXPECT_EQ(wrapper_.GetMaxNameLength(), 255u);
+  EXPECT_DOUBLE_EQ(wrapper_.GetAttrTimeout(kFile), 1.0);
+  EXPECT_DOUBLE_EQ(wrapper_.GetEntryTimeout(kDirectory), 2.0);
+}
+
+}  // namespace client
+}  // namespace dingofs


### PR DESCRIPTION
## Summary

- add an irreversible lifecycle gate in `VFSWrapper`: reject new public operations, drain admitted operations, then tear down the VFS runtime
- serialize concurrent `Stop()` calls and cache immutable getters so stopped sessions never access torn-down core components
- keep the FUSE-owned VFS alive until session workers are joined; `FuseOpDestroy()` stops but does not delete it inline
- stop and join the embedded brpc diagnostic server before Hub teardown, and preserve safe server/service destruction order
- make shutdown writer flushing explicit before detached holders are released, preserve flush/fsync errors, and pin writer lifetime during `FlushAll()`
- introduce `ReaderRegistry` so reader invalidation and final close no longer depend on unlocked handle resource access

## Lifecycle

`Running -> Quiescing (reject new calls) -> drain active public operations -> component Stop/Flush -> Stopped`

The gate is owned by `VFSWrapper`, which is the public client-session boundary. `VFSImpl` and `VFSHub` remain internal core/runtime layers and no longer need to infer global request quiescence from handle references.

## Tests

- `cmake --build build --target dingo-client test_client test_fuse_upgrade -j4`
- `build/bin/test/test_client` (444 passed, 1 skipped)
- `build/bin/test/test_fuse_upgrade` (16 passed)