### PR TITLE
[fix][client] Prevent stale compaction and track write length

### DIFF
--- a/src/client/vfs/metasystem/mds/chunk.cc
+++ b/src/client/vfs/metasystem/mds/chunk.cc
@@ -348,6 +348,13 @@ void ChunkSet::Append(uint32_t index, const std::vector<Slice>& slices) {
     chunk->AppendSlice(slices);
     chunk_map_.emplace(index, chunk);
   }
+
+  // calculate file length with write memo
+  uint64_t chunk_offset = index * chunk_size_;
+  for (const auto& slice : slices) {
+    last_write_slice_length_ =
+        std::max(last_write_slice_length_, chunk_offset + slice.End());
+  }
 }
 
 void ChunkSet::Put(const std::vector<ChunkEntry>& chunks, const char* reason) {

--- a/src/client/vfs/metasystem/mds/chunk.h
+++ b/src/client/vfs/metasystem/mds/chunk.h
@@ -297,6 +297,11 @@ class ChunkSet {
 
   Ino GetIno() const { return ino_; }
 
+  uint64_t GetLastWriteSliceLength() const {
+    utils::ReadLockGuard guard(lock_);
+    return last_write_slice_length_;
+  }
+
   // write memo operations
   void SetLastWriteLength(uint64_t offset, uint64_t size) {
     utils::WriteLockGuard lk(lock_);
@@ -431,9 +436,14 @@ class ChunkSet {
 
   mutable utils::RWLock lock_;
 
+  // record write file length by writeslice operation
+  uint64_t last_write_slice_length_{0};
+
+  // record write file length by write operation
   uint64_t last_write_length_{0};
   uint64_t last_write_time_ns_{0};
 
+  // record commited file length by CommitTask
   uint64_t last_commited_length_{0};
   bool last_commited_length_changed_{false};
 

--- a/src/client/vfs/metasystem/mds/chunk.h
+++ b/src/client/vfs/metasystem/mds/chunk.h
@@ -302,7 +302,7 @@ class ChunkSet {
     return last_write_slice_length_;
   }
 
-  // write memo operations
+  // write memo operationsm
   void SetLastWriteLength(uint64_t offset, uint64_t size) {
     utils::WriteLockGuard lk(lock_);
     last_write_length_ = std::max(last_write_length_, offset + size);

--- a/src/client/vfs/metasystem/mds/compact.cc
+++ b/src/client/vfs/metasystem/mds/compact.cc
@@ -96,10 +96,6 @@ Status CompactChunkTask::Compact() {
   std::vector<Slice> old_slices = chunk_->GetCommitedSlice(version);
   if (old_slices.empty()) return Status::OK();
 
-  LOG(INFO) << fmt::format(
-      "[meta.compact.{}.{}.{}] do compact chunk, old_slices({}) version({}).",
-      ino_, chunk_index, Id(), old_slices.size(), version);
-
   std::vector<Slice> new_slices;
   ContextSPtr ctx = std::make_shared<Context>("");
   status = compactor_.Compact(ctx, ino_, chunk_index, old_slices, new_slices);

--- a/src/client/vfs/metasystem/mds/compact.cc
+++ b/src/client/vfs/metasystem/mds/compact.cc
@@ -29,6 +29,8 @@ DEFINE_uint32(vfs_compact_worker_max_pending_num, 256,
               "compact worker max pending num");
 DEFINE_bool(vfs_compact_worker_use_pthread, true, "compact worker use pthread");
 
+constexpr size_t kCompactedVersionMemoMaxSize = 1024 * 1024;  // 1M
+
 void CompactChunkTask::Run() {
   if (compact_processor_.IsStopped() || IsDeleted()) {
     LOG(INFO) << fmt::format(
@@ -96,6 +98,14 @@ Status CompactChunkTask::Compact() {
   std::vector<Slice> old_slices = chunk_->GetCommitedSlice(version);
   if (old_slices.empty()) return Status::OK();
 
+  // check version
+  uint64_t compacted_version =
+      compact_processor_.GetCompactedVersion(ino_, chunk_index);
+  if (version <= compacted_version) {
+    return Status::NotFit(
+        fmt::format("stale version, {}<={}", version, compacted_version));
+  }
+
   std::vector<Slice> new_slices;
   ContextSPtr ctx = std::make_shared<Context>("");
   status = compactor_.Compact(ctx, ino_, chunk_index, old_slices, new_slices);
@@ -137,6 +147,9 @@ Status CompactChunkTask::Compact() {
                             param.end_pos, param.end_slice_id, new_slices);
       }
     }
+
+    compact_processor_.UpdateComapctedVersion(ino_, chunk_index,
+                                              chunk_entry.version());
 
     LOG(INFO) << fmt::format(
         "[meta.compact.{}.{}.{}] do compact chunk finish, version({}->{}) "
@@ -187,6 +200,44 @@ Status CompactProcessor::LaunchCompact(Ino ino, InodeSPtr inode,
   }
 
   return Status::OK();
+}
+
+uint64_t CompactProcessor::GetCompactedVersion(Ino ino, uint32_t chunk_index) {
+  utils::ReadLockGuard guard(lock_);
+
+  const std::string key = fmt::format("{}:{}", ino, chunk_index);
+  auto it = compacted_version_memo_.find(key);
+  return (it != compacted_version_memo_.end()) ? it->second.version : 0;
+}
+
+void CompactProcessor::UpdateComapctedVersion(Ino ino, uint32_t chunk_index,
+                                              uint64_t version) {
+  utils::WriteLockGuard guard(lock_);
+
+  const std::string key = fmt::format("{}:{}", ino, chunk_index);
+  auto [it, inserted] = compacted_version_memo_.try_emplace(
+      key, Value{.version = version, .last_active_time_s = utils::Timestamp()});
+  if (!inserted && it->second.version < version) {
+    it->second.version = version;
+    it->second.last_active_time_s = utils::Timestamp();
+  }
+}
+
+void CompactProcessor::CleanExpired(uint64_t expire_time_s) {
+  utils::WriteLockGuard guard(lock_);
+
+  if (compacted_version_memo_.size() < kCompactedVersionMemoMaxSize) return;
+
+  for (auto it = compacted_version_memo_.begin();
+       it != compacted_version_memo_.end();) {
+    if (it->second.last_active_time_s < expire_time_s) {
+      auto tmp = it++;
+      compacted_version_memo_.erase(tmp);
+
+    } else {
+      ++it;
+    }
+  }
 }
 
 }  // namespace meta

--- a/src/client/vfs/metasystem/mds/compact.h
+++ b/src/client/vfs/metasystem/mds/compact.h
@@ -15,7 +15,10 @@
 #ifndef DINGOFS_SRC_CLIENT_VFS_META_MDS_COMPACT_H_
 #define DINGOFS_SRC_CLIENT_VFS_META_MDS_COMPACT_H_
 
+#include <absl/container/flat_hash_map.h>
+
 #include <atomic>
+#include <cstdint>
 #include <string>
 
 #include "client/vfs/compaction/compactor.h"
@@ -109,10 +112,23 @@ class CompactProcessor {
 
   bool IsStopped() { return is_stopped_.load(); }
 
+  uint64_t GetCompactedVersion(Ino ino, uint32_t chunk_index);
+  void UpdateComapctedVersion(Ino ino, uint32_t chunk_index, uint64_t version);
+
+  void CleanExpired(uint64_t expire_time_s);
+
  private:
   std::atomic<bool> is_stopped_{false};
 
   Executor executor_;
+
+  struct Value {
+    uint64_t version;
+    uint64_t last_active_time_s;
+  };
+  utils::RWLock lock_;
+  // key: ino + chunk_index, value: compacted version
+  absl::flat_hash_map<std::string, Value> compacted_version_memo_;
 };
 
 }  // namespace meta

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -496,6 +496,12 @@ void MDSMetaSystem::CleanExpiredDirProfileCache() {
   dir_profile_cache_->CleanExpired(utils::Timestamp());
 }
 
+void MDSMetaSystem::CleanExpiredCompactMemo() {
+  uint64_t expired_time_s = utils::Timestamp() - FLAGS_vfs_meta_memo_expired_s;
+
+  compact_processor_.CleanExpired(expired_time_s);
+}
+
 bool MDSMetaSystem::InitCrontab() {
   // add heartbeat crontab
   crontab_configs_.push_back({
@@ -516,6 +522,7 @@ bool MDSMetaSystem::InitCrontab() {
         this->CleanExpiredInodeCache();
         this->CleanExpiredTinyFileDataCache();
         this->CleanExpiredDirProfileCache();
+        this->CleanExpiredCompactMemo();
       },
   });
 

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -1788,9 +1788,18 @@ Status MDSMetaSystem::DoFlushFile(ContextSPtr ctx, InodeSPtr inode,
     return Status::Internal("inode is null");
   }
 
-  Ino ino = inode->Ino();
+  const Ino ino = inode->Ino();
+
+  LOG_DEBUG << fmt::format(
+      "[meta.fs.{}] flush file, writeslice({}) write({}) commited({}) "
+      "is_final({}).",
+      ino, chunk_set->GetLastWriteSliceLength(),
+      chunk_set->GetLastWriteLength(), chunk_set->GetLastComitedLength(),
+      is_final);
+
   uint64_t last_write_length = is_final ? chunk_set->GetLastWriteLength()
                                         : chunk_set->GetLastComitedLength();
+
   if (last_write_length == 0) {
     LOG_DEBUG << fmt::format(
         "[meta.fs.{}] flush file skip cause no write data, length({}).", ino,

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -203,6 +203,7 @@ class MDSMetaSystem : public vfs::MetaSystem {
   void CleanExpiredInodeCache();
   void CleanExpiredTinyFileDataCache();
   void CleanExpiredDirProfileCache();
+  void CleanExpiredCompactMemo();
 
   bool InitCrontab();
 


### PR DESCRIPTION
<!-- Thank you for contributing to dingofs! -->

### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

Compaction can process stale chunk versions more than once, while flush length tracking does not account for write-slice updates.

### What is changed and how it works?

What's Changed:

- Memoize the latest compacted version per inode/chunk and skip stale compaction work.
- Expire compacted-version memo entries from the existing metadata cron job.
- Track the maximum file length observed by write-slice operations and add flush diagnostics.

How it Works:

Compaction checks the memo before processing and updates it after successful compaction. The memo is bounded by periodic expiration once it reaches its configured size threshold.

Side effects(Breaking backward compatibility? Performance regression?):

No known compatibility changes. Adds a small synchronized in-memory memo and periodic cleanup.

### Check List

- [ ] Relevant documentation/comments is changed or added
- [x] I acknowledge that all my contributions will be made under the project's license

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.6_Luna_(High)](https://img.shields.io/badge/GPT_5.6_Luna_(High)-000000)
