### PR TITLE
[fix][client] Refresh stale RADOS OSDMap in background

### DIFF
--- a/src/common/blockaccess/rados/CMakeLists.txt
+++ b/src/common/blockaccess/rados/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_library(rados_accesser
+    osd_map_refresher.cc
     rados_accesser.cc
 )
 

--- a/src/common/blockaccess/rados/osd_map_refresher.cc
+++ b/src/common/blockaccess/rados/osd_map_refresher.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2025 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/blockaccess/rados/osd_map_refresher.h"
+
+#include <bvar/bvar.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <random>
+#include <utility>
+
+namespace dingofs {
+namespace blockaccess {
+namespace {
+
+constexpr auto kSlowRefreshThreshold = std::chrono::seconds(30);
+
+bvar::Adder<int64_t> g_refresh_attempts{
+    "dingofs_rados_map_refresh_attempt_total"};
+bvar::Adder<int64_t> g_refresh_failures{
+    "dingofs_rados_map_refresh_failure_total"};
+
+}  // namespace
+
+OsdMapRefresher::OsdMapRefresher(Options options, RefreshFn refresh_fn)
+    : options_(std::move(options)),
+      refresh_fn_(std::move(refresh_fn)),
+      random_(std::random_device{}()) {}
+
+OsdMapRefresher::~OsdMapRefresher() { Stop(); }
+
+bool OsdMapRefresher::Start() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (started_) {
+    return true;
+  }
+  if (!options_.enabled) {
+    return true;
+  }
+  if (!refresh_fn_ || options_.interval <= std::chrono::milliseconds::zero()) {
+    LOG(ERROR) << "Invalid OSDMap refresher options";
+    return false;
+  }
+
+  stopping_ = false;
+  try {
+    thread_ = std::thread(&OsdMapRefresher::Run, this);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to create OSDMap refresher thread: " << e.what();
+    return false;
+  }
+  started_ = true;
+  return true;
+}
+
+void OsdMapRefresher::Stop() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!started_) {
+      return;
+    }
+    stopping_ = true;
+  }
+  cv_.notify_all();
+
+  if (thread_.joinable()) {
+    // The public librados latest-map API has no request deadline or cancel
+    // handle. If its MON version request or OSDMap subscription never
+    // completes, this join can block shutdown indefinitely. Do not detach the
+    // thread: refresh_fn_ may still access the rados_t owned by RadosAccesser.
+    thread_.join();
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  started_ = false;
+}
+
+void OsdMapRefresher::Run() {
+  while (true) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (stopping_) {
+        return;
+      }
+    }
+
+    g_refresh_attempts << 1;
+    const auto begin = std::chrono::steady_clock::now();
+    const int rc = refresh_fn_();
+    const auto elapsed = std::chrono::steady_clock::now() - begin;
+    const auto duration_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+
+    if (rc != 0) {
+      g_refresh_failures << 1;
+    }
+
+    if (rc != 0) {
+      LOG(WARNING) << "Failed to refresh latest RADOS OSDMap, rc=" << rc
+                   << ", duration=" << duration_us << " us";
+    } else if (elapsed >= kSlowRefreshThreshold) {
+      LOG(INFO) << "Slow refresh of latest RADOS OSDMap, duration="
+                << duration_us << " us";
+    } else {
+      VLOG(1) << "Refreshed latest RADOS OSDMap in " << duration_us << " us";
+    }
+
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait_for(lock, NextInterval(), [this] { return stopping_; });
+    if (stopping_) {
+      return;
+    }
+  }
+}
+
+std::chrono::milliseconds OsdMapRefresher::NextInterval() {
+  const uint32_t jitter_pct = std::min(options_.jitter_pct, 50U);
+  if (jitter_pct == 0) {
+    return options_.interval;
+  }
+
+  const int64_t base = options_.interval.count();
+  const int64_t delta = base * jitter_pct / 100;
+  std::uniform_int_distribution<int64_t> distribution(-delta, delta);
+  return std::chrono::milliseconds(
+      std::max<int64_t>(base + distribution(random_), 1));
+}
+
+}  // namespace blockaccess
+}  // namespace dingofs

--- a/src/common/blockaccess/rados/osd_map_refresher.h
+++ b/src/common/blockaccess/rados/osd_map_refresher.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_COMMON_BLOCK_ACCESS_RADOS_OSD_MAP_REFRESHER_H_
+#define DINGOFS_COMMON_BLOCK_ACCESS_RADOS_OSD_MAP_REFRESHER_H_
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <random>
+#include <thread>
+
+namespace dingofs {
+namespace blockaccess {
+
+class OsdMapRefresher {
+ public:
+  struct Options {
+    bool enabled{true};
+    std::chrono::milliseconds interval{std::chrono::seconds(60)};
+    uint32_t jitter_pct{20};
+  };
+
+  using RefreshFn = std::function<int()>;
+
+  OsdMapRefresher(Options options, RefreshFn refresh_fn);
+  ~OsdMapRefresher();
+
+  OsdMapRefresher(const OsdMapRefresher&) = delete;
+  OsdMapRefresher& operator=(const OsdMapRefresher&) = delete;
+
+  bool Start();
+  void Stop();
+
+ private:
+  void Run();
+  std::chrono::milliseconds NextInterval();
+
+  const Options options_;
+  const RefreshFn refresh_fn_;
+
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  std::thread thread_;
+  std::mt19937_64 random_;
+
+  bool started_{false};
+  bool stopping_{false};
+};
+
+}  // namespace blockaccess
+}  // namespace dingofs
+
+#endif  // DINGOFS_COMMON_BLOCK_ACCESS_RADOS_OSD_MAP_REFRESHER_H_

--- a/src/common/blockaccess/rados/rados_accesser.cc
+++ b/src/common/blockaccess/rados/rados_accesser.cc
@@ -21,6 +21,8 @@
 #include <glog/logging.h>
 #include <rados/librados.h>
 
+#include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstring>
 #include <functional>
@@ -178,15 +180,38 @@ bool RadosAccesser::Init() {
     return false;
   }
 
+  auto refresh_options = OsdMapRefresher::Options{
+      .enabled = FLAGS_rados_map_refresh_enable,
+      .interval = std::chrono::seconds(
+          std::max(FLAGS_rados_map_refresh_interval_s, 10U)),
+      .jitter_pct = std::min(FLAGS_rados_map_refresh_jitter_pct, 50U),
+  };
+  map_refresher_ = std::make_unique<OsdMapRefresher>(
+      refresh_options,
+      [cluster = cluster_]() { return rados_wait_for_latest_osdmap(cluster); });
+  if (!map_refresher_->Start()) {
+    LOG(ERROR) << "Failed to start RADOS OSDMap refresher";
+    map_refresher_.reset();
+    rados_shutdown(cluster_);
+    cluster_ = nullptr;
+    return false;
+  }
+
   LOG(INFO) << "Succss init RadosAccesser cluster: " << cluster_
             << ", mon_host: " << options_.mon_host << options_.cluster_name
-            << ", user: " << options_.user_name << ", key: " << options_.key
-            << ", pool: " << options_.pool_name;
+            << ", user: " << options_.user_name
+            << ", pool: " << options_.pool_name
+            << ", map_refresh_enabled: " << FLAGS_rados_map_refresh_enable;
 
   return true;
 }
 
 bool RadosAccesser::Destroy() {
+  if (map_refresher_ != nullptr) {
+    map_refresher_->Stop();
+    map_refresher_.reset();
+  }
+
   if (cluster_ != nullptr) {
     VLOG(1) << "Waiting all aio to finish before destroy rados cluster: "
             << cluster_;

--- a/src/common/blockaccess/rados/rados_accesser.h
+++ b/src/common/blockaccess/rados/rados_accesser.h
@@ -25,6 +25,7 @@
 #include <variant>
 
 #include "common/blockaccess/accesser.h"
+#include "common/blockaccess/rados/osd_map_refresher.h"
 #include "common/blockaccess/rados/rados_common.h"
 
 namespace dingofs {
@@ -98,6 +99,7 @@ class RadosAccesser : public Accesser {
   const RadosOptions options_;
 
   rados_t cluster_{nullptr};
+  std::unique_ptr<OsdMapRefresher> map_refresher_;
 };
 
 }  // namespace blockaccess

--- a/src/common/options/blockaccess.cc
+++ b/src/common/options/blockaccess.cc
@@ -23,6 +23,13 @@ namespace blockaccess {
 
 // rados option
 DEFINE_int32(rados_op_timeout, 120, "rados operation timeout in seconds");
+DEFINE_bool(rados_map_refresh_enable, true,
+            "enable background refresh of the latest RADOS OSDMap");
+DEFINE_uint32(rados_map_refresh_interval_s, 60,
+              "background RADOS OSDMap refresh interval in seconds");
+DEFINE_uint32(rados_map_refresh_jitter_pct, 20,
+              "random jitter percentage for the RADOS OSDMap refresh "
+              "interval (clamped to 50)");
 
 // aws option
 DEFINE_string(s3_region, "us-east-1", "aws s3 region");

--- a/src/common/options/blockaccess.h
+++ b/src/common/options/blockaccess.h
@@ -23,6 +23,9 @@ namespace dingofs {
 namespace blockaccess {
 
 DECLARE_int32(rados_op_timeout);
+DECLARE_bool(rados_map_refresh_enable);
+DECLARE_uint32(rados_map_refresh_interval_s);
+DECLARE_uint32(rados_map_refresh_jitter_pct);
 
 // aws option
 DECLARE_string(s3_region);

--- a/test/unit/common/blockaccess/CMakeLists.txt
+++ b/test/unit/common/blockaccess/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(test_blockaccess
     files/test_file_accesser.cc
+    rados/test_osd_map_refresher.cc
 )
 
 target_link_libraries(test_blockaccess

--- a/test/unit/common/blockaccess/rados/test_osd_map_refresher.cc
+++ b/test/unit/common/blockaccess/rados/test_osd_map_refresher.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#include "common/blockaccess/rados/osd_map_refresher.h"
+
+namespace dingofs {
+namespace blockaccess {
+namespace {
+
+using namespace std::chrono_literals;
+
+TEST(OsdMapRefresherTest, DisabledDoesNotRun) {
+  std::atomic<uint64_t> calls{0};
+  OsdMapRefresher refresher(
+      {.enabled = false, .interval = 10ms, .jitter_pct = 0}, [&] {
+        ++calls;
+        return 0;
+      });
+
+  ASSERT_TRUE(refresher.Start());
+  std::this_thread::sleep_for(30ms);
+  refresher.Stop();
+
+  EXPECT_EQ(calls.load(), 0);
+}
+
+TEST(OsdMapRefresherTest, RefreshesImmediatelyAndPeriodically) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  uint64_t calls = 0;
+  OsdMapRefresher refresher(
+      {.enabled = true, .interval = 20ms, .jitter_pct = 0}, [&] {
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          ++calls;
+        }
+        cv.notify_all();
+        return 0;
+      });
+
+  ASSERT_TRUE(refresher.Start());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, 1s, [&] { return calls >= 2; }));
+  }
+  refresher.Stop();
+
+  EXPECT_GE(calls, 2);
+}
+
+TEST(OsdMapRefresherTest, StartIsIdempotent) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  uint64_t calls = 0;
+  OsdMapRefresher refresher({.enabled = true, .interval = 10s, .jitter_pct = 0},
+                            [&] {
+                              {
+                                std::lock_guard<std::mutex> lock(mutex);
+                                ++calls;
+                              }
+                              cv.notify_all();
+                              return 0;
+                            });
+
+  ASSERT_TRUE(refresher.Start());
+  ASSERT_TRUE(refresher.Start());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, 1s, [&] { return calls >= 1; }));
+  }
+  refresher.Stop();
+  refresher.Stop();
+
+  EXPECT_EQ(calls, 1);
+}
+
+TEST(OsdMapRefresherTest, StopInterruptsSleep) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  uint64_t calls = 0;
+
+  OsdMapRefresher refresher({.enabled = true, .interval = 10s, .jitter_pct = 0},
+                            [&] {
+                              {
+                                std::lock_guard<std::mutex> lock(mutex);
+                                ++calls;
+                              }
+                              cv.notify_all();
+                              return 0;
+                            });
+
+  ASSERT_TRUE(refresher.Start());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, 1s, [&] { return calls == 1; }));
+  }
+
+  const auto begin = std::chrono::steady_clock::now();
+  refresher.Stop();
+  const auto elapsed = std::chrono::steady_clock::now() - begin;
+
+  EXPECT_LT(elapsed, 1s);
+  EXPECT_EQ(calls, 1);
+}
+
+TEST(OsdMapRefresherTest, ContinuesAfterFailure) {
+  std::mutex mutex;
+  std::condition_variable cv;
+  uint64_t calls = 0;
+  OsdMapRefresher refresher(
+      {.enabled = true, .interval = 20ms, .jitter_pct = 0}, [&] {
+        uint64_t current;
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          current = ++calls;
+        }
+        cv.notify_all();
+        return current == 1 ? -EAGAIN : 0;
+      });
+
+  ASSERT_TRUE(refresher.Start());
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, 1s, [&] { return calls >= 2; }));
+  }
+  refresher.Stop();
+
+  EXPECT_GE(calls, 2);
+}
+
+}  // namespace
+}  // namespace blockaccess
+}  // namespace dingofs


### PR DESCRIPTION
## Problem

A long-idle RADOS client can retain a stale OSDMap. Its first I/O burst may target an old PG primary; the old OSD shares maps but can silently drop a misdirected write, leaving the op to hit `rados_osd_op_timeout`.

## Changes

- add one `OsdMapRefresher` thread per `RadosAccesser` / `rados_t`
- refresh immediately after startup and periodically afterwards
- add configurable interval and jitter to avoid synchronized MON requests
- serialize refreshes and coalesce explicit wakeups
- stop the refresher before `rados_shutdown()`
- expose refresh attempt/success/failure/running/latency/last-result metrics
- remove the Ceph secret from the RADOS initialization log
- add focused unit tests for disable, periodic refresh, wakeup, coalescing, and recovery after failure

## Validation

- `dingo-client` build: PASS
- `test_common`: 23/23 PASS
- `OsdMapRefresherTest`: 5/5 PASS
- `git diff --check`: PASS

## WIP / follow-up

- validate MON unavailable / delayed reply / EAGAIN behavior
- run the deterministic stale-OSDMap enable/disable comparison against the isolated Ceph pool
- consider wiring structured `ETIMEDOUT` to `RequestRefresh()`
- evaluate a cancellable librados latest-map API for bounded shutdown