### PR TITLE
[fix][client] Fix StateMachineImpl::Shutdown deadlock and DiskCacheManager CHECK crash

### DIFF
--- a/src/cache/iutil/state_machine_impl.cc
+++ b/src/cache/iutil/state_machine_impl.cc
@@ -67,14 +67,16 @@ bool StateMachineImpl::Start() {
 }
 
 bool StateMachineImpl::Shutdown() {
-  std::lock_guard<bthread::Mutex> lk(mutex_);
-
-  if (!running_.exchange(false)) {
-    LOG(WARNING) << "StateMachineImpl is already down";
-    return true;
+  {
+    std::lock_guard<bthread::Mutex> lk(mutex_);
+    if (!running_.exchange(false)) {
+      LOG(WARNING) << "StateMachineImpl is already down";
+      return true;
+    }
+    LOG(INFO) << "StateMachineImpl is shutting down...";
   }
-
-  LOG(INFO) << "StateMachineImpl is shutting down...";
+  // mutex_ released here — ProcessEvent can drain any queued StateEvent
+  // without deadlocking against our join.
 
   if (bthread::execution_queue_stop(disk_event_queue_id_) != 0) {
     LOG(ERROR) << "Fail to stop ExecutionQueue";

--- a/src/cache/local/disk_cache_manager.cc
+++ b/src/cache/local/disk_cache_manager.cc
@@ -255,8 +255,9 @@ bool DiskCacheManager::CacheFull() const {
 }
 
 void DiskCacheManager::CheckFreeSpace() {
-  CHECK_RUNNING("Disk cache manager");
-
+  if (!running_.load(std::memory_order_relaxed)) {
+    return;
+  }
   struct iutil::StatFS stat;
   uint64_t want_free_bytes, want_free_files;
   std::string root_dir = GetRootDir();
@@ -353,8 +354,12 @@ void DiskCacheManager::CleanupAllShardsFull(uint64_t want_free_bytes,
 }
 
 void DiskCacheManager::CleanupExpire() {
-  CHECK_RUNNING("Disk cache manager");
-
+  // Background task that may be dequeued after Shutdown() because
+  // TaskThreadPool::Take() returns queued tasks even when the pool is
+  // stopping.  Exit gracefully instead of CHECK-failing.
+  if (!running_.load(std::memory_order_relaxed)) {
+    return;
+  }
   // per-shard scan cap keeps the total budget on par with the pre-shard 1e3
   const uint64_t budget = static_cast<uint64_t>(1e3 / kShardCount) + 1;
 


### PR DESCRIPTION
## What

Two independent bugs found during shutdown-path code review (triggered by [dingo-client SIGSEGV analysis](https://github.com/dingodb/dingofs/blob/main/docs/issues/shutdown-segv-20260803.md)):

1. **StateMachineImpl::Shutdown() deadlock** — `Shutdown()` holds `mutex_` while calling `execution_queue_join()`, but `ProcessEvent()` (drained by the queue) also needs `mutex_`. Classic lock-reversal deadlock when StateEvents are still queued at shutdown time.

2. **DiskCacheManager CHECK_RUNNING crash** — `TaskThreadPool::Stop()` does not drain its queue; workers execute remaining tasks after `running_` is set to false. `CleanupExpire()` and `CheckFreeSpace()` use `CHECK_RUNNING`, which aborts (SIGABRT) in this window.

## Changes

- `src/cache/iutil/state_machine_impl.cc`: Release `mutex_` before `execution_queue_stop/join` — `ProcessEvent` can drain queued events without deadlock.
- `src/cache/local/disk_cache_manager.cc`: Replace `CHECK_RUNNING` with early-return in `CleanupExpire()` and `CheckFreeSpace()` — safe no-op when manager is already shutting down.

## Test

- `DiskHealthChecker*`: 5/5 PASS
- `DiskCacheManagerTest.StartAndShutdownIdempotent`: 10/10 PASS (stable crash before fix)
- `LocalFileSystem*` + `DiskCacheWatcher*`: 4/4 PASS
- `DiskCacheManagerTest.*` (all 19): 18/19 PASS (1 pre-existing flaky `EvictionIsPerShardIndependent`, same rate on unmodified code)