### PR TITLE
feat(client): roll back file length after flush failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ bench_results/
 .issue/
 
 CONTEXT.md
+.pi-subagents/

--- a/docs/adr/0003-flush-failure-length-rollback.md
+++ b/docs/adr/0003-flush-failure-length-rollback.md
@@ -1,0 +1,49 @@
+# 数据 flush 失败时条件式回退文件长度，而非撤销写入
+
+数据 flush（`FileWriter::Flush`）失败时，客户端把 MDS 上的 `attr.length` 回退到 Flush 检查点
+（本次 open 会话中最近一次 flush 成功时的长度，从未成功过则为 open 时的长度），即放弃这轮写。
+我们**只回退长度**：不撤销已通过 WriteSlice 提交的 slices、不回滚 overwrite 内容——完整撤销需要
+快照级机制，成本不成比例；被截掉的悬挂 slice 数据留给 compaction 清理。
+
+回退通过**扩展 FlushFile RPC**（rollback 标志 + checkpoint 长度）在 MDS 事务内条件执行：
+仅当 `checkpoint < 当前 attr.length <= 本会话最后写长度` 时收缩。之所以必须条件式且在 MDS
+侧原子执行，是因为 WriteSlice（`UpsertChunkOperation`）也会推大持久化长度，而并发写者可能
+已把长度合法推进——无条件回退会砍掉别人已持久化的数据。我们只保证单写者正确性；多写者场景
+保守放弃回退（残留 sparse 空洞，无数据损坏）。
+
+其他刻意的取舍：
+
+- **触发点仅限用户可见路径**（`VFSImpl::Flush` / `VFSImpl::Release`）。后台周期 flush 失败经
+  sticky-broken 传导，在下一次用户可见 Flush/Release 时兜住。
+- **尽力而为，无重试状态机**。每个用户可见失败点独立尝试一次回退；最终失败只记日志 + metric，
+  用户仍收到原始 flush 错误。
+- **回退不复位 writer**。sticky-broken 语义保持，用户必须重新 open 才能继续写（POSIX 应用对
+  fsync 失败的标准应对，参见 fsync-gate）。
+- **检查点由客户端维护**（file_session/ChunkSet），MDS 不新增 session 状态；客户端缓存过期的
+  风险由条件式回退兜住。
+- 复用 FlushFile 而非新增 RPC：复用现有 shrink 后处理链路（chunk 缓存失效、attr 回传）；
+  proto3 默认值 0 作"未启用"哨兵，"截断到 0"由 rollback 标志区分。
+
+## 术语（写入与长度）
+
+**MDS 持久化长度（Durable Length）**:
+MDS 后端 inode `attr.length`。由 WriteSlice（`UpsertChunkOperation`，随 slice 提交推大）和
+FlushFile 前移；SetAttr/truncate 可收缩。
+
+**写长度备忘（Write Memo）**:
+客户端 `chunk_set->last_write_length`，在 `MetaSystem::Write` 时即更新（数据可能仍只在客户端
+内存）。GetAttr 用 `max(memo, attr.length)` 撑大内核可见长度。
+
+**Flush 检查点（Flush Checkpoint）**:
+某个 open 写会话中，最近一次数据 flush 完整成功时的文件长度；open 后从未成功过则为 open 时的
+长度。由客户端在 file_session/ChunkSet 维护。长度回退的目标值。
+
+**长度回退（Length Rollback）**:
+数据 flush（`FileWriter::Flush`）失败时，把 MDS 持久化长度条件式收缩到 Flush 检查点，即放弃
+这轮写。只回退长度，不撤销已提交的 slices、不回滚 overwrite 内容。条件式：仅当
+`checkpoint < 当前length <= 本会话最后写长度` 时收缩（单写者正确；多写者保守放弃）。仅在
+用户可见失败点（Flush/Release）触发，尽力而为不重试。
+
+**Sticky-broken**:
+`FileWriter` 一旦 flush 失败即永久置坏，该 fh 上后续 Write/Flush 均返回该错误；长度回退后
+依然保持，用户须重新 open 才能继续写。

--- a/docs/adr/0003-flush-failure-length-rollback.md
+++ b/docs/adr/0003-flush-failure-length-rollback.md
@@ -2,8 +2,9 @@
 
 数据 flush（`FileWriter::Flush`）失败时，客户端把 MDS 上的 `attr.length` 回退到 Flush 检查点
 （本次 open 会话中最近一次 flush 成功时的长度，从未成功过则为 open 时的长度），即放弃这轮写。
-我们**只回退长度**：不撤销已通过 WriteSlice 提交的 slices、不回滚 overwrite 内容——完整撤销需要
-快照级机制，成本不成比例；被截掉的悬挂 slice 数据留给 compaction 清理。
+我们不删除或物理撤销已通过 WriteSlice 提交的 slices，也不回滚 overwrite 内容——完整撤销需要
+快照级机制，成本不成比例。MDS 在回退长度的同一事务中，为收缩区间追加零 slice，确保文件随后
+重新扩展时不会暴露被截掉的数据；旧物理 slice 留给 compaction/GC 清理。
 
 回退通过**扩展 FlushFile RPC**（rollback 标志 + checkpoint 长度）在 MDS 事务内条件执行：
 仅当 `checkpoint < 当前 attr.length <= 本会话最后写长度` 时收缩。之所以必须条件式且在 MDS
@@ -23,6 +24,9 @@
   风险由条件式回退兜住。
 - 复用 FlushFile 而非新增 RPC：复用现有 shrink 后处理链路（chunk 缓存失效、attr 回传）；
   proto3 默认值 0 作"未启用"哨兵，"截断到 0"由 rollback 标志区分。
+- 收缩范围由 MDS 事务内读取的权威旧长度决定。零 slice 与 inode 长度原子提交，只修改收缩范围内
+  已存在的 chunk（缺失 chunk 本身就是 hole）；事务无法容纳全部更新时整体失败，不做分批补偿。
+- 收缩成功或 RPC 返回提交状态不确定的网络错误时，客户端保守失效 inode、chunk 和 read cache。
 
 ## 术语（写入与长度）
 
@@ -40,7 +44,8 @@ FlushFile 前移；SetAttr/truncate 可收缩。
 
 **长度回退（Length Rollback）**:
 数据 flush（`FileWriter::Flush`）失败时，把 MDS 持久化长度条件式收缩到 Flush 检查点，即放弃
-这轮写。只回退长度，不撤销已提交的 slices、不回滚 overwrite 内容。条件式：仅当
+这轮写。不物理撤销已提交的 slices，也不回滚 overwrite 内容；通过零 slice 保证被收缩的数据不会
+在重新扩展后恢复。条件式：仅当
 `checkpoint < 当前length <= 本会话最后写长度` 时收缩（单写者正确；多写者保守放弃）。仅在
 用户可见失败点（Flush/Release）触发，尽力而为不重试。
 

--- a/src/client/vfs/metasystem/local/metasystem.cc
+++ b/src/client/vfs/metasystem/local/metasystem.cc
@@ -1066,6 +1066,16 @@ Status LocalMetaSystem::SetAttr(ContextSPtr, Ino ino, int to_set,
     if (to_set & kSetAttrGid) {
       attr_entry.set_gid(in_attr.gid);
     }
+    if (to_set & (kSetAttrKillSuid | kSetAttrKillSgid | kSetAttrKillPriv)) {
+      uint32_t mode = attr_entry.mode();
+      if (to_set & (kSetAttrKillSuid | kSetAttrKillPriv)) {
+        mode &= ~S_ISUID;
+      }
+      if (to_set & (kSetAttrKillSgid | kSetAttrKillPriv)) {
+        mode &= ~S_ISGID;
+      }
+      attr_entry.set_mode(mode);
+    }
 
     struct timespec now;
     CHECK(clock_gettime(CLOCK_REALTIME, &now) == 0) << "get current time fail.";

--- a/src/client/vfs/metasystem/mds/chunk.h
+++ b/src/client/vfs/metasystem/mds/chunk.h
@@ -311,6 +311,27 @@ class ChunkSet {
     utils::WriteLockGuard lk(lock_);
     last_write_length_ = 0;
   }
+
+  // flush checkpoint (ADR-0003): file length at open, advanced on each
+  // successful data+length flush; rollback target on data-flush failure.
+  // InitFlushCheckpoint only takes effect once per ChunkSet lifetime so a
+  // later open (e.g. a reader) cannot move the writer's rollback target.
+  void InitFlushCheckpoint(uint64_t length) {
+    utils::WriteLockGuard lk(lock_);
+    if (!flush_checkpoint_inited_) {
+      flush_checkpoint_inited_ = true;
+      flush_checkpoint_length_ = length;
+    }
+  }
+  void SetFlushCheckpoint(uint64_t length) {
+    utils::WriteLockGuard lk(lock_);
+    flush_checkpoint_inited_ = true;
+    flush_checkpoint_length_ = length;
+  }
+  uint64_t GetFlushCheckpoint() const {
+    utils::ReadLockGuard guard(lock_);
+    return flush_checkpoint_length_;
+  }
   uint64_t GetLastWriteLength() const {
     utils::ReadLockGuard guard(lock_);
     return last_write_length_;
@@ -400,6 +421,9 @@ class ChunkSet {
   // record write file length by write operation
   uint64_t last_write_length_{0};
   uint64_t last_write_time_ns_{0};
+  // ADR-0003 flush checkpoint, protected by lock_
+  bool flush_checkpoint_inited_{false};
+  uint64_t flush_checkpoint_length_{0};
 
   // chunk index -> chunk
   absl::flat_hash_map<uint32_t, ChunkSPtr> chunk_map_;

--- a/src/client/vfs/metasystem/mds/file_session.cc
+++ b/src/client/vfs/metasystem/mds/file_session.cc
@@ -85,6 +85,19 @@ uint32_t FileSession::DeleteSession(uint64_t fh) {
   return DecRef();
 }
 
+bool FileSession::HasMultipleWriters() {
+  utils::ReadLockGuard lk(lock_);
+
+  uint32_t writer_count = 0;
+  for (const auto& [_, session_info] : session_id_map_) {
+    if ((session_info.flags & O_ACCMODE) != O_RDONLY) {
+      if (++writer_count > 1) return true;
+    }
+  }
+
+  return false;
+}
+
 void FileSession::InvalidateReadCache(bool just_readonly) {
   utils::WriteLockGuard lk(lock_);
 

--- a/src/client/vfs/metasystem/mds/file_session.cc
+++ b/src/client/vfs/metasystem/mds/file_session.cc
@@ -312,6 +312,20 @@ FileSessionMap::GetNeedKeepAliveSession() {
   return file_session_id_map;
 }
 
+bool FileSessionMap::HasSession(Ino ino) {
+  CHECK(ino != 0) << "ino is zero.";
+
+  bool has_session = false;
+  shard_map_.withRLock(
+      [this, ino, &has_session](Map& map) {
+        auto it = map.find(ino);
+        if (it != map.end()) has_session = true;
+      },
+      ino);
+
+  return has_session;
+}
+
 size_t FileSessionMap::Size() {
   size_t size = 0;
   shard_map_.iterate([&size](Map& map) { size += map.size(); });

--- a/src/client/vfs/metasystem/mds/file_session.h
+++ b/src/client/vfs/metasystem/mds/file_session.h
@@ -121,6 +121,7 @@ class FileSessionMap {
   FileSessionSPtr GetSession(Ino ino);
   std::vector<FileSessionSPtr> GetAllSession();
   std::map<Ino, std::vector<std::string>> GetNeedKeepAliveSession();
+  bool HasSession(Ino ino);
 
   size_t Size();
   size_t Bytes();

--- a/src/client/vfs/metasystem/mds/file_session.h
+++ b/src/client/vfs/metasystem/mds/file_session.h
@@ -68,6 +68,8 @@ class FileSession {
   void AddSession(uint64_t fh, const std::string& session_id, uint32_t flags);
   uint32_t DeleteSession(uint64_t fh);
 
+  bool HasMultipleWriters();
+
   void InvalidateReadCache(bool just_readonly);
 
   size_t Size();

--- a/src/client/vfs/metasystem/mds/mds_client.cc
+++ b/src/client/vfs/metasystem/mds/mds_client.cc
@@ -821,6 +821,47 @@ Status MDSClient::FlushFile(ContextSPtr& ctx, Ino ino, uint64_t length,
   return status;
 }
 
+Status MDSClient::RollbackFileLength(ContextSPtr& ctx, Ino ino,
+                                     uint64_t last_write_length,
+                                     uint64_t rollback_to_length,
+                                     AttrEntry& attr_entry,
+                                     bool& shrink_file) {
+  CHECK(fs_id_ != 0) << "fs_id is invalid.";
+
+  auto get_mds_fn = [this, ino](bool& is_primary_mds) -> MDSMeta {
+    return GetMds(ino, is_primary_mds);
+  };
+
+  auto span = trace_manager_.StartChildSpan("MDSClient::RollbackFileLength",
+                                            ctx->GetTraceSpan());
+
+  pb::mds::FlushFileRequest request;
+  pb::mds::FlushFileResponse response;
+
+  SetAncestorInContext(request, ino);
+
+  request.set_fs_id(fs_id_);
+  request.set_ino(ino);
+  request.set_length(last_write_length);
+  request.set_rollback(true);
+  request.set_rollback_to_length(rollback_to_length);
+
+  auto status = SendRequest(SpanScope::GetContext(span, ctx), span, get_mds_fn,
+                            "MDSService", "FlushFile", request, response);
+
+  if (!status.ok()) {
+    SpanScope::SetStatus(span, status);
+    return status;
+  }
+
+  parent_memo_.UpsertVersion(ino, response.inode().version());
+
+  attr_entry.Swap(response.mutable_inode());
+  shrink_file = response.shrink_file();
+
+  return status;
+}
+
 Status MDSClient::Link(ContextSPtr& ctx, Ino ino, Ino new_parent,
                        const std::string& new_name, AttrEntry& attr_entry,
                        AttrEntry& parent_attr_entry) {

--- a/src/client/vfs/metasystem/mds/mds_client.cc
+++ b/src/client/vfs/metasystem/mds/mds_client.cc
@@ -824,8 +824,7 @@ Status MDSClient::FlushFile(ContextSPtr& ctx, Ino ino, uint64_t length,
 Status MDSClient::RollbackFileLength(ContextSPtr& ctx, Ino ino,
                                      uint64_t last_write_length,
                                      uint64_t rollback_to_length,
-                                     AttrEntry& attr_entry,
-                                     bool& shrink_file) {
+                                     AttrEntry& attr_entry, bool& shrink_file) {
   CHECK(fs_id_ != 0) << "fs_id is invalid.";
 
   auto get_mds_fn = [this, ino](bool& is_primary_mds) -> MDSMeta {
@@ -1177,6 +1176,9 @@ Status MDSClient::SetAttr(ContextSPtr& ctx, Ino ino, const Attr& attr,
     request.set_flags(attr.flags);
     temp_to_set |= kSetAttrFlags;
   }
+
+  temp_to_set |=
+      to_set & (kSetAttrKillSuid | kSetAttrKillSgid | kSetAttrKillPriv);
 
   request.set_to_set(temp_to_set);
 

--- a/src/client/vfs/metasystem/mds/mds_client.cc
+++ b/src/client/vfs/metasystem/mds/mds_client.cc
@@ -1721,7 +1721,7 @@ bool MDSClient::UpdateRouter() {
 
   fs_info_.Update(new_fs_info);
 
-  if (!mds_discovery_.RefreshFullyMDSList()) {
+  if (!mds_discovery_.RefreshFullyMDSList(true)) {
     LOG(ERROR) << "[meta.client] refresh mds discovery fail.";
     return false;
   }
@@ -1749,12 +1749,13 @@ void MDSClient::ProcessNotServe() {
   }
 }
 
-void MDSClient::ProcessNetError(MDSMeta& mds_meta) {
+bool MDSClient::ProcessNetError(MDSMeta& mds_meta) {
   // set the current mds as abnormal
   mds_discovery_.SetAbnormalMDS(mds_meta.ID());
 
+  uint64_t old_mds_id = mds_meta.ID();
   // get a normal mds
-  auto mdses = mds_discovery_.GetNormalMDS();
+  auto mdses = mds_discovery_.GetNormalMDS(false);
   for (auto& mds : mdses) {
     if (mds.ID() != mds_meta.ID()) {
       LOG(INFO) << fmt::format(
@@ -1764,6 +1765,8 @@ void MDSClient::ProcessNetError(MDSMeta& mds_meta) {
       break;
     }
   }
+
+  return old_mds_id != mds_meta.ID();
 }
 
 }  // namespace meta

--- a/src/client/vfs/metasystem/mds/mds_client.h
+++ b/src/client/vfs/metasystem/mds/mds_client.h
@@ -149,6 +149,14 @@ class MDSClient {
   Status FlushFile(ContextSPtr& ctx, Ino ino, uint64_t length,
                    AttrEntry& attr_entry, bool& shrink_file);
 
+  // conditional length rollback on data-flush failure (ADR-0003): shrink to
+  // rollback_to_length iff rollback_to_length < current length <=
+  // last_write_length.
+  Status RollbackFileLength(ContextSPtr& ctx, Ino ino,
+                            uint64_t last_write_length,
+                            uint64_t rollback_to_length, AttrEntry& attr_entry,
+                            bool& shrink_file);
+
   Status Link(ContextSPtr& ctx, Ino ino, Ino new_parent,
               const std::string& new_name, AttrEntry& attr_entry,
               AttrEntry& parent_attr_entry);

--- a/src/client/vfs/metasystem/mds/mds_client.h
+++ b/src/client/vfs/metasystem/mds/mds_client.h
@@ -264,7 +264,7 @@ class MDSClient {
 
   void ProcessEpochChange();
   void ProcessNotServe();
-  void ProcessNetError(MDSMeta& mds_meta);
+  bool ProcessNetError(MDSMeta& mds_meta);
 
   template <typename Request>
   void SetAncestorInContext(Request& request, Ino ino);
@@ -362,7 +362,9 @@ Status MDSClient::SendRequest(ContextSPtr ctx, SpanScopeSPtr& span,
         continue;
 
       } else if (status.IsNetError()) {
-        ProcessNetError(mds_meta);
+        if (!ProcessNetError(mds_meta)) {
+          return Status::NetError("no normal mds available");
+        }
 
         is_primary_mds =
             (primary_mds_id != 0 && mds_meta.ID() == primary_mds_id);

--- a/src/client/vfs/metasystem/mds/mds_discovery.cc
+++ b/src/client/vfs/metasystem/mds/mds_discovery.cc
@@ -30,7 +30,7 @@ namespace meta {
 
 static const uint32_t kWaitTimeMs = 100;
 
-bool MDSDiscovery::Init() { return RefreshFullyMDSList(); }
+bool MDSDiscovery::Init() { return RefreshFullyMDSList(true); }
 
 void MDSDiscovery::Stop() {
   stopped_.store(true);
@@ -53,34 +53,6 @@ bool MDSDiscovery::GetMDS(int64_t mds_id, mds::MDSMeta& mds_meta) {
   mds_meta = it->second;
 
   return true;
-}
-
-void MDSDiscovery::PickFirstMDS(mds::MDSMeta& mds_meta) {
-  IncActiveCount();
-  mds::DEFER(DecActiveCount());
-
-  do {
-    if (IsStop()) {
-      LOG(INFO) << "[meta.discovery] stop pick first mds.";
-      return;
-    }
-
-    {
-      utils::ReadLockGuard lk(lock_);
-
-      for (auto& [_, mds] : mdses_) {
-        if (mds.GetState() == mds::MDSMeta::State::kNormal) {
-          mds_meta = mds;
-          return;
-        }
-      }
-    }
-
-    LOG(INFO) << "[meta.discovery] not pick normal mds, try refresh mds list.";
-
-    RefreshFullyMDSList();
-
-  } while (true);
 }
 
 std::vector<mds::MDSMeta> MDSDiscovery::GetAllMDS() {
@@ -114,27 +86,32 @@ std::vector<mds::MDSMeta> MDSDiscovery::GetNormalMDS(bool force) {
   IncActiveCount();
   mds::DEFER(DecActiveCount());
 
-  for (;;) {
-    if (IsStop()) {
-      LOG(INFO) << "[meta.discovery] stop get normal mds.";
-      return {};
-    }
-
-    auto mdses = GetMDSByState(mds::MDSMeta::State::kNormal);
-    if (!force) return mdses;
-    if (!mdses.empty()) return mdses;
-
-    RefreshFullyMDSList();
+  if (IsStop()) {
+    LOG(INFO) << "[meta.discovery] stop get normal mds.";
+    return {};
   }
+
+  auto mdses = GetMDSByState(mds::MDSMeta::State::kNormal);
+  if (!mdses.empty()) return mdses;
+
+  RefreshFullyMDSList(force);
+
+  return GetMDSByState(mds::MDSMeta::State::kNormal);
 }
 
-Status MDSDiscovery::GetMDSList(std::vector<mds::MDSMeta>& mdses) {
+Status MDSDiscovery::GetMDSList(std::vector<mds::MDSMeta>& mdses,
+                                const std::string& reason) {
   pb::mds::GetMDSListRequest request;
   pb::mds::GetMDSListResponse response;
 
   request.mutable_info()->set_request_id(std::to_string(utils::TimestampNs()));
 
+  LOG(INFO) << fmt::format(
+      "[meta.discovery] get mds list, requestid({}) reason({}).",
+      request.info().request_id(), reason);
+
   auto status = rpc_.SendRequest("MDSService", "GetMDSList", request, response);
+
   if (!status.ok()) return status;
 
   mdses.reserve(response.mdses_size());
@@ -154,19 +131,19 @@ void MDSDiscovery::SetAbnormalMDS(int64_t mds_id) {
   }
 }
 
-bool MDSDiscovery::RefreshFullyMDSList() {
+bool MDSDiscovery::RefreshFullyMDSList(bool force) {
   IncActiveCount();
   mds::DEFER(DecActiveCount());
 
   uint64_t retries = 0;
   std::vector<mds::MDSMeta> mdses;
-  for (;;) {
+  do {
     if (IsStop()) {
       LOG(INFO) << "[meta.discovery] stop refresh fully mds list.";
       return false;
     }
 
-    auto status = GetMDSList(mdses);
+    auto status = GetMDSList(mdses, "refresh_fully_mds");
 
     LOG(INFO) << fmt::format(
         "[meta.discovery] get mds list finish, retries({}) error({}).", retries,
@@ -176,7 +153,8 @@ bool MDSDiscovery::RefreshFullyMDSList() {
 
     bthread_usleep(kWaitTimeMs * 1000);
     ++retries;
-  }
+
+  } while (force);
 
   {
     utils::WriteLockGuard lk(lock_);

--- a/src/client/vfs/metasystem/mds/mds_discovery.h
+++ b/src/client/vfs/metasystem/mds/mds_discovery.h
@@ -38,13 +38,12 @@ class MDSDiscovery {
   void Stop();
 
   bool GetMDS(int64_t mds_id, mds::MDSMeta& mds_meta);
-  void PickFirstMDS(mds::MDSMeta& mds_meta);
   std::vector<mds::MDSMeta> GetAllMDS();
   std::vector<mds::MDSMeta> GetMDSByState(mds::MDSMeta::State state);
-  std::vector<mds::MDSMeta> GetNormalMDS(bool force = true);
+  std::vector<mds::MDSMeta> GetNormalMDS(bool force);
 
   void SetAbnormalMDS(int64_t mds_id);
-  bool RefreshFullyMDSList();
+  bool RefreshFullyMDSList(bool force = true);
 
   size_t Size();
   size_t Bytes();
@@ -65,7 +64,8 @@ class MDSDiscovery {
 
   bool IsStop() { return stopped_.load(std::memory_order_acquire); }
 
-  Status GetMDSList(std::vector<mds::MDSMeta>& mdses);
+  Status GetMDSList(std::vector<mds::MDSMeta>& mdses,
+                    const std::string& reason);
 
   utils::RWLock lock_;
   // mds_id -> MDSMeta

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -700,7 +700,7 @@ Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
   // update chunk cache
   auto& chunk_set = file_session->GetChunkSet();
   if (flags & O_TRUNC) {
-    InvalidateLengthShrinkCache(ino, false);
+    InvalidateLengthShrinkCache(ino, false, "open_trunc");
     chunk_set->ResetLastWriteLength();
     chunk_set->SetFlushCheckpoint(0);
   } else {
@@ -832,7 +832,7 @@ Status MDSMetaSystem::Open(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
     LOG(ERROR) << fmt::format("[meta.fs.{}.{}] open file fail, error({}).", ino,
                               fh, status.ToString());
     if (flags & O_TRUNC) {
-      InvalidateLengthShrinkCache(ino, status);
+      InvalidateLengthShrinkCache(ino, status, "open_trunc");
       if (status.IsNetError()) *keep_cache = false;
     }
     file_session_map_.Delete(ino, fh);
@@ -925,7 +925,7 @@ Status MDSMetaSystem::RollbackWriteLength(ContextSPtr ctx, Ino ino,
       ctx, ino, last_write_length, checkpoint, attr_entry, shrink_file);
   // Invalidate even when the response says no shrink: an earlier timed-out
   // attempt may have committed and the RPC retry then observed the checkpoint.
-  InvalidateLengthShrinkCache(ino, status);
+  InvalidateLengthShrinkCache(ino, status, "rollback_write_length");
   if (!status.ok()) {
     LOG(ERROR) << fmt::format(
         "[meta.fs.{}.{}] rollback write length fail, checkpoint({}) "
@@ -1517,7 +1517,8 @@ Status MDSMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
   // Invalidate on every successful size setattr (a timed-out attempt may have
   // committed a shrink while the successful retry reports it as a no-op) and
   // on commit-ambiguous network errors.
-  if (set & kSetAttrSize) InvalidateLengthShrinkCache(ino, status);
+  if (set & kSetAttrSize)
+    InvalidateLengthShrinkCache(ino, status, "setattr_length");
   if (!status.ok()) {
     return status;
   }
@@ -1797,7 +1798,7 @@ Status MDSMetaSystem::DoFlushFile(ContextSPtr ctx, InodeSPtr inode,
   chunk_set->SetFlushCheckpoint(last_write_length);
 
   modify_time_memo_.Remember(ino);
-  if (shrink_file) InvalidateLengthShrinkCache(ino, false);
+  if (shrink_file) InvalidateLengthShrinkCache(ino, false, "flush_file");
 
   PutInodeToCache(attr_entry);
 
@@ -1989,8 +1990,13 @@ void MDSMetaSystem::InvalidateFileSessionReadCache(Ino ino) {
   if (file_session != nullptr) file_session->InvalidateReadCache(true);
 }
 
-void MDSMetaSystem::InvalidateLengthShrinkCache(Ino ino,
-                                                bool invalidate_inode) {
+void MDSMetaSystem::InvalidateLengthShrinkCache(Ino ino, bool invalidate_inode,
+                                                const std::string& reason) {
+  LOG_DEBUG << fmt::format(
+      "[meta.fs.{}] invalidate length shrink cache, invalidate_inode({}) "
+      "reason({}).",
+      ino, invalidate_inode, reason);
+
   chunk_memo_.Forget(ino);
 
   auto file_session = file_session_map_.GetSession(ino);
@@ -2003,12 +2009,12 @@ void MDSMetaSystem::InvalidateLengthShrinkCache(Ino ino,
 // conservatively but keep the inode (caller refreshes it from the RPC attr);
 // on a commit-ambiguous network error also drop the cached inode since the
 // shrink may have committed server-side. Other errors need no invalidation.
-void MDSMetaSystem::InvalidateLengthShrinkCache(Ino ino,
-                                                const Status& status) {
+void MDSMetaSystem::InvalidateLengthShrinkCache(Ino ino, const Status& status,
+                                                const std::string& reason) {
   if (status.ok()) {
-    InvalidateLengthShrinkCache(ino, /*invalidate_inode=*/false);
+    InvalidateLengthShrinkCache(ino, /*invalidate_inode=*/false, reason);
   } else if (status.IsNetError()) {
-    InvalidateLengthShrinkCache(ino, /*invalidate_inode=*/true);
+    InvalidateLengthShrinkCache(ino, /*invalidate_inode=*/true, reason);
   }
 }
 

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -594,6 +594,7 @@ Status MDSMetaSystem::Create(ContextSPtr ctx, Ino parent,
   auto file_session =
       file_session_map_.Put(attr_entry.ino(), fh, session_id, flags);
   file_session->SetInode(inode);
+  file_session->GetChunkSet()->InitFlushCheckpoint(inode->Length());
 
   modify_time_memo_.UpdateKernelMtime(attr->ino, attr->mtime);
 
@@ -674,9 +675,8 @@ Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
 
   AttrEntry attr_entry;
   std::vector<mds::ChunkEntry> chunks;
-  auto status = mds_client_.Open(ctx, ino, flags, session_id,
-                                 is_prefetch_chunk, chunk_descriptors,
-                                 attr_entry, chunks);
+  auto status = mds_client_.Open(ctx, ino, flags, session_id, is_prefetch_chunk,
+                                 chunk_descriptors, attr_entry, chunks);
 
   LOG_DEBUG << fmt::format(
       "[meta.fs.{}.{}] open file flags({:o}:{}) session_id({}) "
@@ -702,6 +702,9 @@ Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
   if (flags & O_TRUNC) {
     chunk_memo_.Forget(ino);
     chunk_set->ResetLastWriteLength();
+    chunk_set->SetFlushCheckpoint(0);
+  } else {
+    chunk_set->InitFlushCheckpoint(inode->Length());
   }
   if (!chunks.empty()) chunk_set->Put(chunks, "open");
 
@@ -796,6 +799,10 @@ Status MDSMetaSystem::Open(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
 
   const std::string session_id = utils::GenerateUUID();
   auto file_session = file_session_map_.Put(ino, fh, session_id, flags);
+  if (file_session->HasMultipleWriters()) {
+    LOG(ERROR) << fmt::format("[meta.fs.{}.{}] open file has multiple writers.",
+                              ino, fh);
+  }
 
   auto inode = GetInodeFromCache(ino);
   if (inode != nullptr) {
@@ -808,6 +815,7 @@ Status MDSMetaSystem::Open(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
     file_session->SetInode(inode);
 
     if (!(flags & O_TRUNC)) {
+      file_session->GetChunkSet()->InitFlushCheckpoint(inode->Length());
       // launch async open
       AsyncOpen(ctx, ino, flags, fh, session_id, file_session);
 
@@ -877,6 +885,55 @@ Status MDSMetaSystem::Flush(ContextSPtr ctx, Ino ino, uint64_t fh) {
   }
 
   return FlushSliceAndFile(ctx, ino);
+}
+
+Status MDSMetaSystem::RollbackWriteLength(ContextSPtr ctx, Ino ino,
+                                          uint64_t fh) {
+  AssertStop();
+
+  auto file_session = file_session_map_.GetSession(ino);
+  if (file_session == nullptr) {
+    LOG(WARNING) << fmt::format(
+        "[meta.fs.{}.{}] rollback skipped, no file session.", ino, fh);
+    return Status::OK();
+  }
+
+  auto& chunk_set = file_session->GetChunkSet();
+  const uint64_t checkpoint = chunk_set->GetFlushCheckpoint();
+  const uint64_t last_write_length = chunk_set->GetLastWriteLength();
+
+  // nothing pushed beyond the checkpoint in this session -- nothing to undo.
+  if (last_write_length == 0 || last_write_length <= checkpoint) {
+    LOG_DEBUG << fmt::format(
+        "[meta.fs.{}.{}] rollback skipped, write({}) checkpoint({}).", ino, fh,
+        last_write_length, checkpoint);
+    return Status::OK();
+  }
+
+  LOG(WARNING) << fmt::format(
+      "[meta.fs.{}.{}] rollback write length, write({}) -> checkpoint({}).",
+      ino, fh, last_write_length, checkpoint);
+
+  AttrEntry attr_entry;
+  bool shrink_file = false;
+  auto status = mds_client_.RollbackFileLength(
+      ctx, ino, last_write_length, checkpoint, attr_entry, shrink_file);
+  if (!status.ok()) {
+    LOG(ERROR) << fmt::format(
+        "[meta.fs.{}.{}] rollback write length fail, checkpoint({}) "
+        "error({}).",
+        ino, fh, checkpoint, status.ToString());
+    return status;
+  }
+
+  // discard the write memo so GetAttr no longer inflates the kernel-visible
+  // length with abandoned writes.
+  chunk_set->ResetLastWriteLength();
+  if (shrink_file) chunk_memo_.Forget(ino);
+
+  PutInodeToCache(attr_entry);
+
+  return Status::OK();
 }
 
 void MDSMetaSystem::AsyncClose(ContextSPtr ctx, Ino ino, uint64_t fh,
@@ -1718,14 +1775,17 @@ Status MDSMetaSystem::DoFlushFile(ContextSPtr ctx, InodeSPtr inode,
 
   AttrEntry attr_entry;
   bool shrink_file;
-  auto status = mds_client_.FlushFile(ctx, ino, last_write_length,
-                                      attr_entry, shrink_file);
+  auto status = mds_client_.FlushFile(ctx, ino, last_write_length, attr_entry,
+                                      shrink_file);
   if (!status.ok()) {
     LOG(ERROR) << fmt::format(
         "[meta.fs.{}] flush file fail, length({}) error({}).", ino,
         last_write_length, status.ToString());
     return status;
   }
+
+  // advance flush checkpoint (ADR-0003): data and length are both durable now.
+  chunk_set->SetFlushCheckpoint(last_write_length);
 
   modify_time_memo_.Remember(ino);
   if (shrink_file) chunk_memo_.Forget(ino);

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -700,7 +700,7 @@ Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
   // update chunk cache
   auto& chunk_set = file_session->GetChunkSet();
   if (flags & O_TRUNC) {
-    chunk_memo_.Forget(ino);
+    InvalidateLengthShrinkCache(ino, false);
     chunk_set->ResetLastWriteLength();
     chunk_set->SetFlushCheckpoint(0);
   } else {
@@ -831,9 +831,14 @@ Status MDSMetaSystem::Open(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
   if (!status.ok()) {
     LOG(ERROR) << fmt::format("[meta.fs.{}.{}] open file fail, error({}).", ino,
                               fh, status.ToString());
+    if (flags & O_TRUNC) {
+      InvalidateLengthShrinkCache(ino, status);
+      if (status.IsNetError()) *keep_cache = false;
+    }
     file_session_map_.Delete(ino, fh);
 
   } else {
+    if (flags & O_TRUNC) *keep_cache = false;
     auto inode = GetInodeFromCache(ino);
     if (inode == nullptr ||
         inode->Mtime() > modify_time_memo_.GetKernelMtime(ino)) {
@@ -918,6 +923,9 @@ Status MDSMetaSystem::RollbackWriteLength(ContextSPtr ctx, Ino ino,
   bool shrink_file = false;
   auto status = mds_client_.RollbackFileLength(
       ctx, ino, last_write_length, checkpoint, attr_entry, shrink_file);
+  // Invalidate even when the response says no shrink: an earlier timed-out
+  // attempt may have committed and the RPC retry then observed the checkpoint.
+  InvalidateLengthShrinkCache(ino, status);
   if (!status.ok()) {
     LOG(ERROR) << fmt::format(
         "[meta.fs.{}.{}] rollback write length fail, checkpoint({}) "
@@ -929,7 +937,6 @@ Status MDSMetaSystem::RollbackWriteLength(ContextSPtr ctx, Ino ino,
   // discard the write memo so GetAttr no longer inflates the kernel-visible
   // length with abandoned writes.
   chunk_set->ResetLastWriteLength();
-  if (shrink_file) chunk_memo_.Forget(ino);
 
   PutInodeToCache(attr_entry);
 
@@ -1507,6 +1514,10 @@ Status MDSMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
 
   MDSClient::AttrWithChunkOut out;
   auto status = mds_client_.SetAttr(ctx, ino, attr, set, out);
+  // Invalidate on every successful size setattr (a timed-out attempt may have
+  // committed a shrink while the successful retry reports it as a no-op) and
+  // on commit-ambiguous network errors.
+  if (set & kSetAttrSize) InvalidateLengthShrinkCache(ino, status);
   if (!status.ok()) {
     return status;
   }
@@ -1532,8 +1543,6 @@ Status MDSMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
 
   modify_time_memo_.Remember(ino);
   modify_time_memo_.UpdateKernelMtime(ino, out_attr->mtime);
-
-  if (out.shrink_file) chunk_memo_.Forget(ino);
 
   return Status::OK();
 }
@@ -1788,7 +1797,7 @@ Status MDSMetaSystem::DoFlushFile(ContextSPtr ctx, InodeSPtr inode,
   chunk_set->SetFlushCheckpoint(last_write_length);
 
   modify_time_memo_.Remember(ino);
-  if (shrink_file) chunk_memo_.Forget(ino);
+  if (shrink_file) InvalidateLengthShrinkCache(ino, false);
 
   PutInodeToCache(attr_entry);
 
@@ -1978,6 +1987,29 @@ bool MDSMetaSystem::CorrectAttrLength(Attr& attr, const std::string& caller) {
 void MDSMetaSystem::InvalidateFileSessionReadCache(Ino ino) {
   auto file_session = file_session_map_.GetSession(ino);
   if (file_session != nullptr) file_session->InvalidateReadCache(true);
+}
+
+void MDSMetaSystem::InvalidateLengthShrinkCache(Ino ino,
+                                                bool invalidate_inode) {
+  chunk_memo_.Forget(ino);
+
+  auto file_session = file_session_map_.GetSession(ino);
+  if (file_session != nullptr) file_session->InvalidateReadCache(false);
+
+  if (invalidate_inode) DeleteInodeFromCache(ino);
+}
+
+// Status-based policy shared by shrink paths: on success invalidate
+// conservatively but keep the inode (caller refreshes it from the RPC attr);
+// on a commit-ambiguous network error also drop the cached inode since the
+// shrink may have committed server-side. Other errors need no invalidation.
+void MDSMetaSystem::InvalidateLengthShrinkCache(Ino ino,
+                                                const Status& status) {
+  if (status.ok()) {
+    InvalidateLengthShrinkCache(ino, /*invalidate_inode=*/false);
+  } else if (status.IsNetError()) {
+    InvalidateLengthShrinkCache(ino, /*invalidate_inode=*/true);
+  }
 }
 
 Status MDSMetaSystem::Compact(ContextSPtr ctx, Ino ino, uint32_t chunk_index,

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -565,6 +565,8 @@ Status MDSMetaSystem::Lookup(ContextSPtr ctx, Ino parent,
   status = CorrectAttr(ctx, ctx->start_time_ns, *attr, is_amend, "lookup");
   if (!status.ok()) return status;
 
+  if (attr->nlink == 0) return Status::NotExist("inode is deleted");
+
   if (!ctx->inner_req) {
     modify_time_memo_.UpdateKernelMtime(attr->ino, attr->mtime);
   }
@@ -1457,12 +1459,16 @@ Status MDSMetaSystem::GetAttr(ContextSPtr ctx, Ino ino, Attr* attr) {
       CorrectAttr(ctx, ctx->start_time_ns, *attr, is_amend, "getattr");
   if (!status.ok()) return status;
 
+  LOG_DEBUG << fmt::format("[meta.fs.{}] get attr length({}) is_amend({}).",
+                           ino, attr->length, is_amend);
+
+  if (attr->nlink == 0 && !file_session_map_.HasSession(ino)) {
+    return Status::NotExist("inode is deleted");
+  }
+
   if (!ctx->inner_req) {
     modify_time_memo_.UpdateKernelMtime(attr->ino, attr->mtime);
   }
-
-  LOG_DEBUG << fmt::format("[meta.fs.{}] get attr length({}) is_amend({}).",
-                           ino, attr->length, is_amend);
 
   return Status::OK();
 }

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -126,7 +126,6 @@ class MDSMetaSystem : public vfs::MetaSystem {
   Status Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t offset,
                uint64_t size, uint64_t fh) override;
 
-
   Status MkDir(ContextSPtr ctx, Ino parent, const std::string& name,
                uint32_t uid, uint32_t gid, uint32_t mode, Attr* attr) override;
   Status RmDir(ContextSPtr ctx, Ino parent, const std::string& name) override;
@@ -229,6 +228,8 @@ class MDSMetaSystem : public vfs::MetaSystem {
                      bool& is_amend, const std::string& caller);
   bool CorrectAttrLength(Attr& attr, const std::string& caller);
   void InvalidateFileSessionReadCache(Ino ino);
+  void InvalidateLengthShrinkCache(Ino ino, bool invalidate_inode);
+  void InvalidateLengthShrinkCache(Ino ino, const Status& status);
 
   Status DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
                 const std::string& session_id, FileSessionSPtr file_session);

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -112,6 +112,8 @@ class MDSMetaSystem : public vfs::MetaSystem {
 
   Status Flush(ContextSPtr ctx, Ino ino, uint64_t fh) override;
 
+  Status RollbackWriteLength(ContextSPtr ctx, Ino ino, uint64_t fh) override;
+
   Status Close(ContextSPtr ctx, Ino ino, uint64_t fh) override;
 
   Status ReadSlice(ContextSPtr ctx, Ino ino, uint64_t index, uint64_t fh,

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -228,8 +228,10 @@ class MDSMetaSystem : public vfs::MetaSystem {
                      bool& is_amend, const std::string& caller);
   bool CorrectAttrLength(Attr& attr, const std::string& caller);
   void InvalidateFileSessionReadCache(Ino ino);
-  void InvalidateLengthShrinkCache(Ino ino, bool invalidate_inode);
-  void InvalidateLengthShrinkCache(Ino ino, const Status& status);
+  void InvalidateLengthShrinkCache(Ino ino, bool invalidate_inode,
+                                   const std::string& reason);
+  void InvalidateLengthShrinkCache(Ino ino, const Status& status,
+                                   const std::string& reason);
 
   Status DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
                 const std::string& session_id, FileSessionSPtr file_session);

--- a/src/client/vfs/metasystem/memory/metasystem.cc
+++ b/src/client/vfs/metasystem/memory/metasystem.cc
@@ -766,6 +766,17 @@ Status MemoryMetaSystem::SetAttr(ContextSPtr ctx, Ino ino, int set,
     inode.set_gid(attr.gid);
     update_fields.push_back("gid");
   }
+  if (set & (kSetAttrKillSuid | kSetAttrKillSgid | kSetAttrKillPriv)) {
+    uint32_t mode = inode.mode();
+    if (set & (kSetAttrKillSuid | kSetAttrKillPriv)) {
+      mode &= ~S_ISUID;
+    }
+    if (set & (kSetAttrKillSgid | kSetAttrKillPriv)) {
+      mode &= ~S_ISGID;
+    }
+    inode.set_mode(mode);
+    update_fields.push_back("mode");
+  }
 
   uint64_t now_timestamp = CurrentTimestamp();
 

--- a/src/client/vfs/metasystem/meta_system.h
+++ b/src/client/vfs/metasystem/meta_system.h
@@ -88,6 +88,16 @@ class MetaSystem {
 
   virtual Status Flush(ContextSPtr ctx, Ino ino, uint64_t fh) = 0;
 
+  // Called when a user-visible data flush fails (ADR-0003): conditionally
+  // roll the file length back to the flush checkpoint, abandoning this round
+  // of writes. Best-effort; backends without rollback support are a no-op.
+  virtual Status RollbackWriteLength(ContextSPtr ctx, Ino ino, uint64_t fh) {
+    (void)ctx;
+    (void)ino;
+    (void)fh;
+    return Status::OK();
+  }
+
   virtual Status Close(ContextSPtr ctx, Ino ino, uint64_t fh) = 0;
 
   /**

--- a/src/client/vfs/metasystem/meta_wrapper.h
+++ b/src/client/vfs/metasystem/meta_wrapper.h
@@ -108,6 +108,10 @@ class MetaWrapper {
 
   Status Flush(ContextSPtr ctx, Ino ino, uint64_t fh);
 
+  Status RollbackWriteLength(ContextSPtr ctx, Ino ino, uint64_t fh) {
+    return target_->RollbackWriteLength(ctx, ino, fh);
+  }
+
   Status Close(ContextSPtr ctx, Ino ino, uint64_t fh) {
     return target_->Close(ctx, ino, fh);
   }

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -750,12 +750,35 @@ Status VFSImpl::Flush(ContextSPtr ctx, Ino ino, uint64_t fh) {
   // O_RDONLY fh has no writer — nothing to flush at the data layer.
   if (handle->resources.writer != nullptr) {
     s = handle->resources.writer->Flush();
-    if (!s.ok()) return s;
+    if (!s.ok()) {
+      RollbackWriteLength(ctx, ino, fh);
+      return s;
+    }
   }
 
   s = meta_system_->Flush(ctx, ino, fh);
 
   return s;
+}
+
+void VFSImpl::RollbackWriteLength(ContextSPtr ctx, Ino ino, uint64_t fh) {
+  // Data flush failed: this round of writes is abandoned (ADR-0003). Ask the
+  // meta system to conditionally shrink the file length back to the flush
+  // checkpoint. Best-effort: on failure only log; the caller still returns
+  // the original flush error, and a later user-visible failure point
+  // (Flush/Release) will try again since the checkpoint condition still
+  // holds.
+  auto s = meta_system_->RollbackWriteLength(ctx, ino, fh);
+  if (!s.ok()) {
+    LOG(ERROR) << fmt::format(
+        "[vfs.{}] rollback write length fail, fh({}) error({}).", ino, fh,
+        s.ToString());
+    return;
+  }
+
+  // abandoned bytes may have been readable through other fhs of this ino;
+  // drop client-side read cache from 0 (checkpoint unknown here, be safe).
+  reader_registry_->InvalidateByIno(ino, 0, INT64_MAX);
 }
 
 Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
@@ -791,12 +814,11 @@ Status VFSImpl::Release(ContextSPtr ctx, Ino ino, uint64_t fh) {
   Status flush_status;
   if (handle->resources.writer != nullptr) {
     flush_status = handle->resources.writer->Flush();
+    if (!flush_status.ok()) RollbackWriteLength(ctx, ino, fh);
   }
 
-  Status close_status;
-  if (!resources_detached) {
-    close_status = meta_system_->Close(ctx, ino, fh);
-  }
+  Status close_status =
+      !resources_detached ? meta_system_->Close(ctx, ino, fh) : Status::OK();
 
   handle_manager_->ReleaseHandler(fh);
 

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -347,7 +347,7 @@ Status VFSImpl::SetAttr(ContextSPtr ctx, Ino ino, int set, const Attr& in_attr,
   // Truncate (size change) must invalidate cached read buffers — readahead
   // buffers in FileReader::requests_ are indexed by (ino, frange) and would
   // otherwise serve stale data after the inode shrinks/grows.
-  if (s.ok() && (set & kSetAttrSize)) {
+  if ((s.ok() || s.IsNetError()) && (set & kSetAttrSize)) {
     reader_registry_->InvalidateByIno(ino, 0,
                                       std::numeric_limits<int64_t>::max());
   }
@@ -599,6 +599,10 @@ Status VFSImpl::Open(ContextSPtr ctx, Ino ino, int flags, uint64_t* fh,
   }
 
   Status s = meta_system_->Open(ctx, TranslateIno(ino), flags, gfh, keep_cache);
+  if ((flags & O_TRUNC) && (s.ok() || s.IsNetError())) {
+    reader_registry_->InvalidateByIno(ino, 0,
+                                      std::numeric_limits<int64_t>::max());
+  }
   if (s.ok()) {
     auto* handle = handle_manager_->NewHandle(gfh, ino, flags);
     if (handle == nullptr) {
@@ -773,11 +777,11 @@ void VFSImpl::RollbackWriteLength(ContextSPtr ctx, Ino ino, uint64_t fh) {
     LOG(ERROR) << fmt::format(
         "[vfs.{}] rollback write length fail, fh({}) error({}).", ino, fh,
         s.ToString());
-    return;
+    if (!s.IsNetError()) return;
   }
 
-  // abandoned bytes may have been readable through other fhs of this ino;
-  // drop client-side read cache from 0 (checkpoint unknown here, be safe).
+  // Abandoned bytes may have been readable through other fhs of this ino. A
+  // network error is commit-ambiguous, so invalidate in that case as well.
   reader_registry_->InvalidateByIno(ino, 0, INT64_MAX);
 }
 

--- a/src/client/vfs/vfs_impl.h
+++ b/src/client/vfs/vfs_impl.h
@@ -104,6 +104,9 @@ class VFSImpl : public VFS {
 
   Status Flush(ContextSPtr ctx, Ino ino, uint64_t fh) override;
 
+  // best-effort length rollback on data-flush failure (ADR-0003)
+  void RollbackWriteLength(ContextSPtr ctx, Ino ino, uint64_t fh);
+
   Status Release(ContextSPtr ctx, Ino ino, uint64_t fh) override;
 
   Status Fsync(ContextSPtr ctx, Ino ino, int datasync, uint64_t fh) override;

--- a/src/client/vfs/vfs_wrapper.cc
+++ b/src/client/vfs/vfs_wrapper.cc
@@ -90,7 +90,9 @@ static std::string DescribeSetAttr(int set) {
   constexpr uint32_t kKnownSetAttr =
       kSetAttrMode | kSetAttrUid | kSetAttrGid | kSetAttrSize | kSetAttrAtime |
       kSetAttrMtime | kSetAttrAtimeNow | kSetAttrMtimeNow | kSetAttrCtime |
-      kSetAttrFlags | kSetAttrNlink;
+      kSetAttrKillSuid | kSetAttrKillSgid | kSetAttrFile | kSetAttrKillPriv |
+      kSetAttrOpen | kSetAttrTimesSet | kSetAttrTouch | kSetAttrFlags |
+      kSetAttrNlink;
 
   std::string description;
   auto append = [&description, value](uint32_t flag, const char* name) {
@@ -108,6 +110,13 @@ static std::string DescribeSetAttr(int set) {
   append(kSetAttrAtimeNow, "atime_now");
   append(kSetAttrMtimeNow, "mtime_now");
   append(kSetAttrCtime, "ctime");
+  append(kSetAttrKillSuid, "kill_suid");
+  append(kSetAttrKillSgid, "kill_sgid");
+  append(kSetAttrFile, "file");
+  append(kSetAttrKillPriv, "kill_priv");
+  append(kSetAttrOpen, "open");
+  append(kSetAttrTimesSet, "times_set");
+  append(kSetAttrTouch, "touch");
   append(kSetAttrFlags, "flags");
   append(kSetAttrNlink, "nlink");
 
@@ -698,6 +707,11 @@ Status VFSWrapper::SetAttr(const Context& ctx, Ino ino, int set,
   ClientOpMetricGuard op_metric(
       {&client_op_metric_->opSetAttr, &client_op_metric_->opAll});
 
+  if (set & (kSetAttrOpen | kSetAttrTimesSet)) {
+    s = Status::InvalidParam("not supported");
+    return s;
+  }
+
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->SetAttr(span_ctx, ino, set, in_attr, out_attr);
   if (!s.ok()) op_metric.FailOp();
@@ -1169,7 +1183,7 @@ Status VFSWrapper::SetXattr(const Context& ctx, Ino ino,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opSetAttr, &client_op_metric_->opAll},
+      {&client_op_metric_->opSetXattr, &client_op_metric_->opAll},
       !dingofs::IsInternalIno(ino));
 
   if (name.length() > vfs_->GetMaxNameLength()) {

--- a/src/common/meta.h
+++ b/src/common/meta.h
@@ -32,17 +32,25 @@ static constexpr Ino kRootIno = 1;
 
 // Bitmask flags for the `set` parameter of SetAttr().
 // Combine with bitwise-OR to indicate which Attr fields to update.
-static constexpr uint32_t kSetAttrMode     = 1 << 0;
-static constexpr uint32_t kSetAttrUid      = 1 << 1;
-static constexpr uint32_t kSetAttrGid      = 1 << 2;
-static constexpr uint32_t kSetAttrSize     = 1 << 3;
-static constexpr uint32_t kSetAttrAtime    = 1 << 4;
-static constexpr uint32_t kSetAttrMtime    = 1 << 5;
+static constexpr uint32_t kSetAttrMode = 1 << 0;
+static constexpr uint32_t kSetAttrUid = 1 << 1;
+static constexpr uint32_t kSetAttrGid = 1 << 2;
+static constexpr uint32_t kSetAttrSize = 1 << 3;
+static constexpr uint32_t kSetAttrAtime = 1 << 4;
+static constexpr uint32_t kSetAttrMtime = 1 << 5;
 static constexpr uint32_t kSetAttrAtimeNow = 1 << 7;
 static constexpr uint32_t kSetAttrMtimeNow = 1 << 8;
-static constexpr uint32_t kSetAttrCtime    = 1 << 10;
-static constexpr uint32_t kSetAttrFlags    = 1 << 11;
-static constexpr uint32_t kSetAttrNlink    = 1 << 12;
+static constexpr uint32_t kSetAttrCtime = 1 << 10;
+static constexpr uint32_t kSetAttrKillSuid = 1 << 11;
+static constexpr uint32_t kSetAttrKillSgid = 1 << 12;
+static constexpr uint32_t kSetAttrFile = 1 << 13;
+static constexpr uint32_t kSetAttrKillPriv = 1 << 14;
+static constexpr uint32_t kSetAttrOpen = 1 << 15;
+static constexpr uint32_t kSetAttrTimesSet = 1 << 16;
+static constexpr uint32_t kSetAttrTouch = 1 << 17;
+
+static constexpr uint32_t kSetAttrFlags = 1 << 20;
+static constexpr uint32_t kSetAttrNlink = 1 << 21;
 
 enum FileType : uint8_t {
   kDirectory = 1,

--- a/src/common/metrics/client/client.h
+++ b/src/common/metrics/client/client.h
@@ -46,6 +46,7 @@ struct ClientOpMetric {
   OpMetric opSetAttr;
   OpMetric opGetXattr;
   OpMetric opListXattr;
+  OpMetric opSetXattr;
   OpMetric opRemoveXattr;
   OpMetric opSymlink;
   OpMetric opReadLink;
@@ -76,6 +77,7 @@ struct ClientOpMetric {
         opSetAttr(prefix, "opSetattr"),
         opGetXattr(prefix, "opGetxattr"),
         opListXattr(prefix, "opListxattr"),
+        opSetXattr(prefix, "opSetxattr"),
         opRemoveXattr(prefix, "opRemovexattr"),
         opSymlink(prefix, "opSymlink"),
         opReadLink(prefix, "opReadlink"),

--- a/src/common/options/client.cc
+++ b/src/common/options/client.cc
@@ -226,7 +226,15 @@ DEFINE_bool(
     "enable parallel lookup and readdir requests in the same directory");
 DEFINE_validator(fuse_enable_parallel_dirops, brpc::PassValidate);
 
-DEFINE_bool(fuse_enable_handle_killpriv_v2, true,
+// Disabled by default: the KILLPRIV_V2 contract (filesystem clears
+// suid/sgid/security.capability on write/truncate/open(O_TRUNC)) is not
+// implemented, and libfuse does not even forward FUSE_WRITE_KILL_SUIDGID /
+// FUSE_OPEN_KILL_SUIDGID to the write/open callbacks. Enabling it makes the
+// kernel skip its own privilege removal, so suid/sgid bits survive writes by
+// non-owners (pjdfstest chmod/12.t). With v2 off, the kernel clears the bits
+// itself via setattr(FATTR_KILL_SUIDGID), which FuseOpSetAttr translates
+// into a mode update.
+DEFINE_bool(fuse_enable_handle_killpriv_v2, false,
             "filesystem handles killing suid/sgid/cap on write/truncate/open, "
             "avoids kernel getxattr(security.capability) before every write");
 DEFINE_validator(fuse_enable_handle_killpriv_v2, brpc::PassValidate);

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -1283,8 +1283,10 @@ Status FileSystem::FlushFile(Context& ctx, Ino ino, const FlushFileParam& param,
   FlushFileOperation::ExtraParam extra_param;
   extra_param.length = param.length;
   extra_param.chunk_size = fs_info_->GetChunkSize();
+  extra_param.rollback = param.rollback;
+  extra_param.rollback_to_length = param.rollback_to_length;
 
-  if (param.length > inode->Length() && inode->Nlink() > 0) {
+  if (!param.rollback && param.length > inode->Length() && inode->Nlink() > 0) {
     // check quota
     if (!quota_manager_.CheckQuota(trace, ino, param.length - inode->Length(), 0)) {
       return Status(pb::error::EQUOTA_EXCEED, "exceed quota limit");

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -1171,8 +1171,7 @@ Status FileSystem::Open(Context& ctx, Ino ino, const OpenParam& param, EntryOutF
 
   FileSessionSPtr file_session = file_session_manager_.Create(ino, client_id, param.session_id);
 
-  OpenFileOperation operation(trace, flags, *file_session, chunk_size,
-                              prefetch_chunks);
+  OpenFileOperation operation(trace, flags, *file_session, chunk_size, prefetch_chunks);
 
   trace.RecordElapsedTime("prepare");
 
@@ -1182,11 +1181,10 @@ Status FileSystem::Open(Context& ctx, Ino ino, const OpenParam& param, EntryOutF
   auto& attr = result.attr;
   int64_t delta_bytes = result.delta_bytes;
   auto& chunks = result.chunks;
-  LOG_DEBUG << fmt::format(
-      "[fs.{}.{}.{}.{}][{}us] open {} finish, flags({:o}:{}) fetch_chunk({}:{}) status({}).", fs_id_,
-      ino, ctx.RequestId(), trace.GetReqTypeInt(), duration.ElapsedUs(), param.session_id, flags,
-      dingofs::Helper::DescOpenFlags(flags), fetch_from,
-      out.chunks.empty() ? chunks.size() : out.chunks.size(), status.error_str());
+  LOG_DEBUG << fmt::format("[fs.{}.{}.{}.{}][{}us] open {} finish, flags({:o}:{}) fetch_chunk({}:{}) status({}).",
+                           fs_id_, ino, ctx.RequestId(), trace.GetReqTypeInt(), duration.ElapsedUs(), param.session_id,
+                           flags, dingofs::Helper::DescOpenFlags(flags), fetch_from,
+                           out.chunks.empty() ? chunks.size() : out.chunks.size(), status.error_str());
   trace.RecordElapsedTime("resume");
 
   if (!status.ok()) return status;
@@ -2873,6 +2871,17 @@ Status FileSystem::WriteSlice(Context& ctx, Ino ino, const std::vector<DeltaSlic
     }
 
     chunk_cache_.PutIf(ino, std::move(chunk));
+  }
+
+  // update quota
+  int64_t delta_bytes = result.delta_bytes;
+  if (delta_bytes != 0) {
+    quota_manager_.AsyncUpdateFsUsage(delta_bytes, 0, reason);
+
+    for (const auto& parent : attr.parents()) {
+      quota_manager_.AsyncUpdateDirUsage(parent, delta_bytes, 0, reason);
+      UpdateDirStat(parent, delta_bytes, 0, 0, reason);
+    }
   }
 
   trace.RecordElapsedTime("post_handle");

--- a/src/mds/filesystem/filesystem.h
+++ b/src/mds/filesystem/filesystem.h
@@ -197,6 +197,10 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
 
   struct FlushFileParam {
     uint64_t length{0};
+    // when rollback is true, conditionally shrink length to rollback_to_length
+    // iff rollback_to_length < current length <= length (ADR-0003).
+    bool rollback{false};
+    uint64_t rollback_to_length{0};
   };
   Status FlushFile(Context& ctx, Ino ino, const FlushFileParam& param, EntryWithFileChangeOut& entry_out);
   using FileSessionParam = pb::mds::HeartbeatRequest::FileSession;

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -1172,68 +1172,57 @@ static Status ScanChunk(TxnUPtr& txn, uint32_t fs_id, Ino ino, std::map<uint64_t
   return status;
 }
 
-// Append zero slices (id=0) over [offset, end_offset) across every chunk the
-// range touches, shadowing existing data so the range reads back as zeros.
-// Slices are append-ordered (last overlapping wins), so this logically clears
-// the range without removing old slices. Touched chunks are written to txn and
-// collected into effected_chunks. Shared by truncate-shrink and fallocate
+// Append zero slices (id=0) over [offset, end_offset), shadowing existing
+// data so the range reads back as zeros. Only existing chunks are touched:
+// absent chunks are already holes, and creating one entry per logical chunk
+// would make shrinking a large sparse file unnecessarily expensive. Slices are
+// append-ordered (last overlapping wins), so this logically clears the range
+// without removing old slices. Touched chunks are written to txn and collected
+// into effected_chunks. Shared by length shrink and fallocate
 // PUNCH_HOLE/ZERO_RANGE.
 static Status AppendZeroSlices(TxnUPtr& txn, uint32_t fs_id, Ino ino, uint64_t offset, uint64_t end_offset,
-                               uint64_t chunk_size, uint64_t block_size, std::vector<ChunkEntry>& effected_chunks) {
+                               uint64_t chunk_size, std::vector<ChunkEntry>& effected_chunks) {
   // Reset so a txn retry (which re-runs this op) doesn't accumulate duplicates.
   effected_chunks.clear();
+  if (offset >= end_offset) return Status::OK();
 
   std::map<uint64_t, ChunkEntry> chunks;
   auto status = ScanChunk(txn, fs_id, ino, chunks);
   if (!status.ok()) return status;
 
-  while (offset < end_offset) {
-    const uint64_t chunk_pos = offset % chunk_size;
-    const uint64_t chunk_index = offset / chunk_size;
-    const uint64_t delta_chunk_size = std::min(end_offset - offset, chunk_size - chunk_pos);
+  const uint64_t first_chunk = offset / chunk_size;
+  const uint64_t last_chunk = (end_offset - 1) / chunk_size;
+  for (auto it = chunks.lower_bound(first_chunk); it != chunks.end() && it->first <= last_chunk; ++it) {
+    auto& chunk = it->second;
+    const uint64_t chunk_offset = it->first * chunk_size;
+    const uint64_t zero_start = std::max(offset, chunk_offset);
+    const uint64_t zero_end = std::min(end_offset, chunk_offset + chunk_size);
+    if (zero_start >= zero_end) continue;
 
     SliceEntry slice;
     slice.set_id(0);
     slice.set_size(0);
-    slice.set_pos(chunk_pos);
+    slice.set_pos(zero_start - chunk_offset);
     slice.set_off(0);
-    slice.set_len(delta_chunk_size);
+    slice.set_len(zero_end - zero_start);
+    chunk.add_slices()->Swap(&slice);
+    // Bump version so ChunkCache::PutIf accepts the updated slice list.
+    chunk.set_version(chunk.version() + 1);
 
-    auto it = chunks.find(chunk_index);
-    if (it == chunks.end()) {
-      ChunkEntry chunk;
-      chunk.set_index(chunk_index);
-      chunk.set_chunk_size(chunk_size);
-      chunk.set_block_size(block_size);
-      chunk.set_version(1);
-      chunk.add_slices()->Swap(&slice);
+    LOG_DEBUG << fmt::format("[operation.{}.{}] update chunk, range[{},{}) version({}), value({}).", fs_id, ino,
+                             zero_start, zero_end, chunk.version(), chunk.ShortDebugString());
 
-      LOG_DEBUG << fmt::format("[operation.{}.{}] update chunk, range[{},{}) version({}), value({}).", fs_id, ino,
-                               offset, end_offset, chunk.version(), chunk.ShortDebugString());
-
-      txn->Put(MetaCodec::EncodeChunkKey(fs_id, ino, chunk_index), MetaCodec::EncodeChunkValue(chunk));
-      effected_chunks.push_back(std::move(chunk));
-
-    } else {
-      auto& chunk = it->second;
-      chunk.add_slices()->Swap(&slice);
-      // bump version so ChunkCache::PutIf accepts the updated slice list.
-      chunk.set_version(chunk.version() + 1);
-      LOG_DEBUG << fmt::format("[operation.{}.{}] update chunk, range[{},{}) version({}), value({}).", fs_id, ino,
-                               offset, end_offset, chunk.version(), chunk.ShortDebugString());
-
-      txn->Put(MetaCodec::EncodeChunkKey(fs_id, ino, chunk_index), MetaCodec::EncodeChunkValue(chunk));
-      effected_chunks.push_back(chunk);
-    }
-
-    offset += delta_chunk_size;
+    txn->Put(MetaCodec::EncodeChunkKey(fs_id, ino, it->first), MetaCodec::EncodeChunkValue(chunk));
+    effected_chunks.push_back(chunk);
   }
 
   return Status::OK();
 }
 
 Status UpdateAttrOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_param) {
-  auto& attr = shared_param.attr;
+  AttrEntry attr = shared_param.attr;
+  result_.delta_bytes = 0;
+  result_.effected_chunks.clear();
 
   if (to_set_ & kSetAttrMode) {
     attr.set_mode(attr_.mode());
@@ -1252,18 +1241,20 @@ Status UpdateAttrOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_pa
     const uint64_t new_length = attr_.length();
     result_.delta_bytes = static_cast<int64_t>(new_length) - static_cast<int64_t>(old_length);
 
-    attr.set_length(new_length);
-
     // Truncate-down must neutralize data beyond the new size; otherwise a later
     // extend (truncate-up / fallocate) re-exposes the dropped bytes, because
     // slices are append-ordered and the stale slice still sits in the chunk.
     // Mirror fallocate ZERO_RANGE: zero [new_length, old_length).
     if (new_length < old_length) {
       auto status = AppendZeroSlices(txn, attr.fs_id(), attr.ino(), new_length, old_length, extra_param_.chunk_size,
-                                     extra_param_.block_size, result_.effected_chunks);
+                                     result_.effected_chunks);
       if (!status.ok()) return status;
     }
 
+    // Update the operation-local inode only after zero-slice preparation
+    // succeeds. The shared batch inode is replaced only after the whole
+    // operation succeeds, preventing partial setattr commits on an error.
+    attr.set_length(new_length);
     attr.set_mtime(std::max(attr.mtime(), GetTime()));
     attr.set_ctime(std::max(attr.ctime(), GetTime()));
   }
@@ -1288,6 +1279,7 @@ Status UpdateAttrOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_pa
     attr.set_flags(attr_.flags());
   }
 
+  shared_param.attr = std::move(attr);
   return Status::OK();
 }
 
@@ -1572,8 +1564,8 @@ Status FallocateOperation::PreAlloc(AttrEntry& attr, uint64_t offset, uint64_t l
 Status FallocateOperation::SetZero(TxnUPtr& txn, AttrEntry& attr, uint64_t offset, uint64_t len, bool keep_size) {
   uint64_t end_offset = keep_size ? std::min(attr.length(), offset + len) : (offset + len);
 
-  auto status = AppendZeroSlices(txn, attr.fs_id(), attr.ino(), offset, end_offset, param_.chunk_size,
-                                 param_.block_size, result_.effected_chunks);
+  auto status =
+      AppendZeroSlices(txn, attr.fs_id(), attr.ino(), offset, end_offset, param_.chunk_size, result_.effected_chunks);
   if (!status.ok()) return status;
 
   if (!keep_size && end_offset > attr.length()) {
@@ -1629,6 +1621,8 @@ Status FallocateOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_par
 }
 
 void OpenFileOperation::PrefetchKey(std::vector<std::string>& keys) {
+  if (flags_ & O_TRUNC) return;
+
   for (const auto& chunk_index : prefetch_chunks_) {
     keys.push_back(MetaCodec::EncodeChunkKey(file_session_.fs_id(), file_session_.ino(), chunk_index));
   }
@@ -1636,16 +1630,23 @@ void OpenFileOperation::PrefetchKey(std::vector<std::string>& keys) {
 
 Status OpenFileOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_param) {
   auto& attr = shared_param.attr;
+  result_.delta_bytes = 0;
   const auto& prefetch_kvs = shared_param.prefetch_kvs;
 
   if (IsDeleted(attr)) {
     return Status(pb::error::EDELETED, "file is deleted");
   }
 
+  result_.chunks.clear();
   if (flags_ & O_TRUNC) {
-    result_.delta_bytes = -static_cast<int64_t>(attr.length());
-    attr.set_length(0);
+    const uint64_t old_length = attr.length();
+    result_.delta_bytes = -static_cast<int64_t>(old_length);
 
+    std::vector<ChunkEntry> effected_chunks;
+    auto status = AppendZeroSlices(txn, attr.fs_id(), attr.ino(), 0, old_length, chunk_size_, effected_chunks);
+    if (!status.ok()) return status;
+
+    attr.set_length(0);
     attr.set_ctime(std::max(attr.ctime(), GetTime()));
     attr.set_mtime(std::max(attr.mtime(), GetTime()));
   }
@@ -1656,9 +1657,11 @@ Status OpenFileOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_para
   txn->Put(MetaCodec::EncodeFileSessionKey(file_session_.fs_id(), file_session_.ino(), file_session_.session_id()),
            MetaCodec::EncodeFileSessionValue(file_session_));
 
-  for (const auto& kv : prefetch_kvs) {
-    if (MetaCodec::IsChunkKey(kv.key)) {
-      result_.chunks.push_back(MetaCodec::DecodeChunkValue(kv.value));
+  if (!(flags_ & O_TRUNC)) {
+    for (const auto& kv : prefetch_kvs) {
+      if (MetaCodec::IsChunkKey(kv.key)) {
+        result_.chunks.push_back(MetaCodec::DecodeChunkValue(kv.value));
+      }
     }
   }
 
@@ -1672,6 +1675,7 @@ Status CloseFileOperation::Run(TxnUPtr& txn) {
 
 Status FlushFileOperation::Run(TxnUPtr& txn) {
   CHECK(param_.chunk_size != 0) << "chunk_size not should be 0.";
+  result_.delta_bytes = 0;
 
   const std::string key = MetaCodec::EncodeInodeKey(fs_id_, ino_);
   std::vector<std::string> keys = {key};
@@ -1700,6 +1704,11 @@ Status FlushFileOperation::Run(TxnUPtr& txn) {
     // writer moved the length legitimately -- give up conservatively.
     if (attr.length() > param_.rollback_to_length && attr.length() <= param_.length) {
       result_.delta_bytes = static_cast<int64_t>(param_.rollback_to_length) - static_cast<int64_t>(attr.length());
+
+      std::vector<ChunkEntry> effected_chunks;
+      status = AppendZeroSlices(txn, attr.fs_id(), attr.ino(), param_.rollback_to_length, attr.length(),
+                                param_.chunk_size, effected_chunks);
+      if (!status.ok()) return status;
 
       attr.set_length(param_.rollback_to_length);
       attr.set_mtime(std::max(attr.mtime(), GetTime()));

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -1360,6 +1360,7 @@ Status UpsertChunkOperation::Run(TxnUPtr& txn) {
 
   bool has_update_chunk = false;
   uint64_t length = 0;
+  result_.delta_bytes = 0;
   result_.effected_chunks.clear();
   for (const auto& delta_slices : delta_slices_) {
     ChunkEntry chunk;
@@ -1440,7 +1441,10 @@ Status UpsertChunkOperation::Run(TxnUPtr& txn) {
 
   // update inode length if needed
   if (has_update_chunk) {
-    if (length > attr.length()) attr.set_length(length);
+    if (length > attr.length()) {
+      result_.delta_bytes = length - attr.length();
+      attr.set_length(length);
+    }
     attr.set_mtime(std::max(attr.mtime(), GetTime()));
     attr.set_ctime(std::max(attr.ctime(), GetTime()));
     attr.set_version(attr.version() + 1);

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -1220,12 +1220,22 @@ static Status AppendZeroSlices(TxnUPtr& txn, uint32_t fs_id, Ino ino, uint64_t o
 }
 
 Status UpdateAttrOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_param) {
-  AttrEntry attr = shared_param.attr;
+  auto& attr = shared_param.attr;
   result_.delta_bytes = 0;
   result_.effected_chunks.clear();
 
   if (to_set_ & kSetAttrMode) {
     attr.set_mode(attr_.mode());
+  }
+  if (to_set_ & (kSetAttrKillSuid | kSetAttrKillSgid | kSetAttrKillPriv)) {
+    uint32_t mode = attr.mode();
+    if (to_set_ & (kSetAttrKillSuid | kSetAttrKillPriv)) {
+      mode &= ~S_ISUID;
+    }
+    if (to_set_ & (kSetAttrKillSgid | kSetAttrKillPriv)) {
+      mode &= ~S_ISGID;
+    }
+    attr.set_mode(mode);
   }
 
   if (to_set_ & kSetAttrUid) {
@@ -1279,7 +1289,6 @@ Status UpdateAttrOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_pa
     attr.set_flags(attr_.flags());
   }
 
-  shared_param.attr = std::move(attr);
   return Status::OK();
 }
 

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -1630,8 +1630,7 @@ Status FallocateOperation::RunInBatch(TxnUPtr& txn, BatchSharedParam& shared_par
 
 void OpenFileOperation::PrefetchKey(std::vector<std::string>& keys) {
   for (const auto& chunk_index : prefetch_chunks_) {
-    keys.push_back(MetaCodec::EncodeChunkKey(file_session_.fs_id(),
-                                              file_session_.ino(), chunk_index));
+    keys.push_back(MetaCodec::EncodeChunkKey(file_session_.fs_id(), file_session_.ino(), chunk_index));
   }
 }
 
@@ -1692,6 +1691,26 @@ Status FlushFileOperation::Run(TxnUPtr& txn) {
 
   if (attr.ino() == 0) {
     return Status(pb::error::ENOT_FOUND, fmt::format("not found inode({})", ino_));
+  }
+
+  if (param_.rollback) {
+    // Conditional length rollback (ADR-0003): only shrink when the current
+    // persisted length still lies within the range this write session pushed,
+    // i.e. rollback_to_length < length <= last write length. Otherwise another
+    // writer moved the length legitimately -- give up conservatively.
+    if (attr.length() > param_.rollback_to_length && attr.length() <= param_.length) {
+      result_.delta_bytes = static_cast<int64_t>(param_.rollback_to_length) - static_cast<int64_t>(attr.length());
+
+      attr.set_length(param_.rollback_to_length);
+      attr.set_mtime(std::max(attr.mtime(), GetTime()));
+      attr.set_ctime(std::max(attr.ctime(), GetTime()));
+      attr.set_version(attr.version() + 1);
+
+      txn->Put(key, MetaCodec::EncodeInodeValue(attr));
+    }
+
+    result_.attr = attr;
+    return Status::OK();
   }
 
   if (param_.length > attr.length()) {

--- a/src/mds/filesystem/store_operation.h
+++ b/src/mds/filesystem/store_operation.h
@@ -1211,6 +1211,10 @@ class FlushFileOperation : public Operation {
   struct ExtraParam {
     uint64_t length;
     uint64_t chunk_size{0};
+    // conditional length rollback (ADR-0003): shrink to rollback_to_length iff
+    // rollback_to_length < current length <= length.
+    bool rollback{false};
+    uint64_t rollback_to_length{0};
   };
 
   FlushFileOperation(Trace& trace, uint32_t fs_id, Ino ino, ExtraParam& param)

--- a/src/mds/filesystem/store_operation.h
+++ b/src/mds/filesystem/store_operation.h
@@ -931,6 +931,7 @@ class UpsertChunkOperation : public Operation {
   struct Result {
     AttrEntry attr;
     std::vector<ChunkEntry> effected_chunks;
+    int64_t delta_bytes{0};
   };
 
   OpType GetOpType() const override { return OpType::kUpsertChunk; }
@@ -1148,8 +1149,7 @@ class FallocateOperation : public Operation {
 
 class OpenFileOperation : public Operation {
  public:
-  OpenFileOperation(Trace& trace, uint32_t flags,
-                    const FileSessionEntry& file_session, uint64_t chunk_size,
+  OpenFileOperation(Trace& trace, uint32_t flags, const FileSessionEntry& file_session, uint64_t chunk_size,
                     const std::vector<uint32_t>& prefetch_chunks)
       : Operation(trace),
         flags_(flags),
@@ -2225,8 +2225,7 @@ class GetDelFileOperation : public Operation {
 
 class CleanDelFileOperation : public Operation {
  public:
-  CleanDelFileOperation(Trace& trace, uint32_t fs_id, Ino ino)
-      : Operation(trace), fs_id_(fs_id), ino_(ino) {};
+  CleanDelFileOperation(Trace& trace, uint32_t fs_id, Ino ino) : Operation(trace), fs_id_(fs_id), ino_(ino) {};
   ~CleanDelFileOperation() override = default;
 
   OpType GetOpType() const override { return OpType::kCleanDelFile; }

--- a/src/mds/service/mds_service.cc
+++ b/src/mds/service/mds_service.cc
@@ -1495,7 +1495,9 @@ void MDSServiceImpl::DoFlushFile(google::protobuf::RpcController*, const pb::mds
 
   Context ctx(request->context(), request->info().request_id(), __func__, CalReqType(request));
 
-  FileSystem::FlushFileParam param{.length = request->length()};
+  FileSystem::FlushFileParam param{.length = request->length(),
+                                   .rollback = request->rollback(),
+                                   .rollback_to_length = request->rollback_to_length()};
 
   EntryWithFileChangeOut entry_out;
   status = file_system->FlushFile(ctx, request->ino(), param, entry_out);

--- a/src/mds/storage/dingodb_storage.cc
+++ b/src/mds/storage/dingodb_storage.cc
@@ -427,39 +427,17 @@ Status DingodbTxn::Scan(const Range& range, uint64_t limit, std::vector<KeyValue
 }
 
 Status DingodbTxn::Scan(const Range& range, ScanHandlerType handler) {
-  Status status;
-  std::vector<KeyValue> kvs;
-  do {
-    kvs.clear();
-    status = Scan(range, FLAGS_mds_scan_batch_size, kvs);
-    if (!status.ok()) {
-      break;
-    }
-
-    bool is_exit = false;
-    for (auto& kv : kvs) {
-      if (!handler(kv.key, kv.value)) {
-        is_exit = true;
-        break;
-      }
-    }
-
-    if (is_exit) break;
-
-  } while (kvs.size() >= FLAGS_mds_scan_batch_size);
-
-  return status;
+  return Scan(range, [&](KeyValue& kv) { return handler(kv.key, kv.value); });
 }
 
 Status DingodbTxn::Scan(const Range& range, std::function<bool(KeyValue&)> handler) {
   Status status;
+  Range page = range;
   std::vector<KeyValue> kvs;
   do {
     kvs.clear();
-    status = Scan(range, FLAGS_mds_scan_batch_size, kvs);
-    if (!status.ok()) {
-      break;
-    }
+    status = Scan(page, FLAGS_mds_scan_batch_size, kvs);
+    if (!status.ok()) break;
 
     bool is_exit = false;
     for (auto& kv : kvs) {
@@ -468,10 +446,13 @@ Status DingodbTxn::Scan(const Range& range, std::function<bool(KeyValue&)> handl
         break;
       }
     }
+    if (is_exit || kvs.size() < FLAGS_mds_scan_batch_size) break;
 
-    if (is_exit) break;
-
-  } while (kvs.size() >= FLAGS_mds_scan_batch_size);
+    // Scan ranges are start-inclusive. Move just past the last key so the next
+    // page does not repeat the same full batch forever.
+    page.start = kvs.back().key;
+    page.start.push_back('\0');
+  } while (page.start < page.end);
 
   return status;
 }

--- a/test/unit/mds/filesystem/test_filesystem.cc
+++ b/test/unit/mds/filesystem/test_filesystem.cc
@@ -1162,6 +1162,74 @@ TEST_F(FileSystemTest, CalcDirStatSameDirHardlink) {
   EXPECT_EQ(st.length(), 7777 * 2);  // length charged once per dentry
 }
 
+// ADR-0003: FlushFile with rollback conditionally shrinks the length back to
+// the flush checkpoint -- only when checkpoint < current length <= the
+// session's last write length. Otherwise it is a no-op (conservative for
+// concurrent writers).
+TEST_F(FileSystemTest, FlushFileRollbackConditionalShrink) {
+  auto fs = Fs();
+  Context ctx;
+
+  FileSystem::MkNodParam p;
+  p.parent = kRootIno;
+  p.name = "rollback_f";
+  p.mode = 0644;
+  p.uid = 1;
+  p.gid = 1;
+  p.rdev = 0;
+  EntryWithPaOut o;
+  ASSERT_TRUE(fs->MkNod(ctx, p, o).ok());
+  Ino f = o.attr.ino();
+
+  // push length to 1000 (checkpoint), then to 5000 (this round's writes).
+  auto flush_to = [&](uint64_t len) {
+    FileSystem::FlushFileParam fp;
+    fp.length = len;
+    EntryWithFileChangeOut fo;
+    ASSERT_TRUE(fs->FlushFile(ctx, f, fp, fo).ok());
+  };
+  flush_to(1000);
+  flush_to(5000);
+
+  // rollback: checkpoint=1000, last write=5000 -> shrink to 1000.
+  {
+    FileSystem::FlushFileParam fp;
+    fp.length = 5000;
+    fp.rollback = true;
+    fp.rollback_to_length = 1000;
+    EntryWithFileChangeOut fo;
+    ASSERT_TRUE(fs->FlushFile(ctx, f, fp, fo).ok());
+    EXPECT_EQ(fo.attr.length(), 1000);
+    EXPECT_TRUE(fo.shrink_file);
+  }
+
+  // repeated rollback is a no-op: current length (1000) == checkpoint.
+  {
+    FileSystem::FlushFileParam fp;
+    fp.length = 5000;
+    fp.rollback = true;
+    fp.rollback_to_length = 1000;
+    EntryWithFileChangeOut fo;
+    ASSERT_TRUE(fs->FlushFile(ctx, f, fp, fo).ok());
+    EXPECT_EQ(fo.attr.length(), 1000);
+    EXPECT_FALSE(fo.shrink_file);
+  }
+
+  // another writer pushed the length beyond this session's last write:
+  // rollback must give up (no shrink).
+  flush_to(9000);
+  {
+    FileSystem::FlushFileParam fp;
+    fp.length = 5000;  // this session's last write
+    fp.rollback = true;
+    fp.rollback_to_length = 1000;
+    EntryWithFileChangeOut fo;
+    ASSERT_TRUE(fs->FlushFile(ctx, f, fp, fo).ok());
+    EXPECT_EQ(fo.attr.length(), 9000);
+    EXPECT_FALSE(fo.shrink_file);
+  }
+}
+
 TEST_F(FileSystemTest, UpdateDirStatOnWrite) {
   auto fs = Fs();
   ASSERT_TRUE(fs->EnableDirStats());

--- a/test/unit/mds/filesystem/test_store_operation.cc
+++ b/test/unit/mds/filesystem/test_store_operation.cc
@@ -1256,7 +1256,7 @@ TEST_F(FallocateRunTest, ZeroRangeWithoutKeepSizeExtendsFile) {
   SeedChunk(ino, MakeSizedChunk(0, {MakeSlice(/*id=*/3000, /*off=*/0,
                                               /*len=*/4096, /*pos=*/0)}));
 
-  // Zero [4096, 12288): tail of chunk 0 then the prefix of chunk 1.
+  // Zero [4096, 12288): tail of existing chunk 0 followed by a sparse hole.
   FallocateOperation op(trace_,
                         MakeParam(ino, FALLOC_FL_ZERO_RANGE,
                                   /*offset=*/4096, /*len=*/kFallocChunkSize,
@@ -1270,7 +1270,7 @@ TEST_F(FallocateRunTest, ZeroRangeWithoutKeepSizeExtendsFile) {
 
   EXPECT_EQ(shared_param.attr.length(), 12288u);
   EXPECT_EQ(op.GetResult().delta_bytes, static_cast<int64_t>(kFallocChunkSize));
-  ASSERT_EQ(op.GetResult().effected_chunks.size(), 2u);
+  ASSERT_EQ(op.GetResult().effected_chunks.size(), 1u);
 
   ChunkEntry chunk0 = GetChunk(ino, 0);
   auto slices0 = SortedSlices(chunk0);
@@ -1280,11 +1280,8 @@ TEST_F(FallocateRunTest, ZeroRangeWithoutKeepSizeExtendsFile) {
   EXPECT_EQ(slices0[1].pos(), 4096u);
   EXPECT_EQ(slices0[1].len(), 4096u);
 
-  ChunkEntry chunk1 = GetChunk(ino, 1);
-  ASSERT_EQ(chunk1.slices_size(), 1);
-  EXPECT_EQ(chunk1.slices(0).id(), 0u);
-  EXPECT_EQ(chunk1.slices(0).pos(), 0u);
-  EXPECT_EQ(chunk1.slices(0).len(), 4096u);
+  // Missing chunks are already holes and must not be materialized.
+  EXPECT_FALSE(ChunkExists(ino, 1));
 }
 
 // FALLOC_FL_ZERO_RANGE without FALLOC_FL_KEEP_SIZE but with the range fully
@@ -1554,6 +1551,14 @@ class UpdateAttrRunTest : public ::testing::Test {
             .ok());
   }
 
+  void SeedInode(const AttrEntry& attr) {
+    ASSERT_TRUE(storage_
+                    ->Put(KVStorage::WriteOption(),
+                          MetaCodec::EncodeInodeKey(attr.fs_id(), attr.ino()),
+                          MetaCodec::EncodeInodeValue(attr))
+                    .ok());
+  }
+
   bool ChunkExists(Ino ino, uint64_t index) {
     std::string value;
     return storage_
@@ -1760,9 +1765,8 @@ TEST_F(UpdateAttrRunTest, AtimeNowAndMtimeNowFlagsAreIgnored) {
 
 // --- size: truncate up / down / same ---------------------------------------
 
-// Truncate up sets the new length, reports a positive delta, and appends NO
-// zero slices (the extended region is sparse). It also leaves the timestamps
-// untouched (size-only setattr does not bump mtime/ctime in this op).
+// Truncate up sets the new length, reports a positive delta, appends no zero
+// slices (the extended region is sparse), and advances mtime/ctime.
 TEST_F(UpdateAttrRunTest, SizeTruncateUpSetsLengthWithoutZeroSlices) {
   const Ino ino = 211;
   auto baseline = MakeFullInode(ino, 4096);
@@ -1780,6 +1784,8 @@ TEST_F(UpdateAttrRunTest, SizeTruncateUpSetsLengthWithoutZeroSlices) {
 
   auto expected = baseline;
   expected.set_length(8192);
+  expected.set_mtime(got.mtime());
+  expected.set_ctime(got.ctime());
   ExpectAttrEq(got, expected);
 }
 
@@ -1809,9 +1815,10 @@ TEST_F(UpdateAttrRunTest, SizeTruncateDownAppendsZeroSlices) {
   EXPECT_EQ(slices[1].pos(), 4096u);
   EXPECT_EQ(slices[1].len(), kFallocChunkSize - 4096);
 
-  // Only length changed; timestamps are left as-is.
   auto expected = baseline;
   expected.set_length(4096);
+  expected.set_mtime(got.mtime());
+  expected.set_ctime(got.ctime());
   ExpectAttrEq(got, expected);
 }
 
@@ -1881,9 +1888,8 @@ TEST_F(UpdateAttrRunTest, TruncateUpdatesSizeAndTimestamps) {
   ExpectAttrEq(got, expected);
 }
 
-// Truncate down over a sparse file: AppendZeroSlices appends to the existing
-// chunks (0 and 2) AND creates the missing middle chunk (1) in a single pass,
-// exercising both branches within one range.
+// Truncate down over a sparse file: AppendZeroSlices appends to existing
+// chunks (0 and 2) but leaves the missing middle chunk (1) as a hole.
 TEST_F(UpdateAttrRunTest, SizeTruncateDownSparseMiddleChunk) {
   const Ino ino = 217;
   const uint64_t length = 3 * kFallocChunkSize;
@@ -1903,15 +1909,92 @@ TEST_F(UpdateAttrRunTest, SizeTruncateDownSparseMiddleChunk) {
 
   EXPECT_EQ(got.length(), 0u);
   EXPECT_EQ(delta, -static_cast<int64_t>(length));
-  ASSERT_EQ(effected, 3u);  // chunks 0, 1, 2 all touched
+  ASSERT_EQ(effected, 2u);  // only existing chunks 0 and 2 are touched
 
-  EXPECT_EQ(SortedSlices(ino, 0).size(), 2u);  // real + zero (append branch)
-  auto mid = SortedSlices(ino, 1);
-  ASSERT_EQ(mid.size(), 1u);  // sparse chunk created fresh (create branch)
-  EXPECT_EQ(mid[0].id(), 0u);
-  EXPECT_EQ(mid[0].pos(), 0u);
-  EXPECT_EQ(mid[0].len(), kFallocChunkSize);
-  EXPECT_EQ(SortedSlices(ino, 2).size(), 2u);  // real + zero (append branch)
+  EXPECT_EQ(SortedSlices(ino, 0).size(), 2u);  // real + zero
+  EXPECT_FALSE(ChunkExists(ino, 1));           // sparse hole stays sparse
+  EXPECT_EQ(SortedSlices(ino, 2).size(), 2u);  // real + zero
+}
+
+TEST_F(UpdateAttrRunTest, FlushRollbackZerosDroppedRangeAtomically) {
+  const Ino ino = 218;
+  const uint64_t old_length = 3 * kFallocChunkSize;
+  SeedInode(MakeFullInode(ino, old_length));
+  SeedChunk(
+      ino, MakeSizedChunk(0, {MakeSlice(/*id=*/4000, 0, kFallocChunkSize, 0)}));
+  // chunk 1 intentionally absent.
+  SeedChunk(
+      ino, MakeSizedChunk(2, {MakeSlice(/*id=*/4002, 0, kFallocChunkSize, 0)}));
+
+  FlushFileOperation::ExtraParam param;
+  param.length = old_length;
+  param.chunk_size = kFallocChunkSize;
+  param.rollback = true;
+  param.rollback_to_length = 4096;
+  FlushFileOperation op(trace_, kFallocFsId, ino, param);
+
+  auto txn = storage_->NewTxn();
+  ASSERT_TRUE(op.Run(txn).ok());
+  ASSERT_TRUE(txn->Commit().ok());
+
+  EXPECT_EQ(op.GetResult().attr.length(), 4096u);
+  EXPECT_EQ(op.GetResult().delta_bytes,
+            -static_cast<int64_t>(old_length - 4096));
+  auto chunk0_slices = SortedSlices(ino, 0);
+  EXPECT_TRUE(std::any_of(chunk0_slices.begin(), chunk0_slices.end(),
+                          [](const SliceEntry& slice) {
+                            return slice.id() == 0 && slice.pos() == 4096;
+                          }));
+  EXPECT_FALSE(ChunkExists(ino, 1));
+  auto chunk2_slices = SortedSlices(ino, 2);
+  EXPECT_TRUE(std::any_of(chunk2_slices.begin(), chunk2_slices.end(),
+                          [](const SliceEntry& slice) {
+                            return slice.id() == 0 && slice.pos() == 0;
+                          }));
+
+  // Re-running after an ambiguous first response sees the checkpoint and is a
+  // no-op; result state must not retain the first attempt's negative delta.
+  auto retry_txn = storage_->NewTxn();
+  ASSERT_TRUE(op.Run(retry_txn).ok());
+  ASSERT_TRUE(retry_txn->Commit().ok());
+  EXPECT_EQ(op.GetResult().delta_bytes, 0);
+  EXPECT_EQ(SortedSlices(ino, 0).size(), chunk0_slices.size());
+  EXPECT_EQ(SortedSlices(ino, 2).size(), chunk2_slices.size());
+}
+
+TEST_F(UpdateAttrRunTest, OpenTruncZerosExistingChunksAndReturnsNoPrefetch) {
+  const Ino ino = 219;
+  const uint64_t old_length = 2 * kFallocChunkSize;
+  auto attr = MakeFullInode(ino, old_length);
+  SeedChunk(
+      ino, MakeSizedChunk(0, {MakeSlice(/*id=*/5000, 0, kFallocChunkSize, 0)}));
+
+  FileSessionEntry session;
+  session.set_fs_id(kFallocFsId);
+  session.set_ino(ino);
+  session.set_session_id("open-trunc-session");
+  std::vector<uint32_t> prefetch_chunks = {0};
+  OpenFileOperation op(trace_, O_TRUNC | O_WRONLY, session, kFallocChunkSize,
+                       prefetch_chunks);
+
+  std::vector<std::string> keys;
+  op.PrefetchKey(keys);
+  EXPECT_TRUE(keys.empty());
+
+  Operation::BatchSharedParam shared_param;
+  shared_param.attr = attr;
+  auto txn = storage_->NewTxn();
+  ASSERT_TRUE(op.RunInBatch(txn, shared_param).ok());
+  ASSERT_TRUE(txn->Commit().ok());
+
+  EXPECT_EQ(shared_param.attr.length(), 0u);
+  EXPECT_EQ(op.GetResult().delta_bytes, -static_cast<int64_t>(old_length));
+  EXPECT_TRUE(op.GetResult().chunks.empty());
+  auto slices = SortedSlices(ino, 0);
+  EXPECT_TRUE(
+      std::any_of(slices.begin(), slices.end(), [](const SliceEntry& slice) {
+        return slice.id() == 0 && slice.pos() == 0;
+      }));
 }
 
 // SetResultAttr copies the mutated shared_param.attr into the result for the

--- a/test/unit/mds/filesystem/test_store_operation.cc
+++ b/test/unit/mds/filesystem/test_store_operation.cc
@@ -1620,6 +1620,40 @@ TEST_F(UpdateAttrRunTest, UpdateModeOnly) {
   ExpectAttrEq(got, expected);
 }
 
+TEST_F(UpdateAttrRunTest, KillPrivilegeBits) {
+  const Ino ino = 210;
+  auto baseline = MakeFullInode(ino, 100);
+  baseline.set_mode(06755);
+  auto new_vals = MakeNewValues();
+
+  auto got = RunUpdate(ino, kSetAttrKillSuid, new_vals, baseline);
+  auto expected = baseline;
+  expected.set_mode(02755);
+  ExpectAttrEq(got, expected);
+
+  got = RunUpdate(ino, kSetAttrKillSgid, new_vals, baseline);
+  expected.set_mode(04755);
+  ExpectAttrEq(got, expected);
+
+  got = RunUpdate(ino, kSetAttrKillPriv, new_vals, baseline);
+  expected.set_mode(0755);
+  ExpectAttrEq(got, expected);
+}
+
+TEST_F(UpdateAttrRunTest, KillPrivilegeBitsAfterModeUpdate) {
+  const Ino ino = 211;
+  auto baseline = MakeFullInode(ino, 100);
+  auto new_vals = MakeNewValues();
+  new_vals.set_mode(06770);
+
+  auto got =
+      RunUpdate(ino, kSetAttrMode | kSetAttrKillPriv, new_vals, baseline);
+
+  auto expected = baseline;
+  expected.set_mode(0770);
+  ExpectAttrEq(got, expected);
+}
+
 TEST_F(UpdateAttrRunTest, UpdateUidOnly) {
   const Ino ino = 201;
   auto baseline = MakeFullInode(ino, 100);


### PR DESCRIPTION
## Summary

When a data flush fails, the file length that WriteSlice already pushed forward on MDS stayed in place, so abandoned, unflushed bytes remained visible as file content. This PR rolls the MDS-persisted length back to the last successful flush checkpoint on flush failure, abandoning the failed round of writes. It also hardens every length-shrink path (truncate-down, O_TRUNC, rollback) to atomically append zero slices over the dropped range, so truncated data can never resurface after a later re-extension.

The MDS-side zero-slice fix ships together with the rollback because rollback correctness depends on the shrink path zeroing dropped data.

## How it works

```mermaid
flowchart TB
    A[VFSImpl Flush / Release] -->|data flush fails| B[RollbackWriteLength]
    B -->|FlushFile RPC, rollback flag| C[MDS FlushFileOperation]
    C -->|checkpoint < length <= last write?| D{conditional}
    D -->|yes| E[append zero slices + shrink length in one txn]
    D -->|no: another writer moved length| F[give up conservatively]
```

- **Flush checkpoint (client-side)**: each open write session records the file length at its last fully successful data flush (or at open, if none). Tracked in ChunkSet/FileSession; MDS gains no new session state.
- **Conditional rollback (MDS-side, atomic)**: reuses the FlushFile RPC with a rollback flag plus the checkpoint length. MDS shrinks only when `checkpoint < current length <= this session's last write length`. WriteSlice also pushes the durable length, so an unconditional rollback could cut data a concurrent writer legitimately persisted. Single-writer correctness is guaranteed; multi-writer cases give up conservatively (a sparse hole remains, never corruption).
- **Zero-slice hardening**: truncate-down, O_TRUNC, and rollback now append id=0 zero slices over the dropped range in the same transaction as the length update. Only existing chunks are touched; missing chunks are already holes and stay sparse.
- **Best-effort trigger**: rollback fires only on user-visible failure points (Flush/Release), one attempt each, no retry state machine. The writer stays sticky-broken; the user must reopen to continue writing, matching standard POSIX fsync-failure handling.
- **Cache safety**: on success or on commit-ambiguous network errors, the client conservatively invalidates inode, chunk, and read caches.

Also fixes DingoStore handler-based Scan pagination, which rescanned the same range forever; large shrink ranges depend on it.

## Key decisions

- Reuse FlushFile instead of adding an RPC: the existing shrink post-processing (chunk cache invalidation, attr writeback) is reused, and proto3 default 0 serves as the "not set" sentinel while the rollback flag disambiguates "shrink to 0".
- No physical undo of committed slices: abandoned slices are shadowed by zero slices and left for compaction/GC. Full undo would need snapshot-level machinery at disproportionate cost.
- Shrink scope is decided by the authoritative old length read inside the MDS transaction; zero slices and the inode length commit atomically, with no batched compensation.

Design details and terminology are in `docs/adr/0003-flush-failure-length-rollback.md`.

## Test plan

- `test_filesystem.cc` — `FlushFileRollbackConditionalShrink`: conditional shrink, idempotent retry after an ambiguous response, and multi-writer give-up.
- `test_store_operation.cc` — `FlushRollbackZerosDroppedRangeAtomically` (zero slices + length in one txn, retry is a no-op), `OpenTruncZerosExistingChunksAndReturnsNoPrefetch`, and updated sparse truncate-down cases asserting holes stay sparse.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![pi](https://img.shields.io/badge/Kimi_K3-000000)