### PR TITLE
[refactor][client] Centralize client session lifecycle; narrow VFS boundaries

### DIFF
--- a/sdk/shim/binding_client.cc
+++ b/sdk/shim/binding_client.cc
@@ -43,7 +43,7 @@ Context BindingClient::MakeContext(uint32_t uid, uint32_t gid) {
   return {uid, gid, pid_, 0};
 }
 
-BindingClient::BindingClient() : vfs_(std::make_unique<VFSWrapper>()) {}
+BindingClient::BindingClient() : vfs_(std::make_unique<ClientSession>()) {}
 
 BindingClient::~BindingClient() = default;
 

--- a/sdk/shim/binding_client.h
+++ b/sdk/shim/binding_client.h
@@ -21,8 +21,8 @@
 #include <string>
 #include <vector>
 
+#include "client/vfs/client_session.h"
 #include "client/vfs/data_buffer.h"
-#include "client/vfs/vfs_wrapper.h"
 #include "common/meta.h"
 #include "common/status.h"
 
@@ -70,8 +70,8 @@ struct OptionInfo {
   std::string description;
 };
 
-// BindingClient wraps VFSWrapper for use from language bindings.
-// It handles gflags/logging setup before delegating to VFSWrapper.
+// BindingClient wraps ClientSession for use from language bindings.
+// It handles gflags/logging setup before delegating to ClientSession.
 class BindingClient {
  public:
   BindingClient();
@@ -160,7 +160,7 @@ class BindingClient {
   Context MakeContext();
   Context MakeContext(uint32_t uid, uint32_t gid);
 
-  std::unique_ptr<VFSWrapper> vfs_;
+  std::unique_ptr<ClientSession> vfs_;
   bool self_inited_glog_ = false;
   int32_t pid_;
 };

--- a/sdk/shim/tests/test_binding_logging.cc
+++ b/sdk/shim/tests/test_binding_logging.cc
@@ -26,6 +26,9 @@
  *   conf_file log_dir : logs written to path from conf_file
  *   no log_dir set    : logs written to /tmp (matches glog's own default)
  *
+ * Group 3 — startup configuration ordering (1 case)
+ *   trace conf flags : TraceManager captures flags after conf_file is loaded
+ *
  * --- Subprocess design ---
  * DingoFS registers spdlog loggers once per process at BindingClient
  * construction time.  Creating a second instance in the same process
@@ -47,6 +50,8 @@
 #include <glog/logging.h>
 
 #include "binding_client.h"
+#include "common/options/common.h"
+#include "common/sync_point.h"
 
 using dingofs::client::BindingClient;
 using dingofs::client::BindingConfig;
@@ -294,6 +299,49 @@ static void test_log_dir_default_tmp() {
 }
 
 /* ============================================================================
+ * Group 3 — startup configuration ordering
+ * ============================================================================ */
+
+static void test_trace_config_from_conf_file() {
+    const char* name =
+        "trace config: TraceManager captures flags after conf_file load";
+
+#ifdef NDEBUG
+    PASS(name);
+#else
+    const std::string endpoint = "127.0.0.1:14317";
+    const std::string conf_path = "/tmp/dingofs-trace-test-conffile.conf";
+    FILE* f = fopen(conf_path.c_str(), "w");
+    ASSERT(name, f != nullptr);
+    fprintf(f, "--otlp_export_endpoint=%s\n", endpoint.c_str());
+    fclose(f);
+
+    bool captured = false;
+    std::string captured_endpoint;
+    dingofs::SyncPoint::GetInstance()->SetCallBack(
+        "TraceManager::TraceManager:after_config_capture", [&](void*) {
+            captured = true;
+            captured_endpoint = dingofs::FLAGS_otlp_export_endpoint;
+        });
+    dingofs::SyncPoint::GetInstance()->EnableProcessing();
+
+    BindingConfig cfg = make_config(/*log_dir=*/"", conf_path);
+    cfg.init_glog = false;
+    BindingClient client;
+    client.Start(cfg);
+
+    dingofs::SyncPoint::GetInstance()->DisableProcessing();
+    dingofs::SyncPoint::GetInstance()->ClearAllCallBacks();
+    client.Stop();
+    unlink(conf_path.c_str());
+
+    ASSERT(name, captured);
+    ASSERT(name, captured_endpoint == endpoint);
+    PASS(name);
+#endif
+}
+
+/* ============================================================================
  * Entry point
  * ============================================================================ */
 
@@ -315,6 +363,8 @@ int main(int argc, char* argv[]) {
         else if (strcmp(id, "dir-explicit") == 0) test_log_dir_explicit();
         else if (strcmp(id, "dir-conffile") == 0) test_log_dir_from_conf_file();
         else if (strcmp(id, "dir-default")  == 0) test_log_dir_default_tmp();
+        else if (strcmp(id, "trace-conffile") == 0)
+            test_trace_config_from_conf_file();
         else { fprintf(stderr, "unknown case: %s\n", id); return 1; }
         return g_fail > 0 ? 1 : 0;
     }
@@ -330,6 +380,9 @@ int main(int argc, char* argv[]) {
         {"dir-explicit", "[dir] explicit config.log_dir  →  logs in that dir"},
         {"dir-conffile", "[dir] log_dir via conf_file     →  logs in conf_file dir"},
         {"dir-default",  "[dir] no log_dir set            →  logs in /tmp"},
+        /* Group 3: startup configuration ordering */
+        {"trace-conffile",
+         "[trace] conf_file flags loaded before TraceManager construction"},
     };
 
     int total_pass = 0, total_fail = 0;

--- a/src/client/common/const.h
+++ b/src/client/common/const.h
@@ -26,11 +26,6 @@
 namespace dingofs {
 namespace client {
 
-// module name
-static const std::string kVFSMoudule = "vfs";
-static const std::string kVFSWrapperMoudule = "vfs_wrapper";
-static const std::string kVFSDataMoudule = "vfs_data";
-
 // ioctl related constants
 static const uint8_t kFlagImmutable = (1 << 0);
 static const uint8_t kFlagAppend = (1 << 1);

--- a/src/client/fuse/fs_context.h
+++ b/src/client/fuse/fs_context.h
@@ -21,7 +21,7 @@
 
 #include "client/fuse/fuse_common.h"
 #include "client/fuse/fuse_server.h"
-#include "client/vfs/vfs_wrapper.h"
+#include "client/vfs/client_session.h"
 
 namespace dingofs {
 namespace client {
@@ -30,10 +30,10 @@ namespace fuse {
 struct FsContext {
   struct MountOption* mount_option;
   FuseServer* fuse_server;
-  // Own the VFS until after fuse_session_loop has stopped and all workers have
-  // been joined. FUSE destroy callbacks may run inline on a worker, so they
-  // must Stop this object but never delete it.
-  std::unique_ptr<VFSWrapper> vfs;
+  // Own the ClientSession until after fuse_session_loop has stopped and all
+  // workers have been joined. FUSE destroy callbacks may run inline on a
+  // worker, so they must Stop this object but never delete it.
+  std::unique_ptr<ClientSession> session;
 };
 
 }  // namespace fuse

--- a/src/client/fuse/fuse_op.cc
+++ b/src/client/fuse/fuse_op.cc
@@ -29,10 +29,10 @@
 #include "client/common/const.h"
 #include "client/fuse/fs_context.h"
 #include "client/fuse/upgrade/state_store.h"
+#include "client/vfs/client_session.h"
 #include "client/vfs/common/helper.h"
 #include "client/vfs/data_buffer.h"
 #include "client/vfs/vfs_meta.h"
-#include "client/vfs/vfs_wrapper.h"
 #include "common/const.h"
 #include "common/io_buffer.h"
 #include "common/options/client.h"
@@ -40,7 +40,7 @@
 #include "fmt/format.h"
 #include "glog/logging.h"
 
-static dingofs::client::VFSWrapper* g_vfs = nullptr;
+static dingofs::client::ClientSession* g_client_session = nullptr;
 
 USING_FLAG(fuse_enable_direct_io)
 USING_FLAG(fuse_enable_keep_cache)
@@ -132,8 +132,8 @@ void Attr2FuseEntry(const Attr& attr, struct fuse_entry_param* e) {
   e->generation = 0;
   Attr2Stat(attr, &e->attr);
 
-  e->attr_timeout = g_vfs->GetAttrTimeout(attr.type);
-  e->entry_timeout = g_vfs->GetEntryTimeout(attr.type);
+  e->attr_timeout = g_client_session->GetAttrTimeout(attr.type);
+  e->entry_timeout = g_client_session->GetEntryTimeout(attr.type);
 }
 
 Attr Stat2Attr(struct stat* stat) {
@@ -177,7 +177,7 @@ static void ReplyAttr(fuse_req_t req, const Attr& attr) {
   memset(&stat, 0, sizeof(stat));
   Attr2Stat(attr, &stat);
 
-  int ret = fuse_reply_attr(req, &stat, g_vfs->GetAttrTimeout(attr.type));
+  int ret = fuse_reply_attr(req, &stat, g_client_session->GetAttrTimeout(attr.type));
   if (ret != 0) {
     LOG(ERROR) << fmt::format("[fuse] fuse_reply_attr fail, ret({}).", errno);
   }
@@ -351,9 +351,9 @@ static void ReplyStatfs(fuse_req_t req, const FsStat& stat) {
   stbuf.f_bfree = stbuf.f_bavail = free_blocks;
   stbuf.f_files = total_inodes;
   stbuf.f_ffree = stbuf.f_favail = free_inodes;
-  stbuf.f_fsid = g_vfs->GetFsId();
+  stbuf.f_fsid = stat.fs_id;
   stbuf.f_flag = 0;
-  stbuf.f_namemax = g_vfs->GetMaxNameLength();
+  stbuf.f_namemax = g_client_session->GetMaxNameLength();
 
   int ret = fuse_reply_statfs(req, &stbuf);
   if (ret != 0) {
@@ -370,7 +370,7 @@ static Context GenCtx(const fuse_req_t& req) {
 static void PrintReadyInfo(struct MountOption* mount_option) {
   // print config info
   std::string info;
-  auto s = g_vfs->GetInfo(&info);
+  auto s = g_client_session->GetInfo(&info);
   if (s.ok()) {
     LOG(INFO) << "[dingofs] client info: " << info;
   }
@@ -402,15 +402,15 @@ void FuseOpInit(void* userdata, struct fuse_conn_info* conn) {
             << ", fs name: " << config.fs_name
             << ", meta_url: " << mount_option->meta_url;
 
-  CHECK(fs_context->vfs == nullptr) << "VFS already initialized";
-  fs_context->vfs = std::make_unique<dingofs::client::VFSWrapper>();
-  g_vfs = fs_context->vfs.get();
+  CHECK(fs_context->session == nullptr) << "VFS already initialized";
+  fs_context->session = std::make_unique<dingofs::client::ClientSession>();
+  g_client_session = fs_context->session.get();
   int upgrade_from_pid = 0;
   if (UpgradeStateStore::GetInstance().GetFuseState() ==
       FuseUpgradeState::kFuseUpgradeNew) {
     upgrade_from_pid = UpgradeStateStore::GetInstance().GetOldFusePid();
   }
-  Status s = g_vfs->Start(config, upgrade_from_pid);
+  Status s = g_client_session->Start(config, upgrade_from_pid);
   if (!s.ok()) {
     LOG(ERROR) << "start vfs fail, status: " << s.ToString();
     fs_context->fuse_server->Shutdown();
@@ -429,7 +429,7 @@ void FuseOpInit(void* userdata, struct fuse_conn_info* conn) {
   // healthy. See handover-ack-handshake-design.md /
   // dingofs-hotupgrade-constraints.md.
   fs_context->fuse_server->SetHandoverCheckpoint([]() -> Status {
-    Status s = g_vfs->Stop(/*handover=*/true);
+    Status s = g_client_session->Stop(/*handover=*/true);
     if (!s.ok()) {
       LOG(FATAL) << "hot-upgrade: stop/dump failed";
     }
@@ -445,10 +445,10 @@ void FuseOpInit(void* userdata, struct fuse_conn_info* conn) {
 
 void FuseOpDestroy(void* userdata) {
   VLOG(1) << "FuseOpDestroy userdata: " << userdata;
-  if (g_vfs) {
+  if (g_client_session) {
     const bool handover = (UpgradeStateStore::GetInstance().GetFuseState() ==
                            FuseUpgradeState::kFuseUpgradeOld);
-    g_vfs->Stop(handover);
+    g_client_session->Stop(handover);
   }
 }
 
@@ -459,7 +459,7 @@ void FuseOpLookup(fuse_req_t req, fuse_ino_t parent, const char* name) {
                          ctx.ToString(), parent, name);
 
   Attr out_attr;
-  Status s = g_vfs->Lookup(ctx, parent, name, &out_attr);
+  Status s = g_client_session->Lookup(ctx, parent, name, &out_attr);
   s.ok() ? ReplyEntry(req, out_attr) : ReplyError(req, s);
 }
 
@@ -469,7 +469,7 @@ void FuseOpGetAttr(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info* fi) {
   VLOG(1) << fmt::format("FuseOpGetAttr ctx({}) ino({})", ctx.ToString(), ino);
 
   Attr out_attr;
-  Status s = g_vfs->GetAttr(ctx, ino, &out_attr);
+  Status s = g_client_session->GetAttr(ctx, ino, &out_attr);
   s.ok() ? ReplyAttr(req, out_attr) : ReplyError(req, s);
 }
 
@@ -482,7 +482,7 @@ void FuseOpSetAttr(fuse_req_t req, fuse_ino_t ino, struct stat* attr,
 
   Attr in_attr = Stat2Attr(attr);
   Attr out_attr;
-  Status s = g_vfs->SetAttr(ctx, ino, to_set, in_attr, &out_attr);
+  Status s = g_client_session->SetAttr(ctx, ino, to_set, in_attr, &out_attr);
   s.ok() ? ReplyAttr(req, out_attr) : ReplyError(req, s);
 }
 
@@ -492,7 +492,7 @@ void FuseOpReadLink(fuse_req_t req, fuse_ino_t ino) {
   VLOG(1) << fmt::format("FuseOpReadLink ctx({}) ino({})", ctx.ToString(), ino);
 
   std::string link;
-  Status s = g_vfs->ReadLink(ctx, ino, &link);
+  Status s = g_client_session->ReadLink(ctx, ino, &link);
   s.ok() ? ReplyReadlink(req, link) : ReplyError(req, s);
 }
 
@@ -506,7 +506,7 @@ void FuseOpMkNod(fuse_req_t req, fuse_ino_t parent, const char* name,
 
   // TODO: extract userinfo struct
   Attr out_attr;
-  Status s = g_vfs->MkNod(ctx, parent, name, mode, rdev, &out_attr);
+  Status s = g_client_session->MkNod(ctx, parent, name, mode, rdev, &out_attr);
   s.ok() ? ReplyEntry(req, out_attr) : ReplyError(req, s);
 }
 
@@ -518,7 +518,7 @@ void FuseOpMkDir(fuse_req_t req, fuse_ino_t parent, const char* name,
                          ctx.ToString(), parent, name, mode);
 
   Attr out_attr;
-  Status s = g_vfs->MkDir(ctx, parent, name, mode, &out_attr);
+  Status s = g_client_session->MkDir(ctx, parent, name, mode, &out_attr);
   s.ok() ? ReplyEntry(req, out_attr) : ReplyError(req, s);
 }
 
@@ -528,7 +528,7 @@ void FuseOpUnlink(fuse_req_t req, fuse_ino_t parent, const char* name) {
   VLOG(1) << fmt::format("FuseOpUnlink ctx({}) parent({}) name({})",
                          ctx.ToString(), parent, name);
 
-  Status s = g_vfs->Unlink(ctx, parent, name);
+  Status s = g_client_session->Unlink(ctx, parent, name);
   ReplyError(req, s);
 }
 
@@ -538,7 +538,7 @@ void FuseOpRmDir(fuse_req_t req, fuse_ino_t parent, const char* name) {
   VLOG(1) << fmt::format("FuseOpRmDir ctx({}) parent({}) name({})",
                          ctx.ToString(), parent, name);
 
-  Status s = g_vfs->RmDir(ctx, parent, name);
+  Status s = g_client_session->RmDir(ctx, parent, name);
   ReplyError(req, s);
 }
 
@@ -550,7 +550,7 @@ void FuseOpSymlink(fuse_req_t req, const char* link, fuse_ino_t parent,
                          ctx.ToString(), link, parent, name);
 
   Attr out_attr;
-  Status s = g_vfs->Symlink(ctx, parent, name, link, &out_attr);
+  Status s = g_client_session->Symlink(ctx, parent, name, link, &out_attr);
   s.ok() ? ReplyEntry(req, out_attr) : ReplyError(req, s);
 }
 
@@ -564,7 +564,7 @@ void FuseOpRename(fuse_req_t req, fuse_ino_t parent, const char* name,
       "flags({})",
       ctx.ToString(), parent, name, newparent, newname, flags);
 
-  Status s = g_vfs->Rename(ctx, parent, name, newparent, newname);
+  Status s = g_client_session->Rename(ctx, parent, name, newparent, newname);
   ReplyError(req, s);
 }
 
@@ -576,7 +576,7 @@ void FuseOpLink(fuse_req_t req, fuse_ino_t ino, fuse_ino_t newparent,
                          ctx.ToString(), ino, newparent, newname);
 
   Attr out_attr;
-  Status s = g_vfs->Link(ctx, ino, newparent, newname, &out_attr);
+  Status s = g_client_session->Link(ctx, ino, newparent, newname, &out_attr);
   s.ok() ? ReplyEntry(req, out_attr) : ReplyError(req, s);
 }
 
@@ -588,7 +588,7 @@ void FuseOpOpen(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info* fi) {
 
   uint64_t fh = 0;
   bool keep_cache = FLAGS_fuse_enable_keep_cache;
-  Status s = g_vfs->Open(ctx, ino, fi->flags, &fh, &keep_cache);
+  Status s = g_client_session->Open(ctx, ino, fi->flags, &fh, &keep_cache);
   if (!s.ok()) {
     ReplyError(req, s);
 
@@ -646,7 +646,7 @@ void FuseOpRead(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   }
 
   uint64_t rsize = 0;
-  Status s = g_vfs->Read(ctx, ino, &data_buffer, size, off, fi->fh, &rsize);
+  Status s = g_client_session->Read(ctx, ino, &data_buffer, size, off, fi->fh, &rsize);
   s.ok() ? ReplyData(req, data_buffer) : ReplyError(req, s);
 }
 
@@ -664,7 +664,7 @@ void FuseOpWrite(fuse_req_t req, fuse_ino_t ino, const char* buf, size_t size,
   }
 
   uint64_t wsize = 0;
-  Status s = g_vfs->Write(ctx, ino, buf, size, off, fi->fh, &wsize);
+  Status s = g_client_session->Write(ctx, ino, buf, size, off, fi->fh, &wsize);
   s.ok() ? ReplyWrite(req, wsize) : ReplyError(req, s);
 }
 
@@ -679,7 +679,7 @@ void FuseOpFlush(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info* fi) {
     return;
   }
 
-  Status s = g_vfs->Flush(ctx, ino, fi->fh);
+  Status s = g_client_session->Flush(ctx, ino, fi->fh);
   ReplyError(req, s);
 }
 
@@ -689,7 +689,7 @@ void FuseOpRelease(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info* fi) {
   VLOG(1) << fmt::format("FuseOpRelease ctx({}) ino({}) fh({})", ctx.ToString(),
                          ino, fi->fh);
 
-  Status s = g_vfs->Release(ctx, ino, fi->fh);
+  Status s = g_client_session->Release(ctx, ino, fi->fh);
   ReplyError(req, s);
 }
 
@@ -706,7 +706,7 @@ void FuseOpFsync(fuse_req_t req, fuse_ino_t ino, int datasync,
     return;
   }
 
-  Status s = g_vfs->Fsync(ctx, ino, datasync, fi->fh);
+  Status s = g_client_session->Fsync(ctx, ino, datasync, fi->fh);
   ReplyError(req, s);
 }
 
@@ -723,7 +723,7 @@ void FuseOpFallocate(fuse_req_t req, fuse_ino_t ino, int mode, off_t offset,
     return;
   }
 
-  Status s = g_vfs->Fallocate(ctx, ino, mode, static_cast<uint64_t>(offset),
+  Status s = g_client_session->Fallocate(ctx, ino, mode, static_cast<uint64_t>(offset),
                               static_cast<uint64_t>(length));
   ReplyError(req, s);
 }
@@ -756,7 +756,7 @@ void FuseOpCopyFileRange(fuse_req_t req, fuse_ino_t ino_in, off_t off_in,
   }
 
   uint64_t bytes_copied = 0;
-  Status s = g_vfs->CopyFileRange(
+  Status s = g_client_session->CopyFileRange(
       ctx, ino_in, static_cast<uint64_t>(off_in), fi_in ? fi_in->fh : 0,
       ino_out, static_cast<uint64_t>(off_out), fi_out ? fi_out->fh : 0,
       static_cast<uint64_t>(len), static_cast<uint32_t>(flags), &bytes_copied);
@@ -774,7 +774,7 @@ void FuseOpOpenDir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info* fi) {
 
   uint64_t fh = 0;
   bool need_cache = true;
-  Status s = g_vfs->OpenDir(ctx, ino, &fh, need_cache);
+  Status s = g_client_session->OpenDir(ctx, ino, &fh, need_cache);
   if (!s.ok()) {
     ReplyError(req, s);
 
@@ -808,7 +808,7 @@ void FuseOpReadDir(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   off_t next_off = off;
   size_t writed_size = 0;
   std::string buffer(size, '\0');
-  Status s = g_vfs->ReadDir(
+  Status s = g_client_session->ReadDir(
       ctx, ino, fi->fh, off, false,
       [&](const dingofs::client::vfs::DirEntry& dir_entry, uint64_t) -> bool {
         VLOG(3) << fmt::format("read dir({}) off[{},{}) fh({}) entry({}/{}).",
@@ -867,7 +867,7 @@ void FuseOpReadDirPlus(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   off_t next_off = off;
   size_t writed_size = 0;
   std::string buffer(size, '\0');
-  Status s = g_vfs->ReadDir(
+  Status s = g_client_session->ReadDir(
       ctx, ino, fi->fh, off, true,
       [ino, off, &next_off, &req, &fi, &buffer, &writed_size](
           const dingofs::client::vfs::DirEntry& dir_entry, uint64_t) -> bool {
@@ -921,7 +921,7 @@ void FuseOpReleaseDir(fuse_req_t req, fuse_ino_t ino,
   VLOG(1) << fmt::format("FuseOpReleaseDir ctx({}) ino:{}, fi->fh:{}",
                          ctx.ToString(), ino, fi->fh);
 
-  Status s = g_vfs->ReleaseDir(ctx, ino, fi->fh);
+  Status s = g_client_session->ReleaseDir(ctx, ino, fi->fh);
   ReplyError(req, s);
 }
 
@@ -935,7 +935,7 @@ void FuseOpSetXattr(fuse_req_t req, fuse_ino_t ino, const char* name,
 
   std::string strname(name);
   std::string strvalue(value, size);
-  Status s = g_vfs->SetXattr(ctx, ino, strname, strvalue, flags);
+  Status s = g_client_session->SetXattr(ctx, ino, strname, strvalue, flags);
   ReplyError(req, s);
 }
 
@@ -947,7 +947,7 @@ void FuseOpGetXattr(fuse_req_t req, fuse_ino_t ino, const char* name,
                          ctx.ToString(), ino, name, size);
 
   std::string value;
-  Status s = g_vfs->GetXattr(ctx, ino, name, &value);
+  Status s = g_client_session->GetXattr(ctx, ino, name, &value);
 
   if (!s.ok()) {
     ReplyError(req, s);
@@ -975,7 +975,7 @@ void FuseOpRemoveXattr(fuse_req_t req, fuse_ino_t ino, const char* name) {
                          ctx.ToString(), ino, name);
 
   std::string strname(name);
-  Status s = g_vfs->RemoveXattr(ctx, ino, strname);
+  Status s = g_client_session->RemoveXattr(ctx, ino, strname);
   ReplyError(req, s);
 }
 
@@ -988,7 +988,7 @@ void FuseOpListXattr(fuse_req_t req, fuse_ino_t ino, size_t size) {
   CHECK_GE(size, 0) << "size is illegal, size: " << size;
 
   std::vector<std::string> names;
-  Status s = g_vfs->ListXattr(ctx, ino, &names);
+  Status s = g_client_session->ListXattr(ctx, ino, &names);
   if (!s.ok()) {
     ReplyError(req, s);
 
@@ -1038,7 +1038,7 @@ void FuseOpCreate(fuse_req_t req, fuse_ino_t parent, const char* name,
 
   uint64_t fh = 0;
   Attr out_attr;
-  Status s = g_vfs->Create(ctx, parent, name, mode, fi->flags, &fh, &out_attr);
+  Status s = g_client_session->Create(ctx, parent, name, mode, fi->flags, &fh, &out_attr);
   if (!s.ok()) {
     ReplyError(req, s);
 
@@ -1080,7 +1080,7 @@ void FuseOpIoctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void* arg,
       ctx.ToString(), ino, cmd, flags, in_bufsz, out_bufsz);
 
   std::string out_buf(out_bufsz, '\0');
-  Status s = g_vfs->Ioctl(ctx, ino, cmd, flags, in_buf, in_bufsz,
+  Status s = g_client_session->Ioctl(ctx, ino, cmd, flags, in_buf, in_bufsz,
                           out_buf.data(), out_bufsz);
   s.ok() ? ReplyIoctl(req, out_buf.data(), out_bufsz) : ReplyError(req, s);
 }
@@ -1094,6 +1094,6 @@ void FuseOpStatFs(fuse_req_t req, fuse_ino_t ino) {
 
   struct statvfs statfs;
   dingofs::client::vfs::FsStat vfs_stat;
-  Status s = g_vfs->StatFs(ctx, ino, &vfs_stat);
+  Status s = g_client_session->StatFs(ctx, ino, &vfs_stat);
   s.ok() ? ReplyStatfs(req, vfs_stat) : ReplyError(req, s);
 }

--- a/src/client/fuse/upgrade/handover_controller.cc
+++ b/src/client/fuse/upgrade/handover_controller.cc
@@ -163,8 +163,9 @@ void HandoverController::Run() {
 
     // Do NOT pause IO (drain) if there is nothing to commit yet. The checkpoint
     // is registered by FuseOpInit during Serve(); a SIGHUP between arming this
-    // controller and that registration -- or after g_vfs->Start() failed and it
-    // is never registered -- would otherwise drain a full round only to abort.
+    // controller and that registration -- or after ClientSession::Start()
+    // failed and it is never registered -- would otherwise drain a full round
+    // only to abort.
     // Tell the new to back off and keep serving without ever pausing.
     bool has_checkpoint;
     {

--- a/src/client/main.cc
+++ b/src/client/main.cc
@@ -244,12 +244,12 @@ int main(int argc, char* argv[]) {
   FsContext fs_context{
       .mount_option = &mount_option,
       .fuse_server = fuse_server,
-      .vfs = nullptr,
+      .session = nullptr,
   };
 
   // fs_context is declared before the session cleanup below, so reverse
   // destruction order guarantees DestroySession() has joined every FUSE
-  // worker before fs_context.vfs is destroyed.
+  // worker before fs_context.session is destroyed.
 
   // create fuse session
   if (fuse_server->CreateSession(&fs_context) == 1) return EXIT_FAILURE;

--- a/src/client/vfs/CMakeLists.txt
+++ b/src/client/vfs/CMakeLists.txt
@@ -23,7 +23,7 @@ add_subdirectory(compaction)
 
 add_library(vfs_lib
     vfs_impl.cc
-    vfs_wrapper.cc
+    client_session.cc
     access_log.cc
 )
 

--- a/src/client/vfs/client_session.cc
+++ b/src/client/vfs/client_session.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "client/vfs/vfs_wrapper.h"
+#include "client/vfs/client_session.h"
 
 #include <bvar/bvar.h>
 #include <fcntl.h>
@@ -45,6 +45,7 @@
 #include "common/options/cache.h"
 #include "common/options/client.h"
 #include "common/status.h"
+#include "common/trace/trace_manager.h"
 #include "common/types.h"
 #include "fmt/format.h"
 #include "glog/logging.h"
@@ -79,7 +80,7 @@ static bvar::Adder<int64_t> g_active_public_operations(
 static bvar::Adder<uint64_t> g_rejected_public_operations(
     "vfs_rejected_public_operations_total");
 
-#define VFS_WRAPPER_OPERATION_GUARD()                              \
+#define CLIENT_SESSION_OPERATION_GUARD()                           \
   auto operation = TryAcquireOperation();                          \
   if (!operation.has_value()) {                                    \
     return Status::Stop("VFS is not accepting public operations"); \
@@ -302,12 +303,16 @@ static Status NormalizeMountRootPath(const std::string& in, std::string& out) {
 
   return Status::OK();
 }
+ClientSession::ClientSession() = default;
 
-VFSWrapper::OperationLease::~OperationLease() {
+ClientSession::~ClientSession() { Stop(/*handover=*/false); }
+
+ClientSession::OperationLease::~OperationLease() {
   if (owner_ != nullptr) owner_->ReleaseOperation();
 }
 
-std::optional<VFSWrapper::OperationLease> VFSWrapper::TryAcquireOperation() {
+std::optional<ClientSession::OperationLease>
+ClientSession::TryAcquireOperation() {
   {
     std::lock_guard<std::mutex> lock(lifecycle_mutex_);
     if (lifecycle_state_ != LifecycleState::kRunning) {
@@ -322,7 +327,7 @@ std::optional<VFSWrapper::OperationLease> VFSWrapper::TryAcquireOperation() {
   return OperationLease(this);
 }
 
-void VFSWrapper::ReleaseOperation() {
+void ClientSession::ReleaseOperation() {
   g_active_public_operations << -1;
 
   std::lock_guard<std::mutex> lock(lifecycle_mutex_);
@@ -334,13 +339,17 @@ void VFSWrapper::ReleaseOperation() {
   }
 }
 
-Status VFSWrapper::FinishStartFailure(const Status& status) {
+Status ClientSession::FinishStartFailure(const Status& status) {
   if (vfs_ != nullptr) {
     Status cleanup_status = vfs_->Stop(/*skip_unmount=*/false);
     if (!cleanup_status.ok()) {
       LOG(ERROR) << "cleanup after VFS start failure failed: "
                  << cleanup_status.ToString();
     }
+  }
+  if (trace_started_) {
+    trace_manager_->Stop();
+    trace_started_ = false;
   }
 
   {
@@ -352,7 +361,7 @@ Status VFSWrapper::FinishStartFailure(const Status& status) {
   return status;
 }
 
-Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
+Status ClientSession::Start(const DingofsConfig& config, int upgrade_from_pid) {
   LOG(INFO) << "vfs start";
 
   {
@@ -413,7 +422,14 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
         FLAGS_vfs_bthread_worker_num, bthread_getconcurrency());
   }
 
-  client_op_metric_ = std::make_unique<metrics::client::ClientOpMetric>();
+  trace_manager_ = std::make_unique<TraceManager>();
+  client_metrics_ = std::make_unique<metrics::client::ClientOpMetric>();
+  if (FLAGS_enable_trace) {
+    if (!trace_manager_->Init()) {
+      return FinishStartFailure(Status::Internal("init trace manager fail"));
+    }
+    trace_started_ = true;
+  }
 
   const bool is_upgrade = upgrade_from_pid > 0;
 
@@ -434,7 +450,7 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
 
   LOG(INFO) << "client id: " << client_id.Description();
 
-  vfs_ = std::make_unique<vfs::VFSImpl>(vfs_conf, client_id);
+  vfs_ = std::make_unique<vfs::VFSImpl>(vfs_conf, client_id, *trace_manager_);
   s = vfs_->Start(/*skip_mount=*/is_upgrade);
   if (!s.ok()) return FinishStartFailure(s);
 
@@ -451,12 +467,6 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
   uid_ = dingofs::Helper::GetOriginalUid();
   gid_ = dingofs::Helper::GetOriginalGid();
 
-  attr_timeout_ = vfs_->GetAttrTimeout(FileType::kFile);
-  entry_timeout_ = vfs_->GetEntryTimeout(FileType::kFile);
-  fs_id_ = vfs_->GetFsId();
-  max_name_length_ = vfs_->GetMaxNameLength();
-  immutable_values_published_.store(true, std::memory_order_release);
-
   {
     std::lock_guard<std::mutex> lock(lifecycle_mutex_);
     lifecycle_state_ = LifecycleState::kRunning;
@@ -466,7 +476,7 @@ Status VFSWrapper::Start(const DingofsConfig& config, int upgrade_from_pid) {
   return Status::OK();
 }
 
-Status VFSWrapper::Stop(bool handover) {
+Status ClientSession::Stop(bool handover) {
   {
     std::unique_lock<std::mutex> lock(lifecycle_mutex_);
     while (lifecycle_state_ == LifecycleState::kStarting) {
@@ -527,6 +537,10 @@ Status VFSWrapper::Stop(bool handover) {
   if (handover && s.ok() && !Dump()) {
     s = Status::InvalidParam("dump vfs state fail");
   }
+  if (trace_started_) {
+    trace_manager_->Stop();
+    trace_started_ = false;
+  }
 
   {
     std::lock_guard<std::mutex> lock(lifecycle_mutex_);
@@ -537,8 +551,8 @@ Status VFSWrapper::Stop(bool handover) {
   return s;
 }
 
-bool VFSWrapper::Dump() {
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Dump");
+bool ClientSession::Dump() {
+  auto span = trace_manager_->StartSpan("ClientSession::Dump");
 
   Json::Value root;
   if (!vfs_->Dump(dingofs::SpanScope::GetContext(span), root)) {
@@ -564,8 +578,8 @@ bool VFSWrapper::Dump() {
   return true;
 }
 
-bool VFSWrapper::Load(const Json::Value& value) {
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Load");
+bool ClientSession::Load(const Json::Value& value) {
+  auto span = trace_manager_->StartSpan("ClientSession::Load");
 
   // TODO(hotupgrade): verify value["schema_version"] matches the running
   // binary's expected version; refuse the handover (return false) on mismatch
@@ -587,46 +601,34 @@ bool VFSWrapper::Load(const Json::Value& value) {
   return true;
 }
 
-Status VFSWrapper::GetInfo(std::string* info) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::GetInfo(std::string* info) {
+  CLIENT_SESSION_OPERATION_GUARD();
   CHECK(vfs_ != nullptr) << "vfs_ is nullptr";
   return vfs_->GetInfo(info);
 }
 
-double VFSWrapper::GetAttrTimeout(FileType type) {
+double ClientSession::GetAttrTimeout(FileType type) {
   (void)type;
-  CHECK(immutable_values_published_.load(std::memory_order_acquire))
-      << "GetAttrTimeout called before VFS Start completed";
-  return attr_timeout_;
+  return static_cast<double>(FLAGS_fuse_attr_cache_timeout_s);
 }
 
-double VFSWrapper::GetEntryTimeout(FileType type) {
+double ClientSession::GetEntryTimeout(FileType type) {
   (void)type;
-  CHECK(immutable_values_published_.load(std::memory_order_acquire))
-      << "GetEntryTimeout called before VFS Start completed";
-  return entry_timeout_;
+  return static_cast<double>(FLAGS_fuse_entry_cache_timeout_s);
 }
 
-uint64_t VFSWrapper::GetFsId() {
-  CHECK(immutable_values_published_.load(std::memory_order_acquire))
-      << "GetFsId called before VFS Start completed";
-  VLOG(6) << "fs_id: " << fs_id_;
-  return fs_id_;
+uint64_t ClientSession::GetMaxNameLength() {
+  const uint64_t max_name_length = FLAGS_vfs_meta_max_name_length;
+  VLOG(6) << "max name length: " << max_name_length;
+  return max_name_length;
 }
 
-uint64_t VFSWrapper::GetMaxNameLength() {
-  CHECK(immutable_values_published_.load(std::memory_order_acquire))
-      << "GetMaxNameLength called before VFS Start completed";
-  VLOG(6) << "max name length: " << max_name_length_;
-  return max_name_length_;
-}
-
-Status VFSWrapper::Lookup(const Context& ctx, Ino parent,
-                          const std::string& name, Attr* attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Lookup(const Context& ctx, Ino parent,
+                             const std::string& name, Attr* attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSLookup parent: " << parent << " name: " << name;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Lookup");
+  auto span = trace_manager_->StartSpan("ClientSession::Lookup");
 
   Status s;
   AccessLogGuard log(
@@ -644,10 +646,10 @@ Status VFSWrapper::Lookup(const Context& ctx, Ino parent,
       !dingofs::IsInternalName(name));
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opLookup, &client_op_metric_->opAll},
+      {&client_metrics_->opLookup, &client_metrics_->opAll},
       !dingofs::IsInternalName(name));
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -659,11 +661,11 @@ Status VFSWrapper::Lookup(const Context& ctx, Ino parent,
   return s;
 }
 
-Status VFSWrapper::GetAttr(const Context& ctx, Ino ino, Attr* attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::GetAttr(const Context& ctx, Ino ino, Attr* attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSGetAttr ino: " << ino;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::GetAttr");
+  auto span = trace_manager_->StartSpan("ClientSession::GetAttr");
 
   Status s;
   AccessLogGuard log(
@@ -675,7 +677,7 @@ Status VFSWrapper::GetAttr(const Context& ctx, Ino ino, Attr* attr) {
       !dingofs::IsInternalIno(ino));
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opGetAttr, &client_op_metric_->opAll},
+      {&client_metrics_->opGetAttr, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
@@ -690,12 +692,12 @@ Status VFSWrapper::GetAttr(const Context& ctx, Ino ino, Attr* attr) {
   return s;
 }
 
-Status VFSWrapper::SetAttr(const Context& ctx, Ino ino, int set,
-                           const Attr& in_attr, Attr* out_attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::SetAttr(const Context& ctx, Ino ino, int set,
+                              const Attr& in_attr, Attr* out_attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSSetAttr ino: " << ino << " set: " << set;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::SetAttr");
+  auto span = trace_manager_->StartSpan("ClientSession::SetAttr");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -705,7 +707,7 @@ Status VFSWrapper::SetAttr(const Context& ctx, Ino ino, int set,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opSetAttr, &client_op_metric_->opAll});
+      {&client_metrics_->opSetAttr, &client_metrics_->opAll});
 
   if (set & (kSetAttrOpen | kSetAttrTimesSet)) {
     s = Status::InvalidParam("not supported");
@@ -719,14 +721,14 @@ Status VFSWrapper::SetAttr(const Context& ctx, Ino ino, int set,
   return s;
 }
 
-Status VFSWrapper::Fallocate(const Context& ctx, Ino ino, int mode,
-                             uint64_t offset, uint64_t length) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Fallocate(const Context& ctx, Ino ino, int mode,
+                                uint64_t offset, uint64_t length) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << fmt::format(
       "VFSFallocate ino: {} mode: 0x{:X} offset: {} length: {}", ino, mode,
       offset, length);
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Fallocate");
+  auto span = trace_manager_->StartSpan("ClientSession::Fallocate");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -736,7 +738,7 @@ Status VFSWrapper::Fallocate(const Context& ctx, Ino ino, int mode,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opFallocate, &client_op_metric_->opAll});
+      {&client_metrics_->opFallocate, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->Fallocate(span_ctx, ino, mode, offset, length);
@@ -745,12 +747,12 @@ Status VFSWrapper::Fallocate(const Context& ctx, Ino ino, int mode,
   return s;
 }
 
-Status VFSWrapper::CopyFileRange(const Context& ctx, Ino src_ino,
-                                 uint64_t src_off, uint64_t src_fh, Ino dst_ino,
-                                 uint64_t dst_off, uint64_t dst_fh,
-                                 uint64_t len, uint32_t flags,
-                                 uint64_t* bytes_copied) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::CopyFileRange(const Context& ctx, Ino src_ino,
+                                    uint64_t src_off, uint64_t src_fh,
+                                    Ino dst_ino, uint64_t dst_off,
+                                    uint64_t dst_fh, uint64_t len,
+                                    uint32_t flags, uint64_t* bytes_copied) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << fmt::format(
       "VFSCopyFileRange src_ino: {} src_off: {} src_fh: {} dst_ino: {} "
       "dst_off: {} dst_fh: {} len: {} flags: 0x{:x}",
@@ -758,7 +760,7 @@ Status VFSWrapper::CopyFileRange(const Context& ctx, Ino src_ino,
 
   CHECK(bytes_copied != nullptr) << "bytes_copied is nullptr";
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::CopyFileRange");
+  auto span = trace_manager_->StartSpan("ClientSession::CopyFileRange");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -770,7 +772,7 @@ Status VFSWrapper::CopyFileRange(const Context& ctx, Ino src_ino,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opCopyFileRange, &client_op_metric_->opAll});
+      {&client_metrics_->opCopyFileRange, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->CopyFileRange(span_ctx, src_ino, src_off, src_fh, dst_ino, dst_off,
@@ -780,11 +782,11 @@ Status VFSWrapper::CopyFileRange(const Context& ctx, Ino src_ino,
   return s;
 }
 
-Status VFSWrapper::ReadLink(const Context& ctx, Ino ino, std::string* link) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::ReadLink(const Context& ctx, Ino ino, std::string* link) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSReadLink ino: " << ino;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::ReadLink");
+  auto span = trace_manager_->StartSpan("ClientSession::ReadLink");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -793,7 +795,7 @@ Status VFSWrapper::ReadLink(const Context& ctx, Ino ino, std::string* link) {
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opReadLink, &client_op_metric_->opAll});
+      {&client_metrics_->opReadLink, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->ReadLink(span_ctx, ino, link);
@@ -802,15 +804,15 @@ Status VFSWrapper::ReadLink(const Context& ctx, Ino ino, std::string* link) {
   return s;
 }
 
-Status VFSWrapper::MkNod(const Context& ctx, Ino parent,
-                         const std::string& name, uint32_t mode, uint64_t dev,
-                         Attr* attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::MkNod(const Context& ctx, Ino parent,
+                            const std::string& name, uint32_t mode,
+                            uint64_t dev, Attr* attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSMknod parent: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " mode: " << mode
           << " dev: " << dev;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::MkNod");
+  auto span = trace_manager_->StartSpan("ClientSession::MkNod");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -820,9 +822,9 @@ Status VFSWrapper::MkNod(const Context& ctx, Ino parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opMkNod, &client_op_metric_->opAll});
+      {&client_metrics_->opMkNod, &client_metrics_->opAll});
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -835,12 +837,12 @@ Status VFSWrapper::MkNod(const Context& ctx, Ino parent,
   return s;
 }
 
-Status VFSWrapper::Unlink(const Context& ctx, Ino parent,
-                          const std::string& name) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Unlink(const Context& ctx, Ino parent,
+                             const std::string& name) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSUnlink parent: " << parent << " name: " << name;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Unlink");
+  auto span = trace_manager_->StartSpan("ClientSession::Unlink");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -849,9 +851,9 @@ Status VFSWrapper::Unlink(const Context& ctx, Ino parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opUnlink, &client_op_metric_->opAll});
+      {&client_metrics_->opUnlink, &client_metrics_->opAll});
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -865,14 +867,14 @@ Status VFSWrapper::Unlink(const Context& ctx, Ino parent,
   return s;
 }
 
-Status VFSWrapper::Symlink(const Context& ctx, Ino parent,
-                           const std::string& name, const std::string& link,
-                           Attr* attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Symlink(const Context& ctx, Ino parent,
+                              const std::string& name, const std::string& link,
+                              Attr* attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSSymlink parent: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " link: " << link;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Symlink");
+  auto span = trace_manager_->StartSpan("ClientSession::Symlink");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -882,9 +884,9 @@ Status VFSWrapper::Symlink(const Context& ctx, Ino parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opSymlink, &client_op_metric_->opAll});
+      {&client_metrics_->opSymlink, &client_metrics_->opAll});
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -896,14 +898,14 @@ Status VFSWrapper::Symlink(const Context& ctx, Ino parent,
   return s;
 }
 
-Status VFSWrapper::Rename(const Context& ctx, Ino old_parent,
-                          const std::string& old_name, Ino new_parent,
-                          const std::string& new_name) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Rename(const Context& ctx, Ino old_parent,
+                             const std::string& old_name, Ino new_parent,
+                             const std::string& new_name) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSRename old_parent: " << old_parent << " old_name: " << old_name
           << " new_parent: " << new_parent << " new_name: " << new_name;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Rename");
+  auto span = trace_manager_->StartSpan("ClientSession::Rename");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -913,10 +915,11 @@ Status VFSWrapper::Rename(const Context& ctx, Ino old_parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opRename, &client_op_metric_->opAll});
+      {&client_metrics_->opRename, &client_metrics_->opAll});
 
-  if (old_name.length() > vfs_->GetMaxNameLength() ||
-      new_name.length() > vfs_->GetMaxNameLength()) {
+  const uint64_t max_name_length = FLAGS_vfs_meta_max_name_length;
+  if (old_name.length() > max_name_length ||
+      new_name.length() > max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}|{}) too long",
                                         old_name.length(), new_name.length()));
     return s;
@@ -931,13 +934,13 @@ Status VFSWrapper::Rename(const Context& ctx, Ino old_parent,
   return s;
 }
 
-Status VFSWrapper::Link(const Context& ctx, Ino ino, Ino new_parent,
-                        const std::string& new_name, Attr* attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Link(const Context& ctx, Ino ino, Ino new_parent,
+                           const std::string& new_name, Attr* attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSLink ino: " << ino << " new_parent: " << new_parent
           << " new_name: " << new_name;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Link");
+  auto span = trace_manager_->StartSpan("ClientSession::Link");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -947,9 +950,9 @@ Status VFSWrapper::Link(const Context& ctx, Ino ino, Ino new_parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opLink, &client_op_metric_->opAll});
+      {&client_metrics_->opLink, &client_metrics_->opAll});
 
-  uint64_t max_name_len = vfs_->GetMaxNameLength();
+  uint64_t max_name_len = FLAGS_vfs_meta_max_name_length;
   if (new_name.length() > max_name_len) {
     LOG(WARNING) << "name too long, name: " << new_name
                  << ", maxNameLength: " << max_name_len;
@@ -965,14 +968,14 @@ Status VFSWrapper::Link(const Context& ctx, Ino ino, Ino new_parent,
   return s;
 }
 
-Status VFSWrapper::Open(const Context& ctx, Ino ino, int flags, uint64_t* fh,
-                        bool* keep_cache) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Open(const Context& ctx, Ino ino, int flags, uint64_t* fh,
+                           bool* keep_cache) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSOpen ino: " << ino << " octal flags: " << std::oct << flags;
   CHECK(fh != nullptr) << "fh is nullptr";
   CHECK(keep_cache != nullptr) << "keep_cache is nullptr";
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Open");
+  auto span = trace_manager_->StartSpan("ClientSession::Open");
 
   Status s;
   AccessLogGuard log(
@@ -985,7 +988,7 @@ Status VFSWrapper::Open(const Context& ctx, Ino ino, int flags, uint64_t* fh,
       !dingofs::IsInternalIno(ino));
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opOpen, &client_op_metric_->opAll},
+      {&client_metrics_->opOpen, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
@@ -995,15 +998,15 @@ Status VFSWrapper::Open(const Context& ctx, Ino ino, int flags, uint64_t* fh,
   return s;
 }
 
-Status VFSWrapper::Create(const Context& ctx, Ino parent,
-                          const std::string& name, uint32_t mode, int flags,
-                          uint64_t* fh, Attr* attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Create(const Context& ctx, Ino parent,
+                             const std::string& name, uint32_t mode, int flags,
+                             uint64_t* fh, Attr* attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSCreate parent: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " mode: " << mode
           << " octal flags: " << std::oct << flags;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Create");
+  auto span = trace_manager_->StartSpan("ClientSession::Create");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1013,9 +1016,9 @@ Status VFSWrapper::Create(const Context& ctx, Ino parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opCreate, &client_op_metric_->opAll});
+      {&client_metrics_->opCreate, &client_metrics_->opAll});
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -1028,11 +1031,11 @@ Status VFSWrapper::Create(const Context& ctx, Ino parent,
   return s;
 }
 
-Status VFSWrapper::Read(const Context& ctx, Ino ino, DataBuffer* data_buffer,
-                        uint64_t size, uint64_t offset, uint64_t fh,
-                        uint64_t* out_rsize) {
-  VFS_WRAPPER_OPERATION_GUARD();
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Read");
+Status ClientSession::Read(const Context& ctx, Ino ino, DataBuffer* data_buffer,
+                           uint64_t size, uint64_t offset, uint64_t fh,
+                           uint64_t* out_rsize) {
+  CLIENT_SESSION_OPERATION_GUARD();
+  auto span = trace_manager_->StartSpan("ClientSession::Read");
   std::string session_id = dingofs::SpanScope::GetSessionID(span);
 
   VLOG(2) << fmt::format("[{}] VFSRead ino: {}, size: {}, offset: {}, fh: {}",
@@ -1049,7 +1052,7 @@ Status VFSWrapper::Read(const Context& ctx, Ino ino, DataBuffer* data_buffer,
       !dingofs::IsInternalIno(ino));
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opRead, &client_op_metric_->opAll},
+      {&client_metrics_->opRead, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
   VFSRWMetricGuard guard(&s, &g_rw_metric.read, out_rsize,
                          !dingofs::IsInternalIno(ino));
@@ -1063,15 +1066,15 @@ Status VFSWrapper::Read(const Context& ctx, Ino ino, DataBuffer* data_buffer,
   return s;
 }
 
-Status VFSWrapper::Write(const Context& ctx, Ino ino, const char* buf,
-                         uint64_t size, uint64_t offset, uint64_t fh,
-                         uint64_t* out_wsize) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Write(const Context& ctx, Ino ino, const char* buf,
+                            uint64_t size, uint64_t offset, uint64_t fh,
+                            uint64_t* out_wsize) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSWrite ino: " << ino
           << ", buf: " << dingofs::Helper::Char2Addr(buf) << ", size: " << size
           << " offset: " << offset << " fh: " << fh;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Write");
+  auto span = trace_manager_->StartSpan("ClientSession::Write");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1081,7 +1084,7 @@ Status VFSWrapper::Write(const Context& ctx, Ino ino, const char* buf,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opWrite, &client_op_metric_->opAll});
+      {&client_metrics_->opWrite, &client_metrics_->opAll});
 
   VFSRWMetricGuard guard(&s, &g_rw_metric.write, out_wsize);
 
@@ -1092,11 +1095,11 @@ Status VFSWrapper::Write(const Context& ctx, Ino ino, const char* buf,
   return s;
 }
 
-Status VFSWrapper::Flush(const Context& ctx, Ino ino, uint64_t fh) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Flush(const Context& ctx, Ino ino, uint64_t fh) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSFlush ino: " << ino << " fh: " << fh;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Flush");
+  auto span = trace_manager_->StartSpan("ClientSession::Flush");
 
   Status s;
   AccessLogGuard log(
@@ -1107,7 +1110,7 @@ Status VFSWrapper::Flush(const Context& ctx, Ino ino, uint64_t fh) {
       !dingofs::IsInternalIno(ino));
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opFlush, &client_op_metric_->opAll},
+      {&client_metrics_->opFlush, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
@@ -1117,11 +1120,11 @@ Status VFSWrapper::Flush(const Context& ctx, Ino ino, uint64_t fh) {
   return s;
 }
 
-Status VFSWrapper::Release(const Context& ctx, Ino ino, uint64_t fh) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Release(const Context& ctx, Ino ino, uint64_t fh) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSRelease ino: " << ino << " fh: " << fh;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Release");
+  auto span = trace_manager_->StartSpan("ClientSession::Release");
 
   Status s;
   AccessLogGuard log(
@@ -1132,7 +1135,7 @@ Status VFSWrapper::Release(const Context& ctx, Ino ino, uint64_t fh) {
       !dingofs::IsInternalIno(ino));
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opRelease, &client_op_metric_->opAll},
+      {&client_metrics_->opRelease, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
@@ -1142,13 +1145,13 @@ Status VFSWrapper::Release(const Context& ctx, Ino ino, uint64_t fh) {
   return s;
 }
 
-Status VFSWrapper::Fsync(const Context& ctx, Ino ino, int datasync,
-                         uint64_t fh) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Fsync(const Context& ctx, Ino ino, int datasync,
+                            uint64_t fh) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSFsync ino: " << ino << " datasync: " << datasync
           << " fh: " << fh;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Fsync");
+  auto span = trace_manager_->StartSpan("ClientSession::Fsync");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1158,7 +1161,7 @@ Status VFSWrapper::Fsync(const Context& ctx, Ino ino, int datasync,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opFsync, &client_op_metric_->opAll});
+      {&client_metrics_->opFsync, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->Fsync(span_ctx, ino, datasync, fh);
@@ -1167,14 +1170,14 @@ Status VFSWrapper::Fsync(const Context& ctx, Ino ino, int datasync,
   return s;
 }
 
-Status VFSWrapper::SetXattr(const Context& ctx, Ino ino,
-                            const std::string& name, const std::string& value,
-                            int flags) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::SetXattr(const Context& ctx, Ino ino,
+                               const std::string& name,
+                               const std::string& value, int flags) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSSetXattr ino: " << ino << " name: " << name
           << " value: " << value << " octal flags: " << std::oct << flags;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::SetXattr");
+  auto span = trace_manager_->StartSpan("ClientSession::SetXattr");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1183,10 +1186,10 @@ Status VFSWrapper::SetXattr(const Context& ctx, Ino ino,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opSetXattr, &client_op_metric_->opAll},
+      {&client_metrics_->opSetXattr, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -1198,12 +1201,12 @@ Status VFSWrapper::SetXattr(const Context& ctx, Ino ino,
   return s;
 }
 
-Status VFSWrapper::GetXattr(const Context& ctx, Ino ino,
-                            const std::string& name, std::string* value) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::GetXattr(const Context& ctx, Ino ino,
+                               const std::string& name, std::string* value) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSGetXattr ino: " << ino << " name: " << name;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::GetXattr");
+  auto span = trace_manager_->StartSpan("ClientSession::GetXattr");
 
   Status s;
   AccessLogGuard log(
@@ -1215,10 +1218,10 @@ Status VFSWrapper::GetXattr(const Context& ctx, Ino ino,
       !dingofs::IsInternalIno(ino));
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opGetXattr, &client_op_metric_->opAll},
+      {&client_metrics_->opGetXattr, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -1235,12 +1238,12 @@ Status VFSWrapper::GetXattr(const Context& ctx, Ino ino,
   return s;
 }
 
-Status VFSWrapper::RemoveXattr(const Context& ctx, Ino ino,
-                               const std::string& name) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::RemoveXattr(const Context& ctx, Ino ino,
+                                  const std::string& name) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSRemoveXattr ino: " << ino << " name: " << name;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::RemoveXattr");
+  auto span = trace_manager_->StartSpan("ClientSession::RemoveXattr");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1249,10 +1252,10 @@ Status VFSWrapper::RemoveXattr(const Context& ctx, Ino ino,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opRemoveXattr, &client_op_metric_->opAll},
+      {&client_metrics_->opRemoveXattr, &client_metrics_->opAll},
       !dingofs::IsInternalIno(ino));
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -1264,12 +1267,12 @@ Status VFSWrapper::RemoveXattr(const Context& ctx, Ino ino,
   return s;
 }
 
-Status VFSWrapper::ListXattr(const Context& ctx, Ino ino,
-                             std::vector<std::string>* xattrs) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::ListXattr(const Context& ctx, Ino ino,
+                                std::vector<std::string>* xattrs) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSListXattr ino: " << ino;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::ListXattr");
+  auto span = trace_manager_->StartSpan("ClientSession::ListXattr");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1278,7 +1281,7 @@ Status VFSWrapper::ListXattr(const Context& ctx, Ino ino,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opListXattr, &client_op_metric_->opAll});
+      {&client_metrics_->opListXattr, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->ListXattr(span_ctx, ino, xattrs);
@@ -1287,13 +1290,14 @@ Status VFSWrapper::ListXattr(const Context& ctx, Ino ino,
   return s;
 }
 
-Status VFSWrapper::MkDir(const Context& ctx, Ino parent,
-                         const std::string& name, uint32_t mode, Attr* attr) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::MkDir(const Context& ctx, Ino parent,
+                            const std::string& name, uint32_t mode,
+                            Attr* attr) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSMkDir parent ino: " << parent << " name: " << name
           << " uid: " << ctx.uid << " gid: " << ctx.gid << " mode: " << mode;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::MkDir");
+  auto span = trace_manager_->StartSpan("ClientSession::MkDir");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1303,9 +1307,9 @@ Status VFSWrapper::MkDir(const Context& ctx, Ino parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opMkDir, &client_op_metric_->opAll});
+      {&client_metrics_->opMkDir, &client_metrics_->opAll});
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -1318,12 +1322,12 @@ Status VFSWrapper::MkDir(const Context& ctx, Ino parent,
   return s;
 }
 
-Status VFSWrapper::OpenDir(const Context& ctx, Ino ino, uint64_t* fh,
-                           bool& need_cache) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::OpenDir(const Context& ctx, Ino ino, uint64_t* fh,
+                              bool& need_cache) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSOpendir ino: " << ino;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::OpenDir");
+  auto span = trace_manager_->StartSpan("ClientSession::OpenDir");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1333,7 +1337,7 @@ Status VFSWrapper::OpenDir(const Context& ctx, Ino ino, uint64_t* fh,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opOpenDir, &client_op_metric_->opAll});
+      {&client_metrics_->opOpenDir, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->OpenDir(span_ctx, ino, fh, need_cache);
@@ -1342,14 +1346,14 @@ Status VFSWrapper::OpenDir(const Context& ctx, Ino ino, uint64_t* fh,
   return s;
 }
 
-Status VFSWrapper::ReadDir(const Context& ctx, Ino ino, uint64_t fh,
-                           uint64_t offset, bool with_attr,
-                           ReadDirHandler handler) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::ReadDir(const Context& ctx, Ino ino, uint64_t fh,
+                              uint64_t offset, bool with_attr,
+                              ReadDirHandler handler) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSReaddir ino: " << ino << " fh: " << fh << " offset: " << offset
           << " with_attr: " << (with_attr ? "true" : "false");
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::ReadDir");
+  auto span = trace_manager_->StartSpan("ClientSession::ReadDir");
 
   Status s;
   uint32_t count = 0;
@@ -1360,7 +1364,7 @@ Status VFSWrapper::ReadDir(const Context& ctx, Ino ino, uint64_t fh,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opReadDir, &client_op_metric_->opAll});
+      {&client_metrics_->opReadDir, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->ReadDir(span_ctx, ino, fh, offset, with_attr, std::move(handler),
@@ -1370,11 +1374,11 @@ Status VFSWrapper::ReadDir(const Context& ctx, Ino ino, uint64_t fh,
   return s;
 }
 
-Status VFSWrapper::ReleaseDir(const Context& ctx, Ino ino, uint64_t fh) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::ReleaseDir(const Context& ctx, Ino ino, uint64_t fh) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSReleaseDir ino: " << ino << " fh: " << fh;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::ReleaseDir");
+  auto span = trace_manager_->StartSpan("ClientSession::ReleaseDir");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1383,7 +1387,7 @@ Status VFSWrapper::ReleaseDir(const Context& ctx, Ino ino, uint64_t fh) {
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opReleaseDir, &client_op_metric_->opAll});
+      {&client_metrics_->opReleaseDir, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->ReleaseDir(span_ctx, ino, fh);
@@ -1392,12 +1396,12 @@ Status VFSWrapper::ReleaseDir(const Context& ctx, Ino ino, uint64_t fh) {
   return s;
 }
 
-Status VFSWrapper::RmDir(const Context& ctx, Ino parent,
-                         const std::string& name) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::RmDir(const Context& ctx, Ino parent,
+                            const std::string& name) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSRmdir parent: " << parent << " name: " << name;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::RmDir");
+  auto span = trace_manager_->StartSpan("ClientSession::RmDir");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1406,9 +1410,9 @@ Status VFSWrapper::RmDir(const Context& ctx, Ino parent,
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opRmDir, &client_op_metric_->opAll});
+      {&client_metrics_->opRmDir, &client_metrics_->opAll});
 
-  if (name.length() > vfs_->GetMaxNameLength()) {
+  if (name.length() > FLAGS_vfs_meta_max_name_length) {
     s = Status::NameTooLong(fmt::format("name({}) too long", name.length()));
     return s;
   }
@@ -1422,11 +1426,11 @@ Status VFSWrapper::RmDir(const Context& ctx, Ino parent,
   return s;
 }
 
-Status VFSWrapper::StatFs(const Context& ctx, Ino ino, FsStat* fs_stat) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::StatFs(const Context& ctx, Ino ino, FsStat* fs_stat) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSStatFs ino: " << ino;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::StatFs");
+  auto span = trace_manager_->StartSpan("ClientSession::StatFs");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1435,7 +1439,7 @@ Status VFSWrapper::StatFs(const Context& ctx, Ino ino, FsStat* fs_stat) {
   });
 
   ClientOpMetricGuard op_metric(
-      {&client_op_metric_->opStatfs, &client_op_metric_->opAll});
+      {&client_metrics_->opStatfs, &client_metrics_->opAll});
 
   auto span_ctx = dingofs::SpanScope::GetContext(span);
   s = vfs_->StatFs(span_ctx, ino, fs_stat);
@@ -1444,14 +1448,14 @@ Status VFSWrapper::StatFs(const Context& ctx, Ino ino, FsStat* fs_stat) {
   return s;
 }
 
-Status VFSWrapper::Ioctl(const Context& ctx, Ino ino, unsigned int cmd,
-                         unsigned flags, const void* in_buf, size_t in_bufsz,
-                         char* out_buf, size_t out_bufsz) {
-  VFS_WRAPPER_OPERATION_GUARD();
+Status ClientSession::Ioctl(const Context& ctx, Ino ino, unsigned int cmd,
+                            unsigned flags, const void* in_buf, size_t in_bufsz,
+                            char* out_buf, size_t out_bufsz) {
+  CLIENT_SESSION_OPERATION_GUARD();
   VLOG(2) << "VFSIoctl ino: " << ino << " cmd: " << cmd << " flags: " << flags
           << " in_bufsz: " << in_bufsz << " out_bufsz: " << out_bufsz;
 
-  auto span = vfs_->GetTraceManager()->StartSpan("VFSWrapper::Ioctl");
+  auto span = trace_manager_->StartSpan("ClientSession::Ioctl");
 
   Status s;
   AccessLogGuard log([&]() {
@@ -1467,7 +1471,7 @@ Status VFSWrapper::Ioctl(const Context& ctx, Ino ino, unsigned int cmd,
   return s;
 }
 
-#undef VFS_WRAPPER_OPERATION_GUARD
+#undef CLIENT_SESSION_OPERATION_GUARD
 
 }  // namespace client
 }  // namespace dingofs

--- a/src/client/vfs/client_session.h
+++ b/src/client/vfs/client_session.h
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef DINGOFS_CLIENT_VFS_VFS_WRAPPER_H_
-#define DINGOFS_CLIENT_VFS_VFS_WRAPPER_H_
+#ifndef DINGOFS_CLIENT_VFS_CLIENT_SESSION_H_
+#define DINGOFS_CLIENT_VFS_CLIENT_SESSION_H_
 
-#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <memory>
@@ -29,11 +28,16 @@
 
 #include "client/vfs/vfs.h"
 #include "common/meta.h"
-#include "common/metrics/client/client.h"
 #include "common/status.h"
 #include "json/value.h"
 
 namespace dingofs {
+class TraceManager;
+namespace metrics {
+namespace client {
+struct ClientOpMetric;
+}  // namespace client
+}  // namespace metrics
 namespace client {
 
 struct DingofsConfig {
@@ -62,11 +66,13 @@ struct Context {
   }
 };
 
-class VFSWrapper {
+class ClientSession {
  public:
-  VFSWrapper() = default;
+  ClientSession();
 
-  ~VFSWrapper() = default;
+  // Blocks until admitted operations and Core teardown complete. The owner
+  // must not destroy this object concurrently with another method call.
+  ~ClientSession();
 
   // Normal start: upgrade_from_pid = 0.
   // Graceful-upgrade start (new process taking over): upgrade_from_pid is the
@@ -81,11 +87,12 @@ class VFSWrapper {
 
   Status GetInfo(std::string* info);
 
+  // Valid after a successful Start, including after Stop. Timeout and
+  // max-name getters read the current process-wide gflags on every call.
+
   double GetAttrTimeout(FileType type);
 
   double GetEntryTimeout(FileType type);
-
-  uint64_t GetFsId();
 
   uint64_t GetMaxNameLength();
 
@@ -156,7 +163,7 @@ class VFSWrapper {
   Status OpenDir(const Context& ctx, Ino ino, uint64_t* fh, bool& need_cache);
 
   // The handler is invoked synchronously and must not re-enter a public method
-  // on this VFSWrapper. This contract is intentionally not enforced with C++
+  // on this ClientSession. This contract is intentionally not enforced with C++
   // thread_local state because callers may execute on migratable bthreads.
   Status ReadDir(const Context& ctx, Ino ino, uint64_t fh, uint64_t offset,
                  bool with_attr, ReadDirHandler handler);
@@ -172,7 +179,7 @@ class VFSWrapper {
                size_t out_bufsz);
 
  private:
-  friend class VFSWrapperLifecycleTest;
+  friend class ClientSessionLifecycleTest;
 
   enum class LifecycleState {
     kCreated,
@@ -193,10 +200,10 @@ class VFSWrapper {
     ~OperationLease();
 
    private:
-    friend class VFSWrapper;
-    explicit OperationLease(VFSWrapper* owner) : owner_(owner) {}
+    friend class ClientSession;
+    explicit OperationLease(ClientSession* owner) : owner_(owner) {}
 
-    VFSWrapper* owner_;
+    ClientSession* owner_;
   };
 
   std::optional<OperationLease> TryAcquireOperation();
@@ -215,22 +222,18 @@ class VFSWrapper {
   uint64_t active_public_operations_{0};
   Status stop_status_;
   bool stop_handover_{false};
-  std::atomic<bool> immutable_values_published_{false};
+  bool trace_started_{false};
 
+  // Declared before vfs_ so borrowed tracing outlives every VFS component.
+  std::unique_ptr<TraceManager> trace_manager_;
+  std::unique_ptr<metrics::client::ClientOpMetric> client_metrics_;
   std::unique_ptr<vfs::VFS> vfs_;
-
-  std::unique_ptr<metrics::client::ClientOpMetric> client_op_metric_;
 
   uint32_t uid_{0};
   uint32_t gid_{0};
-
-  double attr_timeout_{0.0};
-  double entry_timeout_{0.0};
-  uint64_t fs_id_{0};
-  uint64_t max_name_length_{0};
 };
 
 }  // namespace client
 }  // namespace dingofs
 
-#endif  // DINGOFS_CLIENT_VFS_VFS_WRAPPER_H_
+#endif  // DINGOFS_CLIENT_VFS_CLIENT_SESSION_H_

--- a/src/client/vfs/components/prefetch_manager.cc
+++ b/src/client/vfs/components/prefetch_manager.cc
@@ -102,7 +102,7 @@ void PrefetchManager::SubmitTask(PrefetchContext context) {
 
 void PrefetchManager::ProcessPrefetch(const PrefetchContext& context) {
   auto span =
-      vfs_hub_->GetTraceManager()->StartSpan("VFSWrapper::ProcessPrefetch");
+      vfs_hub_->GetTraceManager()->StartSpan("PrefetchManager::ProcessPrefetch");
 
   const auto block_size = vfs_hub_->GetFsInfo().block_size;
   // Prefetch include current block

--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -214,7 +214,7 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
       // written_size > 0, else a hard error, decided after the loop). Don't
       // WARN per chunk -- it floods under back-pressure and misreads a
       // successful short write; the outcome is recorded uniformly in
-      // VFSWrapper's access log (status + out_wsize), the pool-pressure
+      // ClientSession's access log (status + out_wsize), the pool-pressure
       // locality in SliceWriter, and the failure rate in the
       // vfs_write_buffer_alloc_fail_num metric.
       VLOG(3) << "stop write at chunk, ino: " << ino_

--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -78,8 +78,11 @@ static MetaSystemUPtr BuildMetaSystem(const VFSConfig& vfs_conf,
   return nullptr;
 }
 
-VFSHubImpl::VFSHubImpl(const VFSConfig& vfs_conf, ClientId client_id)
-    : client_id_(client_id), vfs_conf_(vfs_conf) {}
+VFSHubImpl::VFSHubImpl(const VFSConfig& vfs_conf, ClientId client_id,
+                       TraceManager& trace_manager)
+    : trace_manager_(trace_manager),
+      client_id_(client_id),
+      vfs_conf_(vfs_conf) {}
 
 WriterTable* VFSHubImpl::GetWriterTable() {
   CHECK_NOTNULL(writer_table_);
@@ -146,10 +149,6 @@ VFSHubImpl::~VFSHubImpl() {
     compactor_.reset();
   }
 
-  if (trace_manager_ != nullptr) {
-    trace_manager_.reset();
-  }
-
   if (logclean_manager_ != nullptr) {
     logclean_manager_.reset();
   }
@@ -166,14 +165,6 @@ Status VFSHubImpl::Start(bool skip_mount) {
   LOG(INFO) << fmt::format("[vfs.hub] vfs hub starting, skip_mount({}).",
                            skip_mount);
 
-  // trace manager
-  trace_manager_ = std::make_unique<TraceManager>();
-  if (FLAGS_enable_trace) {
-    if (!trace_manager_->Init()) {
-      return Status::Internal("init trace manager fail");
-    }
-  }
-
   {
     compactor_ = std::make_unique<CompactorImpl>(this);
     DINGOFS_RETURN_NOT_OK(compactor_->Start());
@@ -182,7 +173,7 @@ Status VFSHubImpl::Start(bool skip_mount) {
   // meta system
   {
     auto meta =
-        BuildMetaSystem(vfs_conf_, client_id_, *trace_manager_, *compactor_);
+        BuildMetaSystem(vfs_conf_, client_id_, trace_manager_, *compactor_);
     if (meta == nullptr) {
       return Status::Internal("build meta system fail");
     }
@@ -193,7 +184,7 @@ Status VFSHubImpl::Start(bool skip_mount) {
 
   // load fs info
   {
-    auto span = trace_manager_->StartSpan("vfs::start");
+    auto span = trace_manager_.StartSpan("vfs::start");
 
     DINGOFS_RETURN_NOT_OK(
         meta_wrapper_->GetFsInfo(SpanScope::GetContext(span), &fs_info_));
@@ -447,7 +438,8 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
 
   // A handover must never publish state after dirty data failed to flush. The
   // old process is already quiesced at this point, so treat this as an
-  // unrecoverable handover failure rather than letting VFSWrapper dump state.
+  // unrecoverable handover failure rather than letting ClientSession dump
+  // state.
   if (skip_unmount && !handle_stop_status.ok()) {
     LOG(FATAL) << fmt::format("Handover writer flush failed: {}",
                               handle_stop_status.ToString());
@@ -478,7 +470,7 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
   }
 
   if (warmup_manager_ != nullptr) {
-    // VFSWrapper has already rejected new public operations and drained all
+    // ClientSession has already rejected new public operations and drained all
     // existing operations before VFSHub::Stop, so no Open trigger can race
     // with this detach.
     if (meta_wrapper_ != nullptr) {
@@ -517,10 +509,6 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
   // drained above. Block-store completions are drained by CBExecutor above.
   if (meta_wrapper_ != nullptr) {
     meta_wrapper_->Stop(skip_unmount);
-  }
-
-  if (trace_manager_ != nullptr) {
-    if (FLAGS_enable_trace) trace_manager_->Stop();
   }
 
   if (logclean_manager_ != nullptr) {

--- a/src/client/vfs/hub/vfs_hub.h
+++ b/src/client/vfs/hub/vfs_hub.h
@@ -106,7 +106,8 @@ class VFSHub {
 
 class VFSHubImpl : public VFSHub {
  public:
-  VFSHubImpl(const VFSConfig& vfs_conf, ClientId client_id);
+  VFSHubImpl(const VFSConfig& vfs_conf, ClientId client_id,
+             TraceManager& trace_manager);
 
   ~VFSHubImpl() override;
 
@@ -203,10 +204,7 @@ class VFSHubImpl : public VFSHub {
     return fs_info_;
   }
 
-  TraceManager* GetTraceManager() override {
-    CHECK_NOTNULL(trace_manager_);
-    return trace_manager_.get();
-  }
+  TraceManager* GetTraceManager() override { return &trace_manager_; }
 
   blockaccess::BlockAccessOptions GetBlockAccesserOptions() override {
     CHECK(started_.load(std::memory_order_relaxed)) << "not started";
@@ -231,13 +229,13 @@ class VFSHubImpl : public VFSHub {
 
   blockaccess::BlockAccessOptions blockaccess_options_;
 
+  TraceManager& trace_manager_;
   const ClientId client_id_;
   const VFSConfig vfs_conf_;
 
   FsInfo fs_info_;
   S3Info s3_info_;
 
-  std::unique_ptr<TraceManager> trace_manager_;
   std::unique_ptr<Compactor> compactor_;
   std::unique_ptr<MetaWrapper> meta_wrapper_;
 

--- a/src/client/vfs/vfs.h
+++ b/src/client/vfs/vfs.h
@@ -26,7 +26,6 @@
 #include "client/vfs/vfs_meta.h"
 #include "common/status.h"
 #include "common/trace/context.h"
-#include "common/trace/trace_manager.h"
 #include "common/types.h"
 
 namespace dingofs {
@@ -51,7 +50,8 @@ class VFS {
 
   virtual ~VFS() = default;
 
-  // skip_mount: if true, skip MountFs on MDS (new process inheriting a session)
+  // skip_mount: if true, skip MountFs on MDS (new process inheriting a
+  // session).
   virtual Status Start(bool skip_mount) = 0;
 
   // skip_unmount: if true, skip UnmountFs on MDS (old process handing off)
@@ -157,16 +157,6 @@ class VFS {
   virtual Status Ioctl(ContextSPtr ctx, Ino ino, uint32_t uid, unsigned int cmd,
                        unsigned flags, const void* in_buf, size_t in_bufsz,
                        char* out_buf, size_t out_bufsz) = 0;
-
-  virtual uint64_t GetFsId() = 0;
-
-  virtual double GetAttrTimeout(const FileType& type) = 0;
-
-  virtual double GetEntryTimeout(const FileType& type) = 0;
-
-  virtual uint64_t GetMaxNameLength() = 0;
-
-  virtual TraceManager* GetTraceManager() = 0;
 
   virtual Status GetInfo(std::string* info) = 0;
 };

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -96,22 +96,19 @@ void VFSImpl::LocalPairToHashed(uint32_t uid, uint32_t gid, uint32_t& out_uid,
   mapper->LocalPairToHashed(uid, gid, out_uid, out_gid);
 }
 
-VFSImpl::VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id)
-    : client_id_(client_id),
+VFSImpl::VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id,
+                 TraceManager& trace_manager)
+    : trace_manager_(trace_manager),
+      client_id_(client_id),
       mount_root_path_(
           vfs_conf.mount_root_path.empty() ? "/" : vfs_conf.mount_root_path),
-      vfs_hub_(std::make_unique<VFSHubImpl>(vfs_conf, client_id_)) {}
+      vfs_hub_(
+          std::make_unique<VFSHubImpl>(vfs_conf, client_id_, trace_manager_)) {}
 
-VFSImpl::~VFSImpl() {
-  Status s = StopBrpcServer();
-  if (!s.ok()) {
-    LOG(ERROR) << "stop brpc server during VFS destruction failed: "
-               << s.ToString();
-  }
-}
+VFSImpl::~VFSImpl() { StopBrpcServer(); }
 
-VFSImpl::VFSImpl(std::unique_ptr<VFSHub> hub)
-    : client_id_(), vfs_hub_(std::move(hub)) {
+VFSImpl::VFSImpl(std::unique_ptr<VFSHub> hub, TraceManager& trace_manager)
+    : trace_manager_(trace_manager), client_id_(), vfs_hub_(std::move(hub)) {
   meta_system_ = vfs_hub_->GetMetaSystem();
   handle_manager_ = vfs_hub_->GetHandleManager();
   reader_registry_ = vfs_hub_->GetReaderRegistry();
@@ -126,7 +123,6 @@ Status VFSImpl::Start(bool skip_mount) {
   reader_registry_ = vfs_hub_->GetReaderRegistry();
 
   DINGOFS_RETURN_NOT_OK(ResolveMountRoot());
-
   DINGOFS_RETURN_NOT_OK(StartBrpcServer());
 
   return Status::OK();
@@ -173,7 +169,7 @@ Status VFSImpl::ResolveMountRoot() {
 }
 
 Status VFSImpl::Stop(bool skip_unmount) {
-  DINGOFS_RETURN_NOT_OK(StopBrpcServer());
+  StopBrpcServer();
   return vfs_hub_->Stop(skip_unmount);
 }
 
@@ -225,14 +221,6 @@ bool VFSImpl::Load(ContextSPtr ctx, const Json::Value& value) {
   }
 
   return meta_system_->Load(ctx, value);
-}
-
-double VFSImpl::GetAttrTimeout(const FileType& type) {  // NOLINT
-  return FLAGS_fuse_attr_cache_timeout_s;
-}
-
-double VFSImpl::GetEntryTimeout(const FileType& type) {  // NOLINT
-  return FLAGS_fuse_entry_cache_timeout_s;
 }
 
 static Attr GenerateTrashDirAttr() {
@@ -649,8 +637,8 @@ Status VFSImpl::Read(ContextSPtr ctx, Ino ino, DataBuffer* data_buffer,
   Status s;
   auto handle = handle_manager_->FindHandlerGuard(fh);
   VFS_CHECK_HANDLE(handle.get(), ino, fh);
-  auto span = vfs_hub_->GetTraceManager()->StartChildSpan("VFSImpl::Read",
-                                                          ctx->GetTraceSpan());
+  auto span =
+      trace_manager_.StartChildSpan("VFSImpl::Read", ctx->GetTraceSpan());
   // read .stats file data
   if (BAIDU_UNLIKELY(ino == kStatsIno)) {
     size_t file_size = handle->file_buffer.size;
@@ -676,8 +664,8 @@ Status VFSImpl::Read(ContextSPtr ctx, Ino ino, DataBuffer* data_buffer,
   }
 
   {
-    auto flush_span = vfs_hub_->GetTraceManager()->StartChildSpan(
-        "VFSImpl::Read.Flush", span);
+    auto flush_span =
+        trace_manager_.StartChildSpan("VFSImpl::Read.Flush", span);
     // Flush all writers for this inode across all open file handles.
     // This ensures read-after-write consistency when multiple file descriptors
     // are open for the same inode: data buffered by any writer fd is flushed
@@ -706,8 +694,8 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
   auto handle = handle_manager_->FindHandlerGuard(fh);
   VFS_CHECK_HANDLE(handle.get(), ino, fh);
 
-  auto span = vfs_hub_->GetTraceManager()->StartChildSpan("VFSImpl::Write",
-                                                          ctx->GetTraceSpan());
+  auto span =
+      trace_manager_.StartChildSpan("VFSImpl::Write", ctx->GetTraceSpan());
 
   if (handle->resources.writer == nullptr) {
     LOG(ERROR) << "writer is null (read-only fh), ino: " << ino
@@ -737,8 +725,8 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
 
   // No status logging here: VFSImpl returns Status without logging per-op
   // outcomes (like the other ops); the uniform status + out_wsize record lives
-  // in VFSWrapper's access log, the pool-pressure locality in SliceWriter, and
-  // the failure rate in the vfs_write_buffer_alloc_fail_num metric.
+  // in ClientSession's access log, the pool-pressure locality in SliceWriter,
+  // and the failure rate in the vfs_write_buffer_alloc_fail_num metric.
   return s;
 }
 
@@ -1050,7 +1038,11 @@ Status VFSImpl::RmDir(ContextSPtr ctx, Ino parent, const std::string& name) {
 }
 
 Status VFSImpl::StatFs(ContextSPtr ctx, Ino ino, FsStat* fs_stat) {
-  return meta_system_->StatFs(ctx, TranslateIno(ino), fs_stat);
+  Status s = meta_system_->StatFs(ctx, TranslateIno(ino), fs_stat);
+  if (!s.ok()) return s;
+
+  fs_stat->fs_id = vfs_hub_->GetFsInfo().id;
+  return Status::OK();
 }
 
 Status VFSImpl::Ioctl(ContextSPtr ctx, Ino ino, uint32_t uid, unsigned int cmd,
@@ -1154,10 +1146,6 @@ Status VFSImpl::Ioctl(ContextSPtr ctx, Ino ino, uint32_t uid, unsigned int cmd,
 
   return Status::OK();
 }
-
-uint64_t VFSImpl::GetFsId() { return 10; }
-
-uint64_t VFSImpl::GetMaxNameLength() { return FLAGS_vfs_meta_max_name_length; }
 
 Status VFSImpl::GetInfo(std::string* info) {
   Json::Value root;
@@ -1274,21 +1262,21 @@ Status VFSImpl::StartBrpcServer() {
   return Status::OK();
 }
 
-Status VFSImpl::StopBrpcServer() {
+void VFSImpl::StopBrpcServer() {
   const brpc::Server::Status status = brpc_server_.status();
+  // UNINITIALIZED has never run; READY is already fully stopped and joined.
+  // Treat both as successful no-ops so teardown remains idempotent.
   if (status == brpc::Server::UNINITIALIZED || status == brpc::Server::READY) {
-    return Status::OK();
+    return;
   }
 
-  if (status == brpc::Server::RUNNING && brpc_server_.Stop(0) != 0) {
-    return Status::Internal("stop brpc server failed");
-  }
+  CHECK(status == brpc::Server::RUNNING || status == brpc::Server::STOPPING)
+      << "unexpected brpc server status: " << static_cast<int>(status);
 
-  if (brpc_server_.Join() != 0) {
-    return Status::Internal("join brpc server failed");
+  if (status == brpc::Server::RUNNING) {
+    CHECK_EQ(0, brpc_server_.Stop(0));
   }
-
-  return Status::OK();
+  CHECK_EQ(0, brpc_server_.Join());
 }
 
 }  // namespace vfs

--- a/src/client/vfs/vfs_impl.h
+++ b/src/client/vfs/vfs_impl.h
@@ -39,7 +39,8 @@ namespace vfs {
 
 class VFSImpl : public VFS {
  public:
-  VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id);
+  VFSImpl(const VFSConfig& vfs_conf, const ClientId& client_id,
+          TraceManager& trace_manager);
 
   ~VFSImpl() override;
 
@@ -50,10 +51,6 @@ class VFSImpl : public VFS {
   bool Dump(ContextSPtr ctx, Json::Value& value) override;
 
   bool Load(ContextSPtr ctx, const Json::Value& value) override;
-
-  double GetAttrTimeout(const FileType& type) override;
-
-  double GetEntryTimeout(const FileType& type) override;
 
   Status Lookup(ContextSPtr ctx, Ino parent, const std::string& name,
                 Attr* attr) override;
@@ -143,25 +140,17 @@ class VFSImpl : public VFS {
                unsigned flags, const void* in_buf, size_t in_bufsz,
                char* out_buf, size_t out_bufsz) override;
 
-  uint64_t GetFsId() override;
-
-  uint64_t GetMaxNameLength() override;
-
-  TraceManager* GetTraceManager() override {
-    return vfs_hub_->GetTraceManager();
-  }
-
   Status GetInfo(std::string* info) override;
 
  private:
   friend class VFSImplTest;
 
   // Test-only constructor: inject a pre-built VFSHub.
-  explicit VFSImpl(std::unique_ptr<VFSHub> hub);
+  VFSImpl(std::unique_ptr<VFSHub> hub, TraceManager& trace_manager);
 
   Status StartBrpcServer();
 
-  Status StopBrpcServer();
+  void StopBrpcServer();
 
   // Resolve `mount_root_path_` to a real directory inode by walking the
   // filesystem. Must be called after `vfs_hub_->Start()` so that
@@ -215,6 +204,7 @@ class VFSImpl : public VFS {
   // the mount-time fs_info; runtime `updatefs --trash_days` requires remount.
   bool IsTrashVisible() const { return vfs_hub_->GetFsInfo().trash_days > 0; }
 
+  TraceManager& trace_manager_;
   const ClientId client_id_;
 
   // Filesystem-internal path mounted as the local mountpoint root.

--- a/src/common/meta.h
+++ b/src/common/meta.h
@@ -83,6 +83,8 @@ struct DirEntry {
 };
 
 struct FsStat {
+  // Filesystem identity fetched by the active VFS and returned with StatFs.
+  uint32_t fs_id{0};
   int64_t max_bytes;
   int64_t used_bytes;
   int64_t max_inodes;

--- a/src/common/trace/trace_manager.cc
+++ b/src/common/trace/trace_manager.cc
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "common/opentrace/tracer.h"
+#include "common/sync_point.h"
 #include "common/version.h"
 #include "gflags/gflags.h"
 
@@ -40,6 +41,8 @@ TraceManager::TraceManager()
     : tracer_(OpenTeleMetryTracer(
           FLAGS_trace_service_name, FLAGS_otlp_export_endpoint,
           FLAGS_trace_export_thread_num, dingofs::GetGitCommitHash(),
-          dingofs::GetGitVersion())) {}
+          dingofs::GetGitVersion())) {
+  TEST_SYNC_POINT("TraceManager::TraceManager:after_config_capture");
+}
 
 }  // namespace dingofs

--- a/src/tools/bench/mdtest_bench.cc
+++ b/src/tools/bench/mdtest_bench.cc
@@ -16,7 +16,7 @@
 
 /*
  * DingoFS Metadata Benchmark (mdtest-like) — bypass FUSE, call the client
- * VFSWrapper C++ API directly.
+ * ClientSession C++ API directly.
  *
  * This tool stress-tests the client-side metadata path (VFS -> MDS) with
  * concurrent directory and file creation, similar to mdtest with -I -L
@@ -73,7 +73,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "client/vfs/vfs_wrapper.h"
+#include "client/vfs/client_session.h"
 #include "common/logging.h"
 #include "common/meta.h"
 #include "common/status.h"
@@ -117,16 +117,16 @@ using dingofs::Attr;
 using dingofs::DirEntry;
 using dingofs::Ino;
 using dingofs::Status;
+using dingofs::client::ClientSession;
 using dingofs::client::Context;
 using dingofs::client::DingofsConfig;
-using dingofs::client::VFSWrapper;
 
 const Context kBenchContext{static_cast<uint32_t>(getuid()),
                             static_cast<uint32_t>(getgid()),
                             static_cast<int32_t>(getpid()), 0};
 
 static double NowSec() {
-  struct timespec ts{};
+  struct timespec ts {};
   if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
     return 0.0;
   }
@@ -196,7 +196,7 @@ static std::vector<std::string> SplitPath(const std::string& path) {
 
 // Resolve an absolute path to its inode. Returns 0 on success, -errno on
 // failure.
-static int ResolvePath(VFSWrapper* vfs, const std::string& path, Ino* ino) {
+static int ResolvePath(ClientSession* vfs, const std::string& path, Ino* ino) {
   std::vector<std::string> parts = SplitPath(path);
   Ino parent = dingofs::kRootIno;
   for (const auto& name : parts) {
@@ -214,7 +214,7 @@ static int ResolvePath(VFSWrapper* vfs, const std::string& path, Ino* ino) {
 }
 
 // Resolve the parent directory of `path` and extract the final component name.
-static int ResolveParent(VFSWrapper* vfs, const std::string& path,
+static int ResolveParent(ClientSession* vfs, const std::string& path,
                          Ino* parent_ino, std::string* name) {
   if (path.empty() || path[0] != '/') return -EINVAL;
 
@@ -294,7 +294,7 @@ struct TreeSpec {
     LOG(INFO) << "Saved ino " << ino << " for dir " << path;
   }
 
-  Ino ResolveParent(VFSWrapper* vfs, const std::string& path) {
+  Ino ResolveParent(ClientSession* vfs, const std::string& path) {
     const std::string dir_path = DirName(path);
 
     {
@@ -388,7 +388,7 @@ struct ThreadResult {
   std::string error_path;  // path of first error
 };
 
-static int CreateDir(VFSWrapper* vfs, const std::string& path) {
+static int CreateDir(ClientSession* vfs, const std::string& path) {
   Ino parent;
   std::string name;
   int rc = ResolveParent(vfs, path, &parent, &name);
@@ -403,7 +403,7 @@ static int CreateDir(VFSWrapper* vfs, const std::string& path) {
   return StatusToErrno(s);
 }
 
-static int CreateDir(VFSWrapper* vfs, Ino parent, const std::string& name,
+static int CreateDir(ClientSession* vfs, Ino parent, const std::string& name,
                      Ino& ino) {
   CHECK(parent != 0) << "Invalid parent inode 0 for " << name;
 
@@ -419,7 +419,7 @@ static int CreateDir(VFSWrapper* vfs, Ino parent, const std::string& name,
   return StatusToErrno(s);
 }
 
-static int UnlinkPath(VFSWrapper* vfs, const std::string& path) {
+static int UnlinkPath(ClientSession* vfs, const std::string& path) {
   Ino parent;
   std::string name;
   int rc = ResolveParent(vfs, path, &parent, &name);
@@ -432,7 +432,7 @@ static int UnlinkPath(VFSWrapper* vfs, const std::string& path) {
   return StatusToErrno(s);
 }
 
-static int RemoveDir(VFSWrapper* vfs, const std::string& path) {
+static int RemoveDir(ClientSession* vfs, const std::string& path) {
   Ino parent;
   std::string name;
   int rc = ResolveParent(vfs, path, &parent, &name);
@@ -446,7 +446,7 @@ static int RemoveDir(VFSWrapper* vfs, const std::string& path) {
   return StatusToErrno(s);
 }
 
-static int CreateEmptyFile(VFSWrapper* vfs, Ino parent,
+static int CreateEmptyFile(ClientSession* vfs, Ino parent,
                            const std::string& name) {
   CHECK(parent != 0) << "Invalid parent inode 0 for " << name;
 
@@ -477,7 +477,7 @@ static int CreateEmptyFile(VFSWrapper* vfs, Ino parent,
 // unique mode: thread i creates its whole subtree (BFS order).
 // On error the thread records it and stops; other threads keep going
 // (the thread still participates in all barriers to avoid deadlock).
-static void UniqueWorker(VFSWrapper* vfs, TreeSpec* spec,
+static void UniqueWorker(ClientSession* vfs, TreeSpec* spec,
                          pthread_barrier_t* barrier,
                          ProgressTracker* dir_progress,
                          ProgressTracker* file_progress, ThreadResult* result) {
@@ -622,7 +622,7 @@ struct SharedWork {
   }
 };
 
-static void SharedWorker(VFSWrapper* vfs, TreeSpec* spec, SharedWork* work,
+static void SharedWorker(ClientSession* vfs, TreeSpec* spec, SharedWork* work,
                          pthread_barrier_t* barrier,
                          ProgressTracker* dir_progress,
                          ProgressTracker* file_progress, ThreadResult* result) {
@@ -700,7 +700,7 @@ static void SharedWorker(VFSWrapper* vfs, TreeSpec* spec, SharedWork* work,
 // Returns 0 on success, first -errno on failure.
 // ---------------------------------------------------------------------------
 
-static int RemoveTreeRecursive(VFSWrapper* vfs, const std::string& path) {
+static int RemoveTreeRecursive(ClientSession* vfs, const std::string& path) {
   Ino dir_ino;
   int rc = ResolvePath(vfs, path, &dir_ino);
   if (rc != 0) return rc;
@@ -825,7 +825,7 @@ int main(int argc, char** argv) {
   std::cout << "  total files: " << total_files << "\n";
   std::cout << "\n";
 
-  // ---- Configure logging before VFSWrapper starts ----
+  // ---- Configure logging before ClientSession starts ----
   FLAGS_log_dir = FLAGS_bench_log_dir;
   dingofs::FLAGS_log_level = FLAGS_bench_log_level;
 
@@ -840,7 +840,7 @@ int main(int argc, char** argv) {
   dingofs::Logger::Init("dingo-mdtest-bench");
 
   // ---- Mount ----
-  auto vfs = std::make_unique<VFSWrapper>();
+  auto vfs = std::make_unique<ClientSession>();
   DingofsConfig config;
   config.mds_addrs = FLAGS_bench_mds_addr;
   config.fs_name = FLAGS_bench_fs_name;

--- a/src/tools/replay/replay.cc
+++ b/src/tools/replay/replay.cc
@@ -17,7 +17,7 @@
 /*
  * dingo-replay: best-effort semantic replay of a legacy `fuse_access`
  * spdlog access-log against an *empty* target DingoFS filesystem, via
- * VFSWrapper (bypassing FUSE), following the src/tools/bench/mdtest_bench.cc
+ * ClientSession (bypassing FUSE), following the src/tools/bench/mdtest_bench.cc
  * setup pattern.
  *
  * See CONTEXT.md for terminology (Access Record, Best-effort Semantic
@@ -41,7 +41,7 @@
  *      fixed-size thread pool (size = max inflight) by reconstructed start
  *      time / speed. Records with the same source pid are assigned to the
  *      same worker. Each task waits (via std::shared_future) on its producer
- *      records' completion, resolves target ino/fh, issues the VFSWrapper
+ *      records' completion, resolves target ino/fh, issues the ClientSession
  *      call, and (if it is itself a producer) publishes its resulting target
  *      ino/fh for dependents.
  */
@@ -66,7 +66,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "client/vfs/vfs_wrapper.h"
+#include "client/vfs/client_session.h"
 #include "common/logging.h"
 #include "common/meta.h"
 #include "common/options/cache.h"
@@ -129,9 +129,9 @@ using dingofs::DirEntry;
 using dingofs::FsStat;
 using dingofs::Ino;
 using dingofs::Status;
+using dingofs::client::ClientSession;
 using dingofs::client::Context;
 using dingofs::client::DataBuffer;
-using dingofs::client::VFSWrapper;
 
 // ---------------------------------------------------------------------------
 // Engine record: a ParsedRecord plus dependency/runtime bookkeeping.
@@ -562,7 +562,7 @@ bool ResolveFh(std::vector<EngineRecord>& records, int64_t dep, uint64_t* out) {
   return true;
 }
 
-Status ExecuteOp(VFSWrapper* vfs, EngineRecord* rec, const Context& ctx,
+Status ExecuteOp(ClientSession* vfs, EngineRecord* rec, const Context& ctx,
                  Ino t_ino1, Ino t_ino2, uint64_t t_fh1, uint64_t t_fh2) {
   const ParsedRecord& p = rec->p;
   Status s;
@@ -741,7 +741,7 @@ Status ExecuteOp(VFSWrapper* vfs, EngineRecord* rec, const Context& ctx,
   return s;
 }
 
-void ExecuteRecord(VFSWrapper* vfs, std::vector<EngineRecord>* records_ptr,
+void ExecuteRecord(ClientSession* vfs, std::vector<EngineRecord>* records_ptr,
                    size_t idx, Stats* stats, AnomalyReport* report,
                    std::chrono::steady_clock::time_point t0) {
   auto& records = *records_ptr;
@@ -818,7 +818,7 @@ void ExecuteRecord(VFSWrapper* vfs, std::vector<EngineRecord>* records_ptr,
   if (r.done_promise) r.done_promise->set_value();
 }
 
-void RunReplay(VFSWrapper* vfs, std::vector<EngineRecord>* records_ptr,
+void RunReplay(ClientSession* vfs, std::vector<EngineRecord>* records_ptr,
                int max_inflight, double speed, Stats* stats,
                AnomalyReport* report) {
   auto& records = *records_ptr;
@@ -1034,7 +1034,7 @@ int main(int argc, char** argv) {
 
   dingofs::tools::replay::PreScan(&records, &report);
 
-  auto vfs = std::make_unique<dingofs::client::VFSWrapper>();
+  auto vfs = std::make_unique<dingofs::client::ClientSession>();
   dingofs::client::DingofsConfig config;
   config.mds_addrs = FLAGS_replay_mds_addr;
   config.fs_name = FLAGS_replay_fs_name;

--- a/src/tools/replay/replay_parser.h
+++ b/src/tools/replay/replay_parser.h
@@ -16,7 +16,7 @@
 
 /*
  * Parser for the legacy `fuse_access` spdlog access-log text produced by
- * client/vfs/access_log.h + vfs_wrapper.cc's AccessLogGuard.
+ * client/vfs/access_log.h + client_session.cc's AccessLogGuard.
  *
  * Line shape (spdlog default "%+" pattern):
  *   [YYYY-MM-DD HH:MM:SS.mmm] [fuse_access] [level] [pid:uid:gid] opname

--- a/test/unit/client/vfs/CMakeLists.txt
+++ b/test/unit/client/vfs/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(metasystem)
 
 add_library(test_vfs_impl
   test_vfs_impl.cc
-  test_vfs_wrapper_lifecycle.cc
+  test_client_session_lifecycle.cc
 )
 target_link_libraries(test_vfs_impl
   vfs_lib

--- a/test/unit/client/vfs/test_client_session_lifecycle.cc
+++ b/test/unit/client/vfs/test_client_session_lifecycle.cc
@@ -14,8 +14,11 @@
 #include <memory>
 #include <thread>
 
-#include "client/vfs/vfs_wrapper.h"
+#include "client/vfs/client_session.h"
+#include "common/metrics/client/client.h"
 #include "common/options/client.h"
+#include "common/trace/trace_manager.h"
+#include "utils/scoped_cleanup.h"
 
 namespace dingofs {
 namespace client {
@@ -103,42 +106,54 @@ class MockLifecycleVFS : public vfs::VFS {
               (ContextSPtr, Ino, uint32_t, unsigned int, unsigned, const void*,
                size_t, char*, size_t),
               (override));
-  MOCK_METHOD(uint64_t, GetFsId, (), (override));
-  MOCK_METHOD(double, GetAttrTimeout, (const FileType&), (override));
-  MOCK_METHOD(double, GetEntryTimeout, (const FileType&), (override));
-  MOCK_METHOD(uint64_t, GetMaxNameLength, (), (override));
-  MOCK_METHOD(TraceManager*, GetTraceManager, (), (override));
   MOCK_METHOD(Status, GetInfo, (std::string*), (override));
 };
 
 }  // namespace
 
-class VFSWrapperLifecycleTest : public ::testing::Test {
+class ClientSessionLifecycleTest : public ::testing::Test {
  protected:
   void SetUp() override {
     previous_access_logging_ = FLAGS_vfs_access_logging;
+    previous_attr_timeout_ = FLAGS_fuse_attr_cache_timeout_s;
+    previous_entry_timeout_ = FLAGS_fuse_entry_cache_timeout_s;
+    previous_max_name_length_ = FLAGS_vfs_meta_max_name_length;
     FLAGS_vfs_access_logging = false;
+    FLAGS_fuse_attr_cache_timeout_s = 1;
+    FLAGS_fuse_entry_cache_timeout_s = 2;
+    FLAGS_vfs_meta_max_name_length = 255;
+    session_ = std::make_unique<ClientSession>();
+    session_->trace_manager_ = std::make_unique<TraceManager>();
     auto core = std::make_unique<MockLifecycleVFS>();
     core_ = core.get();
-    wrapper_.vfs_ = std::move(core);
-    wrapper_.lifecycle_state_ = VFSWrapper::LifecycleState::kRunning;
-    wrapper_.fs_id_ = 10;
-    wrapper_.max_name_length_ = 255;
-    wrapper_.attr_timeout_ = 1.0;
-    wrapper_.entry_timeout_ = 2.0;
-    wrapper_.immutable_values_published_.store(true, std::memory_order_release);
+    session_->vfs_ = std::move(core);
+    session_->lifecycle_state_ = ClientSession::LifecycleState::kRunning;
   }
 
   void TearDown() override {
     FLAGS_vfs_access_logging = previous_access_logging_;
+    FLAGS_fuse_attr_cache_timeout_s = previous_attr_timeout_;
+    FLAGS_fuse_entry_cache_timeout_s = previous_entry_timeout_;
+    FLAGS_vfs_meta_max_name_length = previous_max_name_length_;
   }
 
-  VFSWrapper wrapper_;
+  void SetTraceStarted(bool started) { session_->trace_started_ = started; }
+
+  bool TraceStarted() const { return session_->trace_started_; }
+
+  void InitializeMetrics() {
+    session_->client_metrics_ =
+        std::make_unique<metrics::client::ClientOpMetric>();
+  }
+  std::unique_ptr<ClientSession> session_;
   MockLifecycleVFS* core_{nullptr};
   bool previous_access_logging_{true};
+  uint32_t previous_attr_timeout_{0};
+  uint32_t previous_entry_timeout_{0};
+  uint32_t previous_max_name_length_{0};
 };
 
-TEST_F(VFSWrapperLifecycleTest, StopWaitsForAdmittedOperation) {
+TEST_F(ClientSessionLifecycleTest, StopWaitsForAdmittedOperation) {
   std::promise<void> entered;
   std::promise<void> release;
   auto release_future = release.get_future();
@@ -156,13 +171,13 @@ TEST_F(VFSWrapperLifecycleTest, StopWaitsForAdmittedOperation) {
 
   std::thread operation([&] {
     std::string info;
-    EXPECT_TRUE(wrapper_.GetInfo(&info).ok());
+    EXPECT_TRUE(session_->GetInfo(&info).ok());
   });
   ASSERT_EQ(entered.get_future().wait_for(std::chrono::seconds(5)),
             std::future_status::ready);
 
   auto stop_future =
-      std::async(std::launch::async, [&] { return wrapper_.Stop(false); });
+      std::async(std::launch::async, [&] { return session_->Stop(false); });
   EXPECT_EQ(stop_future.wait_for(std::chrono::milliseconds(100)),
             std::future_status::timeout);
   EXPECT_FALSE(core_stopped.load());
@@ -173,7 +188,7 @@ TEST_F(VFSWrapperLifecycleTest, StopWaitsForAdmittedOperation) {
   EXPECT_TRUE(core_stopped.load());
 }
 
-TEST_F(VFSWrapperLifecycleTest, ConcurrentStopRunsCoreStopOnce) {
+TEST_F(ClientSessionLifecycleTest, ConcurrentStopRunsCoreStopOnce) {
   std::promise<void> stop_entered;
   std::promise<void> release_stop;
   auto release_future = release_stop.get_future();
@@ -185,11 +200,11 @@ TEST_F(VFSWrapperLifecycleTest, ConcurrentStopRunsCoreStopOnce) {
   }));
 
   auto first =
-      std::async(std::launch::async, [&] { return wrapper_.Stop(false); });
+      std::async(std::launch::async, [&] { return session_->Stop(false); });
   ASSERT_EQ(stop_entered.get_future().wait_for(std::chrono::seconds(5)),
             std::future_status::ready);
   auto second =
-      std::async(std::launch::async, [&] { return wrapper_.Stop(false); });
+      std::async(std::launch::async, [&] { return session_->Stop(false); });
 
   EXPECT_EQ(second.wait_for(std::chrono::milliseconds(100)),
             std::future_status::timeout);
@@ -197,21 +212,76 @@ TEST_F(VFSWrapperLifecycleTest, ConcurrentStopRunsCoreStopOnce) {
   EXPECT_TRUE(first.get().ok());
   EXPECT_TRUE(second.get().ok());
 }
+TEST_F(ClientSessionLifecycleTest, TraceOutlivesCoreStop) {
+  SetTraceStarted(true);
+  EXPECT_CALL(*core_, Stop(false)).WillOnce(Invoke([&](bool) {
+    EXPECT_TRUE(TraceStarted());
+    return Status::OK();
+  }));
 
-TEST_F(VFSWrapperLifecycleTest, StoppedSessionRejectsBeforeCoreAccess) {
+  EXPECT_TRUE(session_->Stop(false).ok());
+  EXPECT_FALSE(TraceStarted());
+}
+
+TEST_F(ClientSessionLifecycleTest, DestructorStopsRunningCore) {
   EXPECT_CALL(*core_, Stop(false)).WillOnce(Return(Status::OK()));
-  ASSERT_TRUE(wrapper_.Stop(false).ok());
+  session_.reset();
+}
+
+TEST(ClientSessionOptionTest, GettersReadFlagsWithoutSuccessfulStart) {
+  const uint32_t previous_attr_timeout = FLAGS_fuse_attr_cache_timeout_s;
+  const uint32_t previous_entry_timeout = FLAGS_fuse_entry_cache_timeout_s;
+  const uint32_t previous_max_name_length = FLAGS_vfs_meta_max_name_length;
+  auto restore_flags = MakeScopedCleanup([&]() {
+    FLAGS_fuse_attr_cache_timeout_s = previous_attr_timeout;
+    FLAGS_fuse_entry_cache_timeout_s = previous_entry_timeout;
+    FLAGS_vfs_meta_max_name_length = previous_max_name_length;
+  });
+
+  FLAGS_fuse_attr_cache_timeout_s = 3;
+  FLAGS_fuse_entry_cache_timeout_s = 4;
+  FLAGS_vfs_meta_max_name_length = 5;
+
+  ClientSession session;
+  EXPECT_DOUBLE_EQ(session.GetAttrTimeout(kFile), 3.0);
+  EXPECT_DOUBLE_EQ(session.GetEntryTimeout(kDirectory), 4.0);
+  EXPECT_EQ(session.GetMaxNameLength(), 5u);
+}
+
+TEST_F(ClientSessionLifecycleTest,
+       RuntimeOptionsAffectGettersAndPathValidation) {
+  InitializeMetrics();
+  FLAGS_fuse_attr_cache_timeout_s = 3;
+  FLAGS_fuse_entry_cache_timeout_s = 4;
+  FLAGS_vfs_meta_max_name_length = 4;
+
+  EXPECT_DOUBLE_EQ(session_->GetAttrTimeout(kFile), 3.0);
+  EXPECT_DOUBLE_EQ(session_->GetEntryTimeout(kDirectory), 4.0);
+  EXPECT_EQ(session_->GetMaxNameLength(), 4u);
+
+  EXPECT_CALL(*core_, Stop(false)).WillOnce(Return(Status::OK()));
+  EXPECT_CALL(*core_, Lookup).Times(0);
+  Attr attr;
+  Status status =
+      session_->Lookup(Context{0, 0, 0, 0}, kRootIno, "12345", &attr);
+
+  EXPECT_TRUE(status.IsNameTooLong());
+  EXPECT_TRUE(session_->Stop(false).ok());
+}
+
+TEST_F(ClientSessionLifecycleTest, StoppedSessionRejectsBeforeCoreAccess) {
+  EXPECT_CALL(*core_, Stop(false)).WillOnce(Return(Status::OK()));
+  ASSERT_TRUE(session_->Stop(false).ok());
 
   EXPECT_CALL(*core_, GetInfo(_)).Times(0);
   std::string info;
-  Status status = wrapper_.GetInfo(&info);
+  Status status = session_->GetInfo(&info);
   EXPECT_TRUE(status.IsStop());
   EXPECT_EQ(status.ToSysErrNo(), EIO);
 
-  EXPECT_EQ(wrapper_.GetFsId(), 10u);
-  EXPECT_EQ(wrapper_.GetMaxNameLength(), 255u);
-  EXPECT_DOUBLE_EQ(wrapper_.GetAttrTimeout(kFile), 1.0);
-  EXPECT_DOUBLE_EQ(wrapper_.GetEntryTimeout(kDirectory), 2.0);
+  EXPECT_EQ(session_->GetMaxNameLength(), 255u);
+  EXPECT_DOUBLE_EQ(session_->GetAttrTimeout(kFile), 1.0);
+  EXPECT_DOUBLE_EQ(session_->GetEntryTimeout(kDirectory), 2.0);
 }
 
 }  // namespace client

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -90,9 +90,8 @@ class FakePasswdSource : public PasswdSource {
 class VFSImplTest : public test::VFSTestBase {
  protected:
   void SetUp() override {
-    trace_manager_ = std::make_unique<TraceManager>();
     ON_CALL(*mock_hub_, GetTraceManager())
-        .WillByDefault(Return(trace_manager_.get()));
+        .WillByDefault(Return(&trace_manager_));
     EXPECT_CALL(*mock_hub_, GetTraceManager()).Times(AnyNumber());
 
     ON_CALL(*mock_hub_, GetBlockAccesserOptions())
@@ -102,7 +101,7 @@ class VFSImplTest : public test::VFSTestBase {
     // hub_uptr_ is consumed here; after this, use vfs_ to access VFSImpl.
     // VFSImplTest is a friend of VFSImpl, so the private constructor is
     // accessible.
-    vfs_.reset(new VFSImpl(std::move(hub_uptr_)));
+    vfs_.reset(new VFSImpl(std::move(hub_uptr_), trace_manager_));
   }
 
   void TearDown() override {
@@ -117,8 +116,8 @@ class VFSImplTest : public test::VFSTestBase {
     vfs_.reset();
   }
 
+  TraceManager trace_manager_;
   std::unique_ptr<VFSImpl> vfs_;
-  std::unique_ptr<TraceManager> trace_manager_;
 
   // Helper accessible from TEST_F-derived subclasses (which are not friends
   // of VFSImpl themselves but inherit from this friend class).
@@ -150,17 +149,6 @@ TEST_F(VFSImplTest, StopDrainsBrpcServerBeforeHub) {
 
   EXPECT_TRUE(vfs_->Stop(false).ok());
   EXPECT_EQ(BrpcServerStatus(), brpc::Server::READY);
-}
-
-// --- 1. GetFsId ---
-TEST_F(VFSImplTest, GetFsId_ReturnsFromFsInfo) {
-  // VFSImpl::GetFsId() is hardcoded to 10.
-  EXPECT_EQ(vfs_->GetFsId(), 10u);
-}
-
-// --- 2. GetMaxNameLength ---
-TEST_F(VFSImplTest, GetMaxNameLength_ReturnsValue) {
-  EXPECT_GT(vfs_->GetMaxNameLength(), 0u);
 }
 
 // --- 3. Lookup delegates to meta ---
@@ -579,11 +567,14 @@ TEST_F(VFSImplTest, Unlink_InternalFile_EPERM) {
 }
 
 // --- 11. StatFs delegates ---
-TEST_F(VFSImplTest, StatFs_DelegatesToMetaSystem) {
+TEST_F(VFSImplTest, StatFs_ReturnsDynamicFilesystemId) {
   FsStat fs_stat;
   fs_stat.max_bytes = 1024 * 1024 * 1024LL;
   fs_stat.used_bytes = 512 * 1024 * 1024LL;
 
+  auto fs_info = test::MakeTestFsInfo();
+  fs_info.id = 314159;
+  ON_CALL(*mock_hub_, GetFsInfo()).WillByDefault(Return(fs_info));
   EXPECT_CALL(*mock_meta_system_, StatFs(_, _, _))
       .WillOnce(DoAll(SetArgPointee<2>(fs_stat), Return(Status::OK())));
 
@@ -591,6 +582,7 @@ TEST_F(VFSImplTest, StatFs_DelegatesToMetaSystem) {
   Status s = vfs_->StatFs(ctx_, kRootIno, &out);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(out.max_bytes, fs_stat.max_bytes);
+  EXPECT_EQ(out.fs_id, fs_info.id);
 }
 
 // --- 13. GetInfo returns non-empty JSON ---


### PR DESCRIPTION
## Summary

- rename `VFSWrapper` to `ClientSession` and migrate all callers without compatibility aliases
- let `ClientSession` directly own the lazily constructed `TraceManager` and `ClientOpMetric`; inject only the tracing dependency required by `VFSImpl` and `VFSHubImpl`
- remove `VFS::GetTraceManager()` and the fs-id/timeout/name-length getters so `VFS` remains a lifecycle, state-serialization, and filesystem-operation boundary
- return the dynamic filesystem identity through `FsStat`: `VFSImpl::StatFs()` reads the active `VFSHub::GetFsInfo().id`, and the FUSE reply uses that same operation result for `f_fsid`
- read timeout and max-name reloadable gflags directly, without `MountInfo`, a duplicated option snapshot, or a successful-Start publication latch
- preserve operation draining, concurrent Stop idempotency, handover Dump ordering, trace shutdown ordering, errno behavior, and mount-visible default values

## Runtime contract

- `active_public_operations_` is the mutex-protected operation-drain counter: Stop transitions to `kQuiescing`, rejects new operations, and waits for admitted leases to release before stopping Core
- `ClientSession` declares `TraceManager` before `vfs_`, so every borrowing VFS component is destroyed before the tracing object; tracing is stopped only after Core Stop and handover Dump complete
- `TraceManager` and client metrics remain lazily constructed after config loading; `ClientOpMetric` stays private to the public-operation boundary and is not exposed to VFS runtime components
- filesystem identity is not a constant or gflag; it is fetched from the active filesystem and returned within the guarded `StatFs` operation
- attr/entry timeout and max-name getters always read current process-wide gflags and are independent of ClientSession lifecycle state
- pathname and xattr validation read the current max-name flag; `Rename` caches one value per operation so both names use the same limit
- no `MountInfo`, output parameter, compatibility getter, fixed fs-id constant, or `start_completed_` latch remains

## Tests

- `cmake --build build --target dingo-client test_binding_logging -j16`
- `./build/bin/test/test_client` — 462 passed
- `./build/bin/test_binding_logging` — 6 passed
- focused lifecycle, dynamic-identity, and lifecycle-independent option contracts — 8 passed

## Commit structure

- single commit — centralize client session lifecycle and narrow VFS boundaries