### PR TITLE
[fix][client] Stop RemoteNodeHealthChecker executor before member destruction; add regression test

### DIFF
--- a/src/cache/remote/remote_node_health_checker.cc
+++ b/src/cache/remote/remote_node_health_checker.cc
@@ -93,6 +93,8 @@ RemoteNodeHealthChecker::RemoteNodeHealthChecker(const std::string& ip,
           std::make_unique<Configure>())),
       conn_(RemoteNodeConnection::New()) {}
 
+RemoteNodeHealthChecker::~RemoteNodeHealthChecker() { Shutdown(); }
+
 void RemoteNodeHealthChecker::Start() {
   if (running_.load(std::memory_order_relaxed)) {
     LOG(WARNING) << "RemoteNodeHealthChecker already started";

--- a/src/cache/remote/remote_node_health_checker.h
+++ b/src/cache/remote/remote_node_health_checker.h
@@ -45,6 +45,7 @@ namespace cache {
 class RemoteNodeHealthChecker {
  public:
   RemoteNodeHealthChecker(const std::string& ip, uint32_t port);
+  ~RemoteNodeHealthChecker();
   void Start();
   void Shutdown();
 

--- a/test/unit/cache/remote/test_remote_node_health_checker.cc
+++ b/test/unit/cache/remote/test_remote_node_health_checker.cc
@@ -87,6 +87,23 @@ TEST_F(RemoteNodeHealthCheckerTest, StartAndShutdownIdempotent) {
   checker.Shutdown();
 }
 
+TEST_F(RemoteNodeHealthCheckerTest, DestroyWithoutShutdown) {
+  // Repro for the shutdown SIGSEGV (2026-08-03): implicit destruction frees
+  // conn_ and state_machine_ before executor_ is stopped/joined. Periodic
+  // tasks still running or queued in the pool then dereference freed members
+  // via CheckNode() -> state_machine_->Success()/Error().
+  // Expected: ASAN heap-use-after-free on the unpatched code.
+  FLAGS_cache_node_state_check_duration_ms = 1;
+
+  for (int i = 0; i < 200; ++i) {
+    auto checker =
+        std::make_unique<RemoteNodeHealthChecker>("127.0.0.1", 9300);
+    checker->Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    checker.reset();  // intentionally skip Shutdown()
+  }
+}
+
 TEST_F(RemoteNodeHealthCheckerTest, StageIoResultsDriveHealth) {
   RemoteNodeHealthChecker checker("127.0.0.1", 9300);
   checker.Start();


### PR DESCRIPTION
## Context

Matches the 2026-08-03 dingo-client umount SIGSEGV: `state_machine_->Success()` on freed memory → null vcall (`#0 0x0`) on a brpc worker.

## Root Cause

`RemoteNodeHealthChecker` has no destructor. Implicit destruction frees `conn_` and `state_machine_` *before* `executor_` stops its bthread pool. Periodic tasks still in the pool then touch freed members.

## Fix

Add `~RemoteNodeHealthChecker() { Shutdown(); }`. The existing `Shutdown()` stops the executor while all members are still alive, and is idempotent when already shut down or never started. All production callers are single-owner — no concurrent entry.

## Test

- `DestroyWithoutShutdown` regression test: 1ms interval, no explicit Shutdown, 200-iteration destroy loop. Crashes under ASAN at `state_machine_->Success()` (line 158), identical signature to the field core. Passes after the fix.
- `StartAndShutdownIdempotent` and `StageIoResultsDriveHealth` continue to pass.