### PR TITLE
[fix][client] Zero stale local slices on open truncate; add regression tests

### DIFF
--- a/src/client/vfs/metasystem/local/metasystem.cc
+++ b/src/client/vfs/metasystem/local/metasystem.cc
@@ -382,9 +382,13 @@ Status LocalMetaSystem::Open(ContextSPtr, Ino ino, int flags, uint64_t, bool*) {
     auto status = Get(inode_key, value);
 
     attr_entry = MetaCodec::DecodeInodeValue(value);
+    std::vector<KeyValue> kvs;
 
     if (flags & O_TRUNC) {
       file_length = attr_entry.length();
+      status =
+          AppendZeroSlicesToExistingChunks(fs_id, ino, 0, file_length, kvs);
+      if (!status.ok()) return status;
       attr_entry.set_length(0);
 
       attr_entry.set_ctime(std::max(attr_entry.ctime(), now_ns));
@@ -395,11 +399,10 @@ Status LocalMetaSystem::Open(ContextSPtr, Ino ino, int flags, uint64_t, bool*) {
 
     attr_entry.set_version(attr_entry.version() + 1);
 
-    // write to leveldb
-    std::vector<KeyValue> kvs = {
-        {KeyValue::OpType::kPut, inode_key,
-         MetaCodec::EncodeInodeValue(attr_entry)},
-    };
+    // Commit the inode and zero-slice updates atomically. Otherwise a later
+    // sparse rewrite can expose slices that belonged to the truncated file.
+    kvs.push_back({KeyValue::OpType::kPut, inode_key,
+                   MetaCodec::EncodeInodeValue(attr_entry)});
     status = Put(kvs);
     if (!status.ok()) return status;
   }
@@ -1286,6 +1289,55 @@ Status LocalMetaSystem::AppendZeroSliceToChunk(uint32_t fs_id, Ino ino,
 
   kvs.push_back({KeyValue::OpType::kPut, chunk_key,
                  MetaCodec::EncodeChunkValue(chunk_entry)});
+  return Status::OK();
+}
+
+Status LocalMetaSystem::AppendZeroSlicesToExistingChunks(
+    uint32_t fs_id, Ino ino, uint64_t offset, uint64_t end_offset,
+    std::vector<KeyValue>& kvs) {
+  if (offset >= end_offset) return Status::OK();
+
+  const uint64_t chunk_size = fs_info_.chunk_size();
+  const uint64_t first_chunk = offset / chunk_size;
+  const uint64_t last_chunk = (end_offset - 1) / chunk_size;
+  auto* iter = db_->NewIterator(leveldb::ReadOptions());
+  iter->Seek(MetaCodec::EncodeChunkKey(fs_id, ino, first_chunk));
+
+  while (iter->Valid() && MetaCodec::IsChunkKey(iter->key().ToString())) {
+    uint32_t chunk_fs_id;
+    Ino chunk_ino;
+    uint64_t chunk_index;
+    MetaCodec::DecodeChunkKey(iter->key().ToString(), chunk_fs_id, chunk_ino,
+                              chunk_index);
+    if (chunk_fs_id != fs_id || chunk_ino != ino || chunk_index > last_chunk) {
+      break;
+    }
+
+    auto chunk_entry = MetaCodec::DecodeChunkValue(iter->value().ToString());
+    const uint64_t chunk_offset = chunk_index * chunk_size;
+    const uint64_t zero_start = std::max(offset, chunk_offset);
+    const uint64_t zero_end = std::min(end_offset, chunk_offset + chunk_size);
+    if (zero_start < zero_end) {
+      auto* slice_entry = chunk_entry.add_slices();
+      slice_entry->set_id(0);
+      slice_entry->set_pos(zero_start - chunk_offset);
+      slice_entry->set_size(0);
+      slice_entry->set_off(0);
+      slice_entry->set_len(zero_end - zero_start);
+      chunk_entry.set_version(chunk_entry.version() + 1);
+
+      kvs.push_back({KeyValue::OpType::kPut, iter->key().ToString(),
+                     MetaCodec::EncodeChunkValue(chunk_entry)});
+    }
+    iter->Next();
+  }
+
+  const auto iter_status = iter->status();
+  delete iter;
+  if (!iter_status.ok()) {
+    return Status::IoError(
+        fmt::format("scan chunk fail, {}.", iter_status.ToString()));
+  }
   return Status::OK();
 }
 

--- a/src/client/vfs/metasystem/local/metasystem.h
+++ b/src/client/vfs/metasystem/local/metasystem.h
@@ -236,6 +236,11 @@ class LocalMetaSystem : public vfs::MetaSystem {
   Status AppendZeroSliceToChunk(uint32_t fs_id, Ino ino, uint64_t chunk_index,
                                 uint32_t chunk_pos, uint32_t len,
                                 std::vector<KeyValue>& kvs);
+  // Append zero slices only to chunks already stored for [offset, end_offset).
+  // KV updates are queued so the caller can commit them with the inode update.
+  Status AppendZeroSlicesToExistingChunks(uint32_t fs_id, Ino ino,
+                                          uint64_t offset, uint64_t end_offset,
+                                          std::vector<KeyValue>& kvs);
 
   const std::string fs_name_;
   const std::string db_path_;

--- a/test/unit/client/vfs/metasystem/test_local_metasystem.cc
+++ b/test/unit/client/vfs/metasystem/test_local_metasystem.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "client/vfs/metasystem/local/metasystem.h"
+#include "common/meta.h"
+#include "gtest/gtest.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+namespace local {
+namespace {
+
+class LocalMetaSystemTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    char path[] = "/tmp/dingofs-local-metasystem-XXXXXX";
+    const char* dir = ::mkdtemp(path);
+    ASSERT_NE(dir, nullptr);
+    db_path_ = dir;
+
+    meta_system_ = std::make_unique<LocalMetaSystem>(db_path_, "test-fs", "");
+    auto status = meta_system_->Init(false);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    initialized_ = true;
+  }
+
+  void TearDown() override {
+    if (initialized_) meta_system_->Stop(false);
+    std::filesystem::remove_all(db_path_);
+  }
+
+  Attr CreateFile(const std::string& name) {
+    Attr attr;
+    auto status = meta_system_->MkNod(nullptr, 1, name, 0, 0,
+                                      S_IFREG | S_IRUSR | S_IWUSR, 0, &attr);
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    return attr;
+  }
+
+  void WriteSlice(Ino ino, uint64_t chunk_index, uint64_t id, int32_t pos,
+                  int32_t len) {
+    Slice slice;
+    slice.id = id;
+    slice.pos = pos;
+    slice.size = len;
+    slice.off = 0;
+    slice.len = len;
+    auto status =
+        meta_system_->WriteSlice(nullptr, ino, chunk_index, 0, {slice});
+    ASSERT_TRUE(status.ok()) << status.ToString();
+  }
+
+  std::string db_path_;
+  std::unique_ptr<LocalMetaSystem> meta_system_;
+  bool initialized_{false};
+};
+
+TEST_F(LocalMetaSystemTest, OpenTruncZerosOldSlicesBeforeSparseRewrite) {
+  constexpr int32_t kPageSize = 4096;
+  auto attr = CreateFile("truncate-rewrite");
+  WriteSlice(attr.ino, 0, 100, 0, kPageSize);
+
+  bool keep_cache = false;
+  auto status =
+      meta_system_->Open(nullptr, attr.ino, O_TRUNC | O_WRONLY, 0, &keep_cache);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  Attr truncated_attr;
+  status = meta_system_->GetAttr(nullptr, attr.ino, &truncated_attr);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+  EXPECT_EQ(truncated_attr.length, 0);
+
+  std::vector<Slice> slices;
+  uint64_t version = 0;
+  status = meta_system_->ReadSlice(nullptr, attr.ino, 0, 0, &slices, version);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+  ASSERT_EQ(slices.size(), 2);
+  EXPECT_EQ(slices[0].id, 100);
+  EXPECT_EQ(slices[1].id, 0);
+  EXPECT_EQ(slices[1].pos, 0);
+  EXPECT_EQ(slices[1].len, kPageSize);
+
+  WriteSlice(attr.ino, 0, 101, kPageSize, kPageSize);
+  slices.clear();
+  status = meta_system_->ReadSlice(nullptr, attr.ino, 0, 0, &slices, version);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+  ASSERT_EQ(slices.size(), 3);
+  EXPECT_EQ(slices[1].id, 0);
+  EXPECT_EQ(slices[1].pos, 0);
+  EXPECT_EQ(slices[1].len, kPageSize);
+  EXPECT_EQ(slices[2].id, 101);
+  EXPECT_EQ(slices[2].pos, kPageSize);
+}
+
+TEST_F(LocalMetaSystemTest, OpenTruncDoesNotMaterializeSparseChunks) {
+  auto attr = CreateFile("truncate-sparse");
+  WriteSlice(attr.ino, 0, 200, 0, 4096);
+
+  Attr grown_attr;
+  grown_attr.length = 2 * meta_system_->GetFsInfo().chunk_size();
+  Attr out_attr;
+  auto status = meta_system_->SetAttr(nullptr, attr.ino, kSetAttrSize,
+                                      grown_attr, &out_attr);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  bool keep_cache = false;
+  status =
+      meta_system_->Open(nullptr, attr.ino, O_TRUNC | O_WRONLY, 0, &keep_cache);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  std::vector<Slice> slices;
+  uint64_t version = 0;
+  status = meta_system_->ReadSlice(nullptr, attr.ino, 1, 0, &slices, version);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+  EXPECT_TRUE(slices.empty());
+}
+
+}  // namespace
+}  // namespace local
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs


### PR DESCRIPTION
## Context

Local-mode xfstests `generic/647` and `generic/729` fail after `open(O_TRUNC)` followed by a sparse rewrite: direct I/O reads old bytes from what must be a hole. The MDS path already prevents this by appending zero slices over the truncated range.

## Root Cause

`LocalMetaSystem::Open(O_TRUNC)` resets only the inode length. It leaves existing chunk slice lists unchanged. A later sparse write extends the file but does not cover the leading hole, so the old slice remains the newest mapping there and truncated data resurfaces.

## Fix

Mirror the MDS truncate semantics in the local metasystem:

- scan only persisted chunks in `[0, old_length)`, so sparse holes are not materialized
- append an `id=0` zero slice over the truncated range of every existing chunk
- bump each affected chunk version
- commit the chunk updates and inode `length=0` in one LevelDB `WriteBatch`

## Test

- `LocalMetaSystemTest.OpenTruncZerosOldSlicesBeforeSparseRewrite` pins zero-slice ordering across truncate and sparse rewrite.
- `LocalMetaSystemTest.OpenTruncDoesNotMaterializeSparseChunks` verifies absent chunks remain holes.
- `build/bin/test/test_client --gtest_filter='LocalMetaSystemTest.*'`: 2/2 passed.
- local-mode xfstests `generic/647 generic/729`: 2/2 passed; both failed before the fix with `pread (D_DIRECT) from hole is broken`.