### PR TITLE
[fix][client] Skip queued prefetch work during shutdown

### DIFF
--- a/src/client/vfs/components/prefetch_manager.cc
+++ b/src/client/vfs/components/prefetch_manager.cc
@@ -46,8 +46,12 @@ int PrefetchManager::HandlePrefetch(
   for (; iter; iter++) {
     auto& context = *iter;
 
-    self->prefetch_executor_->Execute(
-        [self, context]() { self->ProcessPrefetch(context); });
+    self->prefetch_executor_->Execute([self, context]() {
+      if (!self->running_.load()) {
+        return;
+      }
+      self->ProcessPrefetch(context);
+    });
   }
 
   return 0;

--- a/test/unit/client/vfs/components/test_prefetch_manager.cc
+++ b/test/unit/client/vfs/components/test_prefetch_manager.cc
@@ -18,7 +18,10 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -218,15 +221,45 @@ TEST_F(PrefetchManagerTest, SubmitTask_MultipleBlocks) {
   waiter.Wait();
 }
 
-TEST_F(PrefetchManagerTest, Stop_DrainsPendingTasks) {
-  ASSERT_TRUE(mgr_->Start(2).ok());
+TEST_F(PrefetchManagerTest, Stop_DropsQueuedTasks) {
+  ASSERT_TRUE(mgr_->Start(1).ok());
 
-  // Submit many tasks and then stop - should not crash or hang.
-  for (int i = 0; i < 20; ++i) {
-    mgr_->SubmitTask(MakeSingleBlockCtx(static_cast<uint64_t>(i + 1000)));
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool first_started = false;
+  bool release_first = false;
+
+  EXPECT_CALL(*mock_block_store_, PrefetchAsync(_, _, _))
+      .Times(1)
+      .WillOnce([&](ContextSPtr, PrefetchReq, StatusCallback cb) {
+        {
+          std::unique_lock<std::mutex> lock(mutex);
+          first_started = true;
+          cv.notify_one();
+          cv.wait(lock, [&]() { return release_first; });
+        }
+        cb(Status::OK());
+      });
+
+  mgr_->SubmitTask(MakeSingleBlockCtx(1000));
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    cv.wait(lock, [&]() { return first_started; });
   }
+  mgr_->SubmitTask(MakeSingleBlockCtx(1001));
 
-  ASSERT_TRUE(mgr_->Stop().ok());
+  std::thread releaser([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      release_first = true;
+    }
+    cv.notify_one();
+  });
+
+  auto status = mgr_->Stop();
+  releaser.join();
+  ASSERT_TRUE(status.ok());
 }
 
 TEST_F(PrefetchManagerTest, Concurrent_SubmitFromMultipleThreads) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`PrefetchManager::Stop()` drains its thread pool. Pending speculative prefetch tasks therefore continued scanning large slice lists during client shutdown. In `generic/074`, a single chunk contained 30,720 slices and delayed `PrefetchManager::Stop()` by 48.36 seconds, causing the next mount attempt to exceed its 30-second wait.

### What is changed and how it works?

What's Changed:

- Check the manager's running state in each queued executor callback.
- Drop speculative prefetch work that has not started when shutdown begins.
- Replace the old drain-only test with a deterministic cancellation test that blocks the active task and verifies the queued task is not dispatched.

How it Works:

`Stop()` already clears `running_` before stopping the execution queue and draining the executor. Queued callbacks now observe that state and return before slice scanning or block-store prefetch submission. Tasks already executing continue to drain normally.

Measured with the same extracted `generic/074` workload:

- `PrefetchManager::Stop()`: 48.36s -> 0.24s
- client process exit: 49.67s -> 1.51s

Validation:

- `cmake --build build --target dingo-client -j32`
- `cmake --build build --target test_client -j32`
- `test_client --gtest_filter='PrefetchManagerTest.*'`: 9/9 passed
- latest upstream `generic/074`: 9 consecutive rounds passed before the local batch was paused so the branch could be shared; extended 50-round validation can continue in parallel

Side effects(Breaking backward compatibility? Performance regression?):

No API or data-path compatibility change. Prefetch is best-effort speculative work; only queued work that has not started is skipped during shutdown. Foreground reads and already-started prefetch operations are unchanged.

### Check List

- [x] Relevant tests are changed or added
- [x] I acknowledge that all my contributions will be made under the project's license