### PR TITLE
[feat][client] Add write-page admission and pressure flushing

### DIFF
--- a/sdk/shim/binding_client.cc
+++ b/sdk/shim/binding_client.cc
@@ -57,7 +57,7 @@ Status BindingClient::Start(const BindingConfig& config) {
 
   // Remember whether log_dir was set by conf_file before step 2 runs.
   // ResetBrpcFlagDefaultValue() (step 2) will overwrite an empty FLAGS_log_dir
-  // with ~/.dingofs/log, so we must capture the state beforehand.
+  // with ~/.dingo/log, so we must capture the state beforehand.
   const bool conf_file_set_log_dir = !FLAGS_log_dir.empty();
 
   // 2. Apply dingofs-preferred brpc defaults for flags the user didn't set.
@@ -71,7 +71,7 @@ Status BindingClient::Start(const BindingConfig& config) {
     } else if (!conf_file_set_log_dir) {
       // Neither config.log_dir nor conf_file specified a log directory.
       // Use the system temp dir to match glog's own default behaviour,
-      // rather than letting Logger::Init() redirect to ~/.dingofs/log/.
+      // rather than letting Logger::Init() redirect to ~/.dingo/log/.
       FLAGS_log_dir = P_tmpdir;
     }
     // else: conf_file set log_dir — keep the value it loaded.

--- a/sdk/shim/tests/test_binding_logging.cc
+++ b/sdk/shim/tests/test_binding_logging.cc
@@ -255,7 +255,7 @@ static void test_log_dir_from_conf_file() {
 
 /* Case 3: neither config.log_dir nor conf_file sets log_dir.
  * Expected: logs go to /tmp, matching glog's own default.
- * We must NOT see logs in ~/.dingofs/log/. */
+ * We must NOT see logs in ~/.dingo/log/. */
 static void test_log_dir_default_tmp() {
     const char* name = "log_dir: not set  →  logs in /tmp (glog default)";
 
@@ -273,10 +273,10 @@ static void test_log_dir_default_tmp() {
 
         ASSERT(name, check_log_file_in("/tmp", "dingofs-binding.info.log.", name));
 
-        /* DingoFS default dir (~/.dingofs/log/) must NOT have been used. */
+        /* DingoFS default dir (~/.dingo/log/) must NOT have been used. */
         const char* dingofs_default = getenv("HOME");
         if (dingofs_default) {
-            std::string default_log = std::string(dingofs_default) + "/.dingofs/log";
+            std::string default_log = std::string(dingofs_default) + "/.dingo/log";
             ASSERT(name, !dir_has_file_with_prefix(default_log,
                                                    "dingofs-binding.info.log."));
         }

--- a/src/client/fuse/fuse_op.cc
+++ b/src/client/fuse/fuse_op.cc
@@ -18,10 +18,12 @@
 
 #include <sys/types.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -47,6 +49,8 @@ USING_FLAG(fuse_enable_keep_cache)
 USING_FLAG(fuse_enable_readdir_cache)
 USING_FLAG(fuse_enable_parallel_dirops)
 USING_FLAG(fuse_dryrun_bench_mode)
+USING_FLAG(vfs_write_buffer_page_size)
+USING_FLAG(vfs_write_buffer_total_mb)
 
 using dingofs::Status;
 using dingofs::client::fuse::FuseUpgradeState;
@@ -107,6 +111,22 @@ void InitFuseConnInfo(struct fuse_conn_info* conn) {
 
   conn->max_readahead = FLAGS_fuse_max_readahead_kb * 1024;
   conn->max_background = FLAGS_fuse_max_background;
+
+  // One foreground request may start at the last byte of a page. Cap the
+  // negotiated payload so its worst-case page need always fits in the pool;
+  // larger user writes are split by the kernel instead of becoming an
+  // impossible FIFO head.
+  constexpr uint64_t kMiB = 1024 * 1024;
+  const uint64_t capacity_bytes = FLAGS_vfs_write_buffer_total_mb * kMiB;
+  CHECK_GE(capacity_bytes, FLAGS_vfs_write_buffer_page_size);
+  const uint64_t safe_max_write =
+      capacity_bytes - FLAGS_vfs_write_buffer_page_size + 1;
+  if (conn->max_write > safe_max_write) {
+    conn->max_write = static_cast<uint32_t>(std::min<uint64_t>(
+        safe_max_write, std::numeric_limits<uint32_t>::max()));
+    LOG(INFO) << "cap FUSE max_write to write-page admission capacity: "
+              << conn->max_write;
+  }
 }
 
 void Attr2Stat(const Attr& attr, struct stat* stat) {
@@ -177,7 +197,8 @@ static void ReplyAttr(fuse_req_t req, const Attr& attr) {
   memset(&stat, 0, sizeof(stat));
   Attr2Stat(attr, &stat);
 
-  int ret = fuse_reply_attr(req, &stat, g_client_session->GetAttrTimeout(attr.type));
+  int ret =
+      fuse_reply_attr(req, &stat, g_client_session->GetAttrTimeout(attr.type));
   if (ret != 0) {
     LOG(ERROR) << fmt::format("[fuse] fuse_reply_attr fail, ret({}).", errno);
   }
@@ -646,7 +667,8 @@ void FuseOpRead(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
   }
 
   uint64_t rsize = 0;
-  Status s = g_client_session->Read(ctx, ino, &data_buffer, size, off, fi->fh, &rsize);
+  Status s =
+      g_client_session->Read(ctx, ino, &data_buffer, size, off, fi->fh, &rsize);
   s.ok() ? ReplyData(req, data_buffer) : ReplyError(req, s);
 }
 
@@ -723,8 +745,9 @@ void FuseOpFallocate(fuse_req_t req, fuse_ino_t ino, int mode, off_t offset,
     return;
   }
 
-  Status s = g_client_session->Fallocate(ctx, ino, mode, static_cast<uint64_t>(offset),
-                              static_cast<uint64_t>(length));
+  Status s =
+      g_client_session->Fallocate(ctx, ino, mode, static_cast<uint64_t>(offset),
+                                  static_cast<uint64_t>(length));
   ReplyError(req, s);
 }
 
@@ -1038,7 +1061,8 @@ void FuseOpCreate(fuse_req_t req, fuse_ino_t parent, const char* name,
 
   uint64_t fh = 0;
   Attr out_attr;
-  Status s = g_client_session->Create(ctx, parent, name, mode, fi->flags, &fh, &out_attr);
+  Status s = g_client_session->Create(ctx, parent, name, mode, fi->flags, &fh,
+                                      &out_attr);
   if (!s.ok()) {
     ReplyError(req, s);
 
@@ -1081,7 +1105,7 @@ void FuseOpIoctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void* arg,
 
   std::string out_buf(out_bufsz, '\0');
   Status s = g_client_session->Ioctl(ctx, ino, cmd, flags, in_buf, in_bufsz,
-                          out_buf.data(), out_bufsz);
+                                     out_buf.data(), out_bufsz);
   s.ok() ? ReplyIoctl(req, out_buf.data(), out_bufsz) : ReplyError(req, s);
 }
 

--- a/src/client/vfs/client_session.cc
+++ b/src/client/vfs/client_session.cc
@@ -59,7 +59,7 @@ namespace dingofs {
 namespace client {
 
 // State file lives under the dingofs runtime data dir (not /tmp), e.g.
-// $DINGOFS_BASE_DIR/data, /var/dingofs/data (root) or $HOME/.dingofs/data.
+// $DINGOFS_BASE_DIR/data, /var/dingo/data (root) or $HOME/.dingo/data.
 // Old (writer) and new (reader) processes resolve the same path as long as
 // they run with the same uid and DINGOFS_BASE_DIR env -- the same assumption
 // already made for the fd-comm socket dir (GetDefaultDir(kSocketDir)).

--- a/src/client/vfs/compaction/compactor_impl.cc
+++ b/src/client/vfs/compaction/compactor_impl.cc
@@ -45,6 +45,14 @@ DEFINE_uint32(vfs_compact_cleanup_batch_size, 100,
 // own, so clamp here (same bound as mds gc kBatchDeleteObjectSize).
 constexpr size_t kMaxCleanupBatchSize = 1000;
 
+size_t CompactionPageNeed(int32_t offset_in_chunk, int64_t len,
+                          int64_t page_size) {
+  CHECK_GT(page_size, 0);
+  CHECK_GT(len, 0);
+  return static_cast<size_t>(
+      ((offset_in_chunk % page_size) + len + page_size - 1) / page_size);
+}
+
 Status CompactorImpl::Start() {
   LOG(INFO) << "CompactorImpl started";
   return Status::OK();
@@ -103,6 +111,16 @@ Status CompactorImpl::DoCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
   int32_t offset_in_chunk =
       static_cast<int32_t>(file_range.offset % chunk_size);
 
+  // Compaction is best-effort and must never queue behind foreground writes.
+  // Reserve before allocating/filling the dense read buffer so a capacity miss
+  // does not add heap pressure or backend read work.
+  WriteMemPool* write_pool = vfs_hub_->GetWriteMemPool();
+  WritePageLease lease;
+  DINGOFS_RETURN_NOT_OK(
+      write_pool->TryAcquire(CompactionPageNeed(offset_in_chunk, file_range.len,
+                                                write_pool->GetPageSize()),
+                             &lease));
+
   ChunkReq req(ino, chunk_index, offset_in_chunk, file_range);
 
   VLOG(9) << "Start comaction for req: " << req.ToString();
@@ -134,25 +152,15 @@ Status CompactorImpl::DoCompact(ContextSPtr ctx, Ino ino, int64_t chunk_index,
   Slice compacted;
 
   {
-    auto page_size = vfs_hub_->GetWriteMemPool()->GetPageSize();
-
+    const auto page_size = write_pool->GetPageSize();
     SliceDataContext ctx(fs_info.id, ino, chunk_index, chunk_size,
                          fs_info.block_size, page_size);
 
     auto writer = std::make_shared<SliceWriter>(ctx, vfs_hub_, offset_in_chunk);
 
-    Status ret =
-        writer->Write(SpanScope::GetContext(span), to_write.data(),
-                      static_cast<int32_t>(to_write.size()), offset_in_chunk);
-    if (!ret.ok()) {
-      // Compaction is best-effort: a write failure (e.g. NoSpace when the write
-      // page pool is under back-pressure) must abort this compaction and be
-      // retried later, never crash the client. Propagate like the read/flush
-      // failures above; the caller (CompactChunkTask::Run) just logs it.
-      LOG(WARNING) << "Fail compaction because write failed: " << ret.ToString()
-                   << ", ino: " << ino << ", chunk_index: " << chunk_index;
-      return ret;
-    }
+    writer->Write(SpanScope::GetContext(span), to_write.data(),
+                  static_cast<int32_t>(to_write.size()), offset_in_chunk,
+                  &lease);
 
     Status s;
     BSynchronizer sync;

--- a/src/client/vfs/data/CMakeLists.txt
+++ b/src/client/vfs/data/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(vfs_data
     writer/file_writer.cc
     writer/chunk_writer.cc
     writer_table.cc
+    write_pressure_controller.cc
     writer/task/file_flush_task.cc
     writer/task/chunk_flush_task.cc
     chunk.cc

--- a/src/client/vfs/data/slice/block_data.cc
+++ b/src/client/vfs/data/slice/block_data.cc
@@ -42,7 +42,7 @@ void BlockData::FreePageData() {
                             Helper::Char2Addr(page_data->page));
   }
   pages_.clear();
-  write_buffer_manager_->DeAllocateBatch(pages.data(), pages.size());
+  write_buffer_manager_->Release(pages.data(), pages.size());
 }
 
 PageData* BlockData::FindPageData(uint32_t page_index) {
@@ -50,8 +50,8 @@ PageData* BlockData::FindPageData(uint32_t page_index) {
   return iter == pages_.end() ? nullptr : iter->second.get();
 }
 
-Status BlockData::ReservePages(int32_t size, int32_t block_offset,
-                               std::vector<uint32_t>* created_pages) {
+void BlockData::ReservePages(int32_t size, int32_t block_offset,
+                             WritePageLease* lease) {
   CHECK_GT(size, 0);
   CHECK_GE(block_offset, 0);
   CHECK_LE(block_offset + size, context_.block_size);
@@ -77,14 +77,13 @@ Status BlockData::ReservePages(int32_t size, int32_t block_offset,
     ++page_index;
   }
 
-  if (missing_indexes.empty()) return Status::OK();
+  if (missing_indexes.empty()) return;
   std::vector<char*> allocated(missing_indexes.size());
-  const size_t allocated_count = write_buffer_manager_->TryAllocateBatch(
-      allocated.size(), allocated.data());
+  lease->Take(allocated.size(), allocated.data());
   const uint32_t first_page_index =
       static_cast<uint32_t>(block_offset / page_size);
   const int32_t first_page_offset = block_offset % page_size;
-  for (size_t i = 0; i < allocated_count; ++i) {
+  for (size_t i = 0; i < allocated.size(); ++i) {
     const uint32_t new_page_index = missing_indexes[i];
     auto [iter, inserted] = pages_.emplace(
         new_page_index,
@@ -92,40 +91,16 @@ Status BlockData::ReservePages(int32_t size, int32_t block_offset,
             vfs_hub_, new_page_index, context_.page_size, allocated[i],
             new_page_index == first_page_index ? first_page_offset : 0));
     CHECK(inserted);
-    created_pages->push_back(new_page_index);
     VLOG(12) << fmt::format("{} Reserved new page_data: {} for page index: {}",
                             UUID(), iter->second->ToString(), new_page_index);
   }
-  return allocated_count == missing_indexes.size()
-             ? Status::OK()
-             : Status::NoSpace("write page pool exhausted");
 }
 
-void BlockData::RollbackPages(const std::vector<uint32_t>& created_pages) {
-  std::vector<char*> pages;
-  pages.reserve(created_pages.size());
-  for (uint32_t idx : created_pages) {
-    auto it = pages_.find(idx);
-    if (it != pages_.end()) {
-      if (it->second->page != nullptr) {
-        pages.push_back(it->second->page);
-      }
-      pages_.erase(it);
-    }
-  }
-  write_buffer_manager_->DeAllocateBatch(pages.data(), pages.size());
-  VLOG(6) << fmt::format("{} RollbackPages freed {} pages", UUID(),
-                         created_pages.size());
-}
-
-// INVARIANT: ApplyWrite must be infallible -- SliceWriter's two-phase
-// atomicity relies on it (all fallible work, i.e. allocation, lives in
-// ReservePages/phase 1; phase 2 only memcpys). It is infallible only because
-// writes are append-only (SliceWriter gates on CHECK_EQ(chunk_offset, End())):
-// PageData::Write then always sees a contiguous append/prepend and never its
-// "illegal range" CHECK. If a random-overwrite write path is ever added, that
-// CHECK can fire mid-apply -- after other blocks were already reserved/applied
-// -- and abort the process, breaking the transaction. Revisit this split then.
+// INVARIANT: ApplyWrite must be infallible. All capacity admission happens
+// before writer locks, and ReservePages only transfers owned pages. This split
+// remains safe because writes are append-only (SliceWriter gates on
+// CHECK_EQ(chunk_offset, End())). If random overwrite is added, revisit the
+// PageData contiguity contract before allowing a partial phase-2 apply.
 void BlockData::ApplyWrite(ContextSPtr ctx, const char* buf, int32_t size,
                            int32_t block_offset) {
   auto span = vfs_hub_->GetTraceManager()->StartChildSpan(

--- a/src/client/vfs/data/slice/block_data.h
+++ b/src/client/vfs/data/slice/block_data.h
@@ -51,18 +51,9 @@ class BlockData {
   ~BlockData() { FreePageData(); }
 
   // Phase 1: ensure every page this write needs exists; allocate only, no
-  // memcpy, no len_ bump. New pages are appended to *created_pages (existing
-  // pages are skipped, not recorded). Allocates via TryAllocateBatch (never
-  // waits for capacity under the slice lock); on a short allocation returns
-  // NoSpace WITHOUT self-rollback so the caller can also undo pages it
-  // reserved in other blocks of the same SliceWriter transaction.
-  Status ReservePages(int32_t size, int32_t block_offset,
-                      std::vector<uint32_t>* created_pages);
-
-  // Free + erase the named pages. They MUST be this transaction's newly
-  // created pages (from ReservePages' created_pages) -- never pre-existing
-  // ones.
-  void RollbackPages(const std::vector<uint32_t>& created_pages);
+  // memcpy, no len_ bump. Missing pages transfer from the caller's admitted
+  // lease, so this operation cannot fail after successful pool admission.
+  void ReservePages(int32_t size, int32_t block_offset, WritePageLease* lease);
 
   // Phase 2: memcpy buf into already-reserved pages and bump
   // block_offset_/len_. Precondition: ReservePages covering this range already

--- a/src/client/vfs/data/slice/slice_writer.cc
+++ b/src/client/vfs/data/slice/slice_writer.cc
@@ -110,37 +110,31 @@ void SliceWriter::StartPrepareSliceId() {
 
 // --- Write with streaming upload ---
 
-Status SliceWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
-                          int32_t chunk_offset) {
+void SliceWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
+                        int32_t chunk_offset, WritePageLease* lease) {
   auto span = vfs_hub_->GetTraceManager()->StartChildSpan("SliceWriter::Write",
                                                           ctx->GetTraceSpan());
 
-  int32_t end_in_chunk = chunk_offset + size;
-
+  const int32_t end_in_chunk = chunk_offset + size;
   VLOG(4) << fmt::format("{} Start writing chunk_range: [{}-{}] len: {}",
                          UUID(), chunk_offset, end_in_chunk, size);
 
   CHECK_GT(size, 0);
+  CHECK_NOTNULL(lease);
   CHECK_EQ(chunk_offset, End()) << fmt::format(
       "{} Unexpected chunk offset: {}, End(): {}, chunk_offset_: {}",
       ToString(), chunk_offset, End(), chunk_offset_);
 
-  int32_t block_size = context_.block_size;
-  int32_t slice_internal_offset = chunk_offset - chunk_offset_;
-  uint32_t block_index = slice_internal_offset / block_size;
-  int32_t block_offset = slice_internal_offset % block_size;
+  const int32_t block_size = context_.block_size;
+  const int32_t slice_internal_offset = chunk_offset - chunk_offset_;
+  const uint32_t block_index = slice_internal_offset / block_size;
+  const int32_t block_offset = slice_internal_offset % block_size;
 
-  // One memcpy unit in phase 2: which block, where in it, from where in buf.
   struct BlockApply {
     BlockData* block;
     const char* buf;
     int32_t size;
     int32_t block_offset;
-  };
-  // Pages this call newly reserved in a block -- the rollback unit.
-  struct Reserved {
-    BlockData* block;
-    std::vector<uint32_t> pages;
   };
 
   {
@@ -149,84 +143,39 @@ Status SliceWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
         "{} Write called after FlushAsync closed the write epoch", UUID());
 
     std::vector<BlockApply> applies;
-    std::vector<Reserved> reserved;        // every block's new pages this call
-    std::vector<uint32_t> created_blocks;  // BlockData newly created this call
+    uint32_t bi = block_index;
+    int32_t bo = block_offset;
+    const char* p = buf;
+    int32_t remain_len = size;
 
-    // ---- Phase 1: reserve pages across ALL blocks (allocate only) ----
-    // Nothing is memcpy'd and len_ is untouched, so any pool miss can be fully
-    // rolled back, leaving zero visible state -- a same-offset retry stays
-    // clean (no contiguity CHECK trip) and flush can't pick up a half-write.
-    Status fail_status;
-    bool failed = false;
-    {
-      uint32_t bi = block_index;
-      int32_t bo = block_offset;
-      const char* p = buf;
-      int32_t remain_len = size;
-      while (remain_len > 0) {
-        int32_t write_size = std::min(remain_len, block_size - bo);
-
-        BlockData* block = FindBlockDataUnlocked(bi);
-        if (block == nullptr) {
-          block = CreateBlockDataUnlocked(bi, bo);
-          created_blocks.push_back(bi);
-        }
-
-        std::vector<uint32_t> pages;
-        Status s = block->ReservePages(write_size, bo, &pages);
-        reserved.push_back({block, std::move(pages)});
-        if (!s.ok()) {
-          fail_status = s;
-          failed = true;
-          break;
-        }
-        applies.push_back({block, p, write_size, bo});
-
-        remain_len -= write_size;
-        p += write_size;
-        bo = 0;
-        ++bi;
+    // Admission happened before entering any writer lock. Phase 1 only
+    // transfers already-owned pages from the lease; it cannot wait or fail.
+    while (remain_len > 0) {
+      const int32_t write_size = std::min(remain_len, block_size - bo);
+      BlockData* block = FindBlockDataUnlocked(bi);
+      if (block == nullptr) {
+        block = CreateBlockDataUnlocked(bi, bo);
       }
+
+      block->ReservePages(write_size, bo, lease);
+      applies.push_back({block, p, write_size, bo});
+
+      remain_len -= write_size;
+      p += write_size;
+      bo = 0;
+      ++bi;
     }
 
-    // ---- Rollback: free this call's new pages, drop this call's new blocks
-    // ----
-    if (failed) {
-      for (auto it = reserved.rbegin(); it != reserved.rend(); ++it) {
-        it->block->RollbackPages(it->pages);
-      }
-      for (auto it = created_blocks.rbegin(); it != created_blocks.rend();
-           ++it) {
-        block_datas_.erase(*it);
-      }
-      // Page pool could not back this slice; record the rolled-back range so
-      // the locality is visible by default (the VFSImpl boundary log only knows
-      // the whole-write offset/size, not which slice failed).
-      LOG(INFO) << fmt::format(
-          "{} Write reserve failed, rolled back chunk_range: [{}-{}], "
-          "status: {}",
-          UUID(), chunk_offset, end_in_chunk, fail_status.ToString());
-      return fail_status;
+    for (const auto& apply : applies) {
+      apply.block->ApplyWrite(SpanScope::GetContext(span), apply.buf,
+                              apply.size, apply.block_offset);
     }
 
-    // ---- Phase 2: every page exists -- memcpy + bump each BlockData::len_
-    // ----
-    for (const auto& a : applies) {
-      a.block->ApplyWrite(SpanScope::GetContext(span), a.buf, a.size,
-                          a.block_offset);
-    }
-
-    // ---- Publish slice len (only after full success) ----
-    // chunk_offset_ is const (forward-append only); only len_ grows.
-    int32_t old_len = len_;
+    const int32_t old_len = len_;
     len_ += size;
     VLOG(4) << fmt::format("{} Update slice data, old_len: {}, updated: {}",
                            UUID(), old_len, ToStringUnlocked());
 
-    // ---- Trigger streaming upload ----
-    // flush_requested_ was checked under this same lock, so this writer still
-    // belongs to its write epoch. ChunkWriter normally enforces the same
-    // ownership transition; the local CHECK makes violations fail loudly.
     if (len_ >= context_.block_size) {
       FlushUpTo(len_);
     }
@@ -234,8 +183,6 @@ Status SliceWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
 
   VLOG(4) << fmt::format("{} End writing chunk_range: [{}-{}], len: {}", UUID(),
                          chunk_offset, end_in_chunk, size);
-
-  return Status::OK();
 }
 
 // --- FlushUpTo: upload all blocks with end <= written_len ---

--- a/src/client/vfs/data/slice/slice_writer.h
+++ b/src/client/vfs/data/slice/slice_writer.h
@@ -51,8 +51,9 @@ class SliceWriter : public std::enable_shared_from_this<SliceWriter> {
 
   ~SliceWriter() = default;
 
-  Status Write(ContextSPtr ctx, const char* buf, int32_t size,
-               int32_t chunk_offset);
+  // The lease must own every page needed by this write.
+  void Write(ContextSPtr ctx, const char* buf, int32_t size,
+             int32_t chunk_offset, WritePageLease* lease);
 
   // Should be called only once (protected by ChunkWriter).
   void FlushAsync(StatusCallback cb);

--- a/src/client/vfs/data/write_pressure_controller.cc
+++ b/src/client/vfs/data/write_pressure_controller.cc
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client/vfs/data/write_pressure_controller.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cstdint>
+
+#include "client/vfs/data/writer_table.h"
+#include "utils/executor/executor.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+
+WritePressureController::WritePressureController(WriterTable* writer_table,
+                                                 Executor* executor)
+    : writer_table_(CHECK_NOTNULL(writer_table)),
+      executor_(CHECK_NOTNULL(executor)),
+      event_num_("vfs_write_pressure_event_num"),
+      coalesced_event_num_("vfs_write_pressure_coalesced_event_num"),
+      round_num_("vfs_write_pressure_round_num"),
+      round_failure_num_("vfs_write_pressure_round_failure_num"),
+      submit_failure_num_("vfs_write_pressure_submit_failure_num") {}
+
+WritePressureController::~WritePressureController() { StopAndDrain(); }
+
+void WritePressureController::OnWritePressure() {
+  bool submit = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (stopped_) return;
+    ++event_epoch_;
+    event_num_ << 1;
+    if (running_) {
+      pending_ = true;
+      coalesced_event_num_ << 1;
+      return;
+    }
+    running_ = true;
+    pending_ = false;
+    submit = true;
+  }
+  if (submit) SubmitRound(/*attempt=*/0);
+}
+
+void WritePressureController::SubmitRound(uint32_t attempt) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (stopped_) {
+      running_ = false;
+      pending_ = false;
+      cv_.notify_all();
+      return;
+    }
+  }
+
+  if (executor_->Execute([this] { RunRound(); })) return;
+
+  submit_failure_num_ << 1;
+  if (attempt < kMaxSubmitRetries) {
+    const int delay_ms = kInitialRetryDelayMs << attempt;
+    if (executor_->Schedule([this, attempt] { SubmitRound(attempt + 1); },
+                            delay_ms)) {
+      return;
+    }
+    submit_failure_num_ << 1;
+  }
+  FinishSubmitFailure();
+}
+
+void WritePressureController::FinishSubmitFailure() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  running_ = false;
+  pending_ = false;
+  cv_.notify_all();
+}
+
+void WritePressureController::RunRound() {
+  uint64_t event_snapshot = 0;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (stopped_) {
+      running_ = false;
+      pending_ = false;
+      cv_.notify_all();
+      return;
+    }
+    event_snapshot = event_epoch_;
+    pending_ = false;
+    round_num_ << 1;
+  }
+
+  writer_table_->FlushDirtyAsync([this, event_snapshot](Status status) mutable {
+    OnRoundDone(event_snapshot, std::move(status));
+  });
+}
+
+void WritePressureController::OnRoundDone(uint64_t event_snapshot,
+                                          Status status) {
+  if (!status.ok()) {
+    round_failure_num_ << 1;
+    LOG(WARNING) << "write pressure flush round failed: " << status.ToString();
+  }
+
+  bool run_again = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (stopped_) {
+      running_ = false;
+      pending_ = false;
+      cv_.notify_all();
+      return;
+    }
+
+    if (pending_ || event_epoch_ != event_snapshot) {
+      pending_ = false;
+      run_again = true;
+    } else {
+      running_ = false;
+      cv_.notify_all();
+    }
+  }
+  if (run_again) SubmitRound(/*attempt=*/0);
+}
+
+void WritePressureController::StopAndDrain() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (!stopped_) {
+    stopped_ = true;
+    pending_ = false;
+  }
+  cv_.wait(lock, [this] { return !running_; });
+}
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/src/client/vfs/data/write_pressure_controller.h
+++ b/src/client/vfs/data/write_pressure_controller.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_CLIENT_VFS_DATA_WRITE_PRESSURE_CONTROLLER_H_
+#define DINGOFS_CLIENT_VFS_DATA_WRITE_PRESSURE_CONTROLLER_H_
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+#include "bvar/reducer.h"
+#include "common/status.h"
+#include "common/writemempool/write_pressure_observer.h"
+
+namespace dingofs {
+
+class Executor;
+
+namespace client {
+namespace vfs {
+
+class WriterTable;
+
+// Event-driven control plane for write-page pressure. It coalesces pressure
+// events into at most one running and one pending round, then asks WriterTable
+// to fan out dirty writers. It does not rate-limit backend PUT traffic.
+class WritePressureController final : public WritePressureObserver {
+ public:
+  WritePressureController(WriterTable* writer_table, Executor* executor);
+  ~WritePressureController() override;
+
+  WritePressureController(const WritePressureController&) = delete;
+  WritePressureController& operator=(const WritePressureController&) = delete;
+
+  // May be called from foreground writers and upload completion threads. It
+  // only mutates the small controller state and submits work to executor.
+  void OnWritePressure() override;
+
+  // Rejects new events and waits for the active round, its writer callbacks,
+  // and any bounded submit retry to finish. The executor and WriterTable must
+  // remain alive until this returns.
+  void StopAndDrain();
+
+ private:
+  static constexpr uint32_t kMaxSubmitRetries = 3;
+  static constexpr int kInitialRetryDelayMs = 10;
+
+  void SubmitRound(uint32_t attempt);
+  void RunRound();
+  void OnRoundDone(uint64_t event_snapshot, Status status);
+  void FinishSubmitFailure();
+
+  WriterTable* writer_table_{nullptr};
+  Executor* executor_{nullptr};
+
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool running_{false};
+  bool pending_{false};
+  bool stopped_{false};
+  uint64_t event_epoch_{0};
+
+  bvar::Adder<int64_t> event_num_;
+  bvar::Adder<int64_t> coalesced_event_num_;
+  bvar::Adder<int64_t> round_num_;
+  bvar::Adder<int64_t> round_failure_num_;
+  bvar::Adder<int64_t> submit_failure_num_;
+};
+
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs
+
+#endif  // DINGOFS_CLIENT_VFS_DATA_WRITE_PRESSURE_CONTROLLER_H_

--- a/src/client/vfs/data/writer/chunk_writer.cc
+++ b/src/client/vfs/data/writer/chunk_writer.cc
@@ -24,7 +24,6 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <unordered_map>
 #include <utility>
 
 #include "client/vfs/common/async_util.h"
@@ -61,38 +60,33 @@ void ChunkWriter::Stop() {
     return;
   }
 
-  int64_t writers_count = WritersCount();
-  while (writers_count > 0) {
-    LOG(INFO) << fmt::format(
-        "{} Stop ChunkWriter waiting writers to finish, writers_count: {}",
-        UUID(), writers_count);
-    sleep(1);
-    writers_count = WritersCount();
-  }
+  CHECK_EQ(WritersCount(), 0) << fmt::format(
+      "{} Stop requires the caller to close the write entry "
+      "and drain all FileWriter writes first",
+      UUID());
 
   DoSyncFlush();
 
-  int64_t flush_tasks_count = FlushTasksCount();
-  while (flush_tasks_count > 0) {
-    LOG(INFO) << fmt::format(
-        "{} Stop ChunkWriter waiting flush tasks to finish, "
-        "flush_tasks_count: {}",
-        UUID(), flush_tasks_count);
-    sleep(1);
-    flush_tasks_count = FlushTasksCount();
+  {
+    // A prior flush failure makes DoSyncFlush return without enqueueing its
+    // FIFO sentinel, so an older task may still be in flight.
+    std::unique_lock<std::mutex> lg(flush_mutex_);
+    TEST_SYNC_POINT("ChunkWriter::Stop:before_wait_flush_queue");
+    flush_cv_.wait(lg, [this] { return flush_queue_.empty(); });
   }
 
   stopped_.store(true, std::memory_order_relaxed);
 }
 
-Status ChunkWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
-                          int32_t chunk_offset) {
+void ChunkWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
+                        int32_t chunk_offset, WritePageLease* lease) {
   CHECK(!stopped_.load(std::memory_order_relaxed));
+  CHECK_NOTNULL(lease);
   auto span = hub_->GetTraceManager()->StartChildSpan("ChunkWriter::Write",
                                                       ctx->GetTraceSpan());
 
   int64_t write_file_offset = chunk_.chunk_start + chunk_offset;
-  ChunkWriteInfo info(buf, size, chunk_offset, write_file_offset);
+  ChunkWriteInfo info(buf, size, chunk_offset, write_file_offset, lease);
   Writer writer;
   writer.write_info = &info;
 
@@ -102,21 +96,6 @@ Status ChunkWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
 
   // TODO: check mem ratio, sleep when mem is near full
   bool has_full = false;
-  // Per-writer result of the batch the leader drives below. Each write_info the
-  // leader actually wrote records its own status (OK, or the NoSpace that
-  // stopped the batch); write_infos past the failure point aren't inserted and
-  // fall back to batch_fail_status. This must be per-writer: a late failure
-  // must NOT clobber writers whose data already landed in the buffer -- they
-  // have to return OK, otherwise the caller retries the same range and
-  // double-writes (or trips a downstream CHECK).
-  std::unordered_map<const ChunkWriteInfo*, Status> batch_results;
-  Status batch_fail_status = Status::OK();
-  // A writer's status is its own write_info result if the leader reached it,
-  // else the batch failure (its data was never written -> must not return OK).
-  auto status_for = [&](const ChunkWriteInfo* wi) -> Status {
-    auto it = batch_results.find(wi);
-    return it != batch_results.end() ? it->second : batch_fail_status;
-  };
 
   {
     std::unique_lock<std::mutex> lg(writer_mutex_);
@@ -132,7 +111,7 @@ Status ChunkWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
       VLOG(4) << fmt::format(
           "{} BufferWrite End, writer already done, writer: {}", UUID(),
           writer.ToString());
-      return writer.status;
+      return;
     }
 
     // only the first writer can go here
@@ -177,16 +156,9 @@ Status ChunkWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
 
         CHECK_NOTNULL(slice);
 
-        Status s = slice->Write(SpanScope::GetContext(span), write_info->buf,
-                                write_info->size, write_info->chunk_offset);
-        batch_results[write_info] = s;
-        if (!s.ok()) {
-          // Pool exhausted. Stop the batch here; write_infos already processed
-          // keep their own (OK) status, the rest fall back to this failure in
-          // the wakeup loop below so none blocks forever (fills former TODO).
-          batch_fail_status = s;
-          break;
-        }
+        slice->Write(SpanScope::GetContext(span), write_info->buf,
+                     write_info->size, write_info->chunk_offset,
+                     write_info->lease);
 
         if (slice->Len() == chunk_.chunk_size) {
           has_full = true;
@@ -202,7 +174,6 @@ Status ChunkWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
       Writer* ready = writers_.front();
       writers_.pop_front();
       if (ready != &writer) {
-        ready->status = status_for(ready->write_info);
         ready->done = true;
         ready->cv.notify_all();
       }
@@ -218,8 +189,6 @@ Status ChunkWriter::Write(ContextSPtr ctx, const char* buf, int32_t size,
   if (has_full) {
     TriggerFlush();
   }
-
-  return status_for(&info);
 }
 
 SliceWriter* ChunkWriter::GetSliceUnlocked(int32_t chunk_pos, int32_t size) {
@@ -371,14 +340,16 @@ void ChunkWriter::TryCommitFlushTasks(ContextSPtr ctx) {
             "commit, fake header is removed, cur_commit_seq: {},"
             " remain flush_queue_size: {}",
             uuid, commit_seq, flush_queue_.size());
+        // Removing the fake header only shrinks the queue; notify Stop only
+        // when this removal actually makes the queue empty.
         flush_queue_.pop_front();
+        if (flush_queue_.empty()) {
+          flush_cv_.notify_all();
+        }
         return;
       }
 
     }  //  end lock_guard
-
-    CHECK(!to_commit.empty());
-
     std::vector<Slice> batch_commit_slices;
     for (FlushTask* task : to_commit) {
       if (task->status.ok()) {
@@ -452,10 +423,16 @@ void ChunkWriter::TryCommitFlushTasks(ContextSPtr ctx) {
       }
     }  // end if commit_slices not empty
 
-    hub_->GetCBExecutor()->Execute([&, uuid, commit_ctx] {
+    // Snapshot the batch error status and capture by value: this lambda may
+    // still sit in the CBExecutor queue when the ChunkWriter is deleted by
+    // FileWriter::Close, so it must not dereference `this`. Snapshotting here
+    // is also more precise: every task failure in the batch was already
+    // folded into the sticky status above.
+    Status batch_status = GetErrorStatus();
+    hub_->GetCBExecutor()->Execute([uuid, commit_ctx, batch_status] {
       for (FlushTask* task : commit_ctx->flush_tasks) {
         // if one task fail, all task fail
-        task->cb(GetErrorStatus());
+        task->cb(batch_status);
         VLOG(6) << fmt::format(
             "{} TryCommitFlushTasks delete chunk_flush_task: {}", uuid,
             task->ToString());

--- a/src/client/vfs/data/writer/chunk_writer.h
+++ b/src/client/vfs/data/writer/chunk_writer.h
@@ -48,15 +48,18 @@ struct ChunkWriteInfo {
   const int32_t end_chunk_offset{0};
   const int64_t file_offset{0};
   const int64_t end_file_offset{0};
+  WritePageLease* lease{nullptr};
 
   explicit ChunkWriteInfo(const char* _buf, int32_t _size,
-                          int32_t _chunk_offset, int64_t _file_offset)
+                          int32_t _chunk_offset, int64_t _file_offset,
+                          WritePageLease* _lease)
       : buf(_buf),
         size(_size),
         chunk_offset(_chunk_offset),
         end_chunk_offset(_chunk_offset + size),
         file_offset(_file_offset),
-        end_file_offset(_file_offset + size) {}
+        end_file_offset(_file_offset + size),
+        lease(_lease) {}
 
   std::string ToString() const {
     return fmt::format(
@@ -72,11 +75,14 @@ class ChunkWriter {
 
   ~ChunkWriter();
 
+  // The caller must prevent new Write calls and wait for all in-flight Write
+  // calls before Stop().
   void Stop();
 
-  // chunk_offset is the offset in the chunk, not in the file.
-  Status Write(ContextSPtr ctx, const char* buf, int32_t size,
-               int32_t chunk_offset);
+  // chunk_offset is relative to the chunk. The caller must admit sufficient
+  // pages and must not call after Stop(); contract violations CHECK-fail.
+  void Write(ContextSPtr ctx, const char* buf, int32_t size,
+             int32_t chunk_offset, WritePageLease* lease);
 
   // All slice data can be flushed in concurrent, but commit must be in order.
   // If slice data is empty, the empty flush task must be submitted
@@ -110,7 +116,6 @@ class ChunkWriter {
   struct Writer {
     ChunkWriteInfo* write_info{nullptr};
     std::condition_variable cv;
-    Status status;
     bool done{false};
 
     std::string ToString() const {
@@ -161,11 +166,6 @@ class ChunkWriter {
     }
   }
 
-  int64_t FlushTasksCount() const {
-    std::lock_guard<std::mutex> lg(flush_mutex_);
-    return flush_queue_.size();
-  }
-
   VFSHub* hub_;
   const Chunk chunk_;
   const int64_t page_size_;
@@ -184,6 +184,9 @@ class ChunkWriter {
 
   mutable std::mutex flush_mutex_;
   std::deque<FlushTask*> flush_queue_;
+  // Signalled when flush_queue_ becomes empty; Stop() waits on it for
+  // quiescence after DoSyncFlush. Guarded by flush_mutex_.
+  std::condition_variable flush_cv_;
   // Guarded by flush_mutex_. Never invoke a completion callback while holding
   // this mutex; callbacks may enter higher-level writer objects.
   // when this not ok, all write and flush should return error

--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -22,27 +22,14 @@
 #include <unistd.h>
 
 #include <atomic>
-#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <thread>
 
 #include "client/vfs/common/async_util.h"
 #include "client/vfs/data/writer/chunk_writer.h"
 #include "client/vfs/hub/vfs_hub.h"
 #include "common/writemempool/write_mem_pool.h"
-
-DEFINE_int64(vfs_stale_write_sleep_us, 10, "sleep us when detect memory low");
-
-DEFINE_double(vfs_write_throttle_soft_ratio, 0.85,
-              "write buffer usage ratio at which to start soft throttle");
-DEFINE_double(vfs_write_throttle_hard_ratio, 0.95,
-              "write buffer usage ratio at which to keep throttling until "
-              "the flush worker drains it back below");
-DEFINE_int64(vfs_write_throttle_budget_ms, 5000,
-             "max time to block in hard throttle before returning NoSpace; "
-             "bounds the wait so a stalled flush can't hang the FUSE syscall");
 
 namespace dingofs {
 namespace client {
@@ -54,48 +41,13 @@ static std::atomic<uint64_t> file_flush_id_gen{1};
 
 namespace {
 
-// Throttle counters (lock-free per-thread Adder). Only bumped on the slow path
-// (usage already past soft_ratio), so the normal write path never touches them.
-bvar::Adder<int64_t> g_throttle_num("vfs_write_throttle_num");
-bvar::Adder<int64_t> g_throttle_timeout_num("vfs_write_throttle_timeout_num");
 bvar::Adder<int64_t> g_close_after_flush_failure_num(
     "vfs_file_writer_close_after_flush_failure_num");
 
-// Memory-pressure throttle (pool-backed WriteMemPool, usage is hard-capped at
-// 100% so the old `used > total` / `> 2*total` thresholds never fire). Now
-// ratio-based with a soft pre-throttle:
-//   usage < soft_ratio  -> pass;
-//   usage >= soft_ratio -> sleep once to slow the writer;
-//   usage >= hard_ratio -> keep sleeping (bounded by budget_ms) until the
-//                          flush worker drains it back below.
-// The soft pre-throttle keeps the pool from truly filling, which would make
-// Allocate's bounded-acquire time out into ENOSPC. The wait is bounded so a
-// stalled flush (S3 down) can't D-state the FUSE syscall forever -- on timeout
-// we return NoSpace (-> ENOSPC) instead of blocking indefinitely.
-Status ApplyWriteBufferThrottle(WriteMemPool* bm) {
-  if (!bm->IsHighPressure(FLAGS_vfs_write_throttle_soft_ratio)) {
-    return Status::OK();
-  }
-
-  g_throttle_num << 1;  // soft limit hit (slow path only)
-  VLOG(1) << "WriteMemPool soft pressure, usage=" << bm->GetUsageRatio();
-  std::this_thread::sleep_for(
-      std::chrono::microseconds(FLAGS_vfs_stale_write_sleep_us));
-
-  auto deadline = std::chrono::steady_clock::now() +
-                  std::chrono::milliseconds(FLAGS_vfs_write_throttle_budget_ms);
-  while (bm->IsHighPressure(FLAGS_vfs_write_throttle_hard_ratio)) {
-    if (std::chrono::steady_clock::now() >= deadline) {
-      g_throttle_timeout_num << 1;
-      LOG(WARNING) << "WriteMemPool throttle timeout, usage="
-                   << bm->GetUsageRatio() << " used=" << bm->GetUsedBytes()
-                   << " total=" << bm->GetTotalBytes();
-      return Status::NoSpace("write buffer throttle timeout");
-    }
-    std::this_thread::sleep_for(
-        std::chrono::microseconds(10 * FLAGS_vfs_stale_write_sleep_us));
-  }
-  return Status::OK();
+size_t PageNeed(uint64_t offset, uint64_t size, uint64_t page_size) {
+  CHECK_GT(page_size, 0);
+  return static_cast<size_t>(((offset % page_size) + size + page_size - 1) /
+                             page_size);
 }
 
 }  // namespace
@@ -163,17 +115,9 @@ void FileWriter::ReleaseRef() {
 
 Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
                          uint64_t offset, uint64_t* out_wsize) {
-  // Define the out-param on every path: the early-return error paths below
-  // (sticky status / throttle timeout / closed) leave it 0 instead of relying
-  // on the caller to pre-zero.
+  // Define the out-param on every path.
   *out_wsize = 0;
-
-  // Sticky-broken fast-fail.
   DINGOFS_RETURN_NOT_OK(GetStatus());
-
-  // Memory-pressure throttle (soft pre-throttle; bounded hard wait). On timeout
-  // returns NoSpace -> ENOSPC instead of blocking the FUSE syscall forever.
-  DINGOFS_RETURN_NOT_OK(ApplyWriteBufferThrottle(vfs_hub_->GetWriteMemPool()));
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -201,28 +145,44 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
 
   Status s;
   uint64_t written_size = 0;
+  WriteMemPool* pool = vfs_hub_->GetWriteMemPool();
 
   while (size > 0) {
-    int32_t write_size = static_cast<int32_t>(
+    const int32_t write_size = static_cast<int32_t>(
         std::min(size, static_cast<uint64_t>(chunk_size - chunk_offset)));
 
-    ChunkWriter* chunk = GetOrCreateChunkWriter(chunk_index);
-    s = chunk->Write(SpanScope::GetContext(span), pos, write_size,
-                     chunk_offset);
-    if (!s.ok()) {
-      // Detail-only: this chunk stopped the write (surfaces as a short write if
-      // written_size > 0, else a hard error, decided after the loop). Don't
-      // WARN per chunk -- it floods under back-pressure and misreads a
-      // successful short write; the outcome is recorded uniformly in
-      // ClientSession's access log (status + out_wsize), the pool-pressure
-      // locality in SliceWriter, and the failure rate in the
-      // vfs_write_buffer_alloc_fail_num metric.
-      VLOG(3) << "stop write at chunk, ino: " << ino_
-              << ", chunk_index: " << chunk_index
-              << ", chunk_offset: " << chunk_offset
-              << ", write_size: " << write_size << ", status: " << s.ToString();
-      break;
+    // Capacity admission is the only blocking point and happens before any
+    // ChunkWriter/SliceWriter lock. One extra page covers worst-case
+    // unaligned boundaries; unused pages return through the lease.
+    WritePageLease lease;
+    s = pool->Acquire(PageNeed(static_cast<uint64_t>(chunk_offset),
+                               static_cast<uint64_t>(write_size),
+                               static_cast<uint64_t>(pool->GetPageSize())),
+                      &lease);
+    if (!s.ok()) break;
+
+    // Acquire may have waited while flush or shutdown changed writer state.
+    s = GetStatus();
+    if (!s.ok()) break;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (closed_) {
+        s = Status::BadFd("file already closed");
+      }
     }
+    if (!s.ok()) break;
+
+    ChunkWriter* chunk = GetOrCreateChunkWriter(chunk_index);
+    chunk->Write(SpanScope::GetContext(span), pos, write_size, chunk_offset,
+                 &lease);
+
+    // Publish every independently flushable chunk before the next Acquire can
+    // block. Pressure flush uses these generations as its dirty predicate.
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      ++write_generation_;
+    }
+    pool->NotifyDirtyPublished();
 
     pos += write_size;
     size -= write_size;
@@ -236,9 +196,6 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (written_size > 0) {
-      ++write_generation_;
-    }
     writers_count_--;
     if (writers_count_ == 0) {
       cv_.notify_all();
@@ -247,11 +204,8 @@ Status FileWriter::Write(ContextSPtr ctx, const char* buf, uint64_t size,
 
   *out_wsize = written_size;
 
-  // Partial progress is a POSIX short write, not a failure. SliceWriter::Write
-  // is atomic per chunk, so written_size is exactly the prefix of fully-written
-  // chunks; report OK + that prefix so the caller advances and re-issues the
-  // rest (which hits the throttle / backpressure). Only a zero-byte write
-  // surfaces the error (e.g. the very first chunk got ENOSPC).
+  // Partial progress is a POSIX short write, not a failure. A zero-byte result
+  // surfaces the admission, sticky writer, or shutdown status.
   if (written_size > 0) {
     return Status::OK();
   }
@@ -349,6 +303,7 @@ void FileWriter::AsyncFlush(StatusCallback cb) {
     VLOG(3) << fmt::format(
         "{} File::AsyncFlush end file_flush_id: {}, chunk_count: {} calling "
         "callback directly",
+
         uuid_, file_flush_id, chunk_count);
     // chunk_writers_ only grows after a successful write reaches a chunk.
     // Therefore an empty writer has no generation that needs flushing.
@@ -368,6 +323,22 @@ void FileWriter::AsyncFlush(StatusCallback cb) {
     FileFlushTaskDone(file_flush_id, target_generation, rcb, std::move(status));
     ReleaseRef();
   });
+}
+void FileWriter::FlushDirtyAsync(StatusCallback cb) {
+  bool dirty = false;
+  bool closed = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    closed = closed_;
+    dirty = write_generation_ > flushed_generation_;
+  }
+  if (closed) {
+    cb(Status::BadFd("file already closed"));
+  } else if (!dirty) {
+    cb(Status::OK());
+  } else {
+    AsyncFlush(std::move(cb));
+  }
 }
 
 Status FileWriter::Flush() {

--- a/src/client/vfs/data/writer/file_writer.h
+++ b/src/client/vfs/data/writer/file_writer.h
@@ -36,9 +36,7 @@ class VFSHub;
 class FileWriter {
  public:
   FileWriter(VFSHub* hub, uint64_t ino)
-      : vfs_hub_(hub),
-        ino_(ino),
-        uuid_(fmt::format("file_writer-{}", ino_)) {}
+      : vfs_hub_(hub), ino_(ino), uuid_(fmt::format("file_writer-{}", ino_)) {}
 
   ~FileWriter();
 
@@ -50,6 +48,10 @@ class FileWriter {
                uint64_t* out_wsize);
 
   Status Flush();
+
+  // Starts a flush only when published writes are not fully flushed. The
+  // callback is invoked exactly once, possibly inline for a clean writer.
+  void FlushDirtyAsync(StatusCallback cb);
 
   void AcquireRef();
 
@@ -82,7 +84,7 @@ class FileWriter {
   std::atomic<int64_t> refs_{0};
 
   mutable std::mutex status_mutex_;
-  Status file_status_;   // sticky after first error
+  Status file_status_;  // sticky after first error
 
   mutable std::mutex mutex_;
   std::condition_variable cv_;

--- a/src/client/vfs/data/writer_table.cc
+++ b/src/client/vfs/data/writer_table.cc
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -81,6 +82,57 @@ Status WriterTable::FlushAll() {
   return final_status;
 }
 
+void WriterTable::FlushDirtyAsync(StatusCallback cb) {
+  std::vector<FileWriter*> snap;
+  {
+    std::lock_guard<std::mutex> lg(mutex_);
+    snap.reserve(writers_.size());
+    for (auto& [ino, entry] : writers_) {
+      entry.writer->AcquireRef();
+      ++entry.holders;
+      snap.push_back(entry.writer);
+    }
+  }
+
+  if (snap.empty()) {
+    cb(Status::OK());
+    return;
+  }
+
+  struct FlushGroup {
+    std::mutex mutex;
+    size_t remaining{0};
+    Status status;
+    StatusCallback done;
+  };
+  auto group = std::make_shared<FlushGroup>();
+  group->remaining = snap.size();
+  group->done = std::move(cb);
+
+  for (FileWriter* writer : snap) {
+    writer->FlushDirtyAsync([this, writer, group](Status status) {
+      // Holder release is part of round completion: it may be the last holder
+      // and synchronously close the writer.
+      ReleaseWriter(writer);
+
+      StatusCallback done;
+      Status final_status;
+      {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        if (!status.ok() && group->status.ok()) {
+          group->status = status;
+        }
+        CHECK_GT(group->remaining, 0);
+        if (--group->remaining == 0) {
+          final_status = group->status;
+          done = std::move(group->done);
+        }
+      }
+      if (done) done(std::move(final_status));
+    });
+  }
+}
+
 size_t WriterTable::Size() const {
   std::lock_guard<std::mutex> lg(mutex_);
   return writers_.size();
@@ -102,7 +154,7 @@ FileWriter* WriterTable::AcquireWriter(uint64_t ino) {
 
   // First-time create.
   auto* w = new FileWriter(vfs_hub_, ino);
-  w->AcquireRef();   // ref balance for the AcquireWriter caller
+  w->AcquireRef();  // ref balance for the AcquireWriter caller
   Status s = w->Open();
   if (!s.ok()) {
     LOG(ERROR) << fmt::format("AcquireWriter Open failed, ino={}, status={}",
@@ -155,9 +207,9 @@ void WriterTable::ReleaseWriter(FileWriter* writer) {
   //   - ReleaseRef may transitively call delete-this; doing it outside
   //     also keeps the table mutex's critical section short.
   if (need_close) {
-    writer->Close();   // flips closed_ so SchedulePeriodicFlush stops arming
+    writer->Close();  // flips closed_ so SchedulePeriodicFlush stops arming
   }
-  writer->ReleaseRef();   // may delete-this once refs_ reaches 0
+  writer->ReleaseRef();  // may delete-this once refs_ reaches 0
 }
 
 }  // namespace vfs

--- a/src/client/vfs/data/writer_table.h
+++ b/src/client/vfs/data/writer_table.h
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <unordered_map>
 
+#include "common/callback.h"
 #include "common/status.h"
 
 namespace dingofs {
@@ -70,10 +71,14 @@ class WriterTable {
 
   // Lifecycle.
   Status Start();
-  void Stop();   // refuse new acquires; does not flush
+  void Stop();  // refuse new acquires; does not flush
 
   // Synchronously flush all live writers; idempotent.
   Status FlushAll();
+
+  // Fan-outs all currently dirty writers and invokes cb exactly once after
+  // every participant callback and transient holder release completes.
+  void FlushDirtyAsync(StatusCallback cb);
 
   // Get-or-create the FileWriter for ino. Returned pointer has a holder
   // outstanding; caller MUST call ReleaseWriter exactly once.

--- a/src/client/vfs/hub/vfs_hub.cc
+++ b/src/client/vfs/hub/vfs_hub.cc
@@ -30,6 +30,7 @@
 #include "client/vfs/components/prefetch_manager.h"
 #include "client/vfs/components/warmup_manager.h"
 #include "client/vfs/data/reader/reader_registry.h"
+#include "client/vfs/data/write_pressure_controller.h"
 #include "client/vfs/data/writer_table.h"
 #include "client/vfs/metasystem/local/metasystem.h"
 #include "client/vfs/metasystem/mds/metasystem.h"
@@ -44,7 +45,6 @@
 #include "common/directory.h"
 #include "common/options/cache.h"
 #include "common/options/client.h"
-#include "common/options/common.h"
 #include "common/status.h"
 #include "common/version.h"
 #include "utils/executor/thread/executor_impl.h"
@@ -58,6 +58,7 @@ static const std::string kReadExecutorName = "vfs_read";
 static const std::string kReadCleanupExecutorName = "vfs_read_cleanup";
 static const std::string kWriteBackgroundExecutorName = "vfs_write_bg";
 static const std::string kCBExecutorName = "vfs_callback";
+static const std::string kWritePressureExecutorName = "vfs_write_pressure";
 
 static MetaSystemUPtr BuildMetaSystem(const VFSConfig& vfs_conf,
                                       const ClientId& client_id,
@@ -109,6 +110,10 @@ VFSHubImpl::~VFSHubImpl() {
     handle_manager_.reset();
   }
 
+  if (write_pressure_controller_ != nullptr) {
+    write_pressure_controller_.reset();
+  }
+
   if (writer_table_ != nullptr) {
     writer_table_.reset();
   }
@@ -127,6 +132,10 @@ VFSHubImpl::~VFSHubImpl() {
 
   if (flush_executor_ != nullptr) {
     flush_executor_.reset();
+  }
+
+  if (write_pressure_executor_ != nullptr) {
+    write_pressure_executor_.reset();
   }
 
   if (warmup_manager_ != nullptr) {
@@ -165,6 +174,14 @@ Status VFSHubImpl::Start(bool skip_mount) {
   LOG(INFO) << fmt::format("[vfs.hub] vfs hub starting, skip_mount({}).",
                            skip_mount);
 
+  const uint64_t write_buffer_total_bytes =
+      FLAGS_vfs_write_buffer_total_mb * 1024 * 1024;
+  if (write_buffer_total_bytes % FLAGS_vfs_write_buffer_page_size != 0) {
+    return Status::InvalidParam(fmt::format(
+        "write buffer total size ({}) must be a multiple of page size ({})",
+        write_buffer_total_bytes, FLAGS_vfs_write_buffer_page_size));
+  }
+
   {
     compactor_ = std::make_unique<CompactorImpl>(this);
     DINGOFS_RETURN_NOT_OK(compactor_->Start());
@@ -193,6 +210,27 @@ Status VFSHubImpl::Start(bool skip_mount) {
     if (fs_info_.status != FsStatus::kNormal) {
       return Status::Internal(fmt::format("fs is unavailable, status({})",
                                           FsStatus2Str(fs_info_.status)));
+    }
+
+    if (fs_info_.block_size % FLAGS_vfs_write_buffer_page_size != 0) {
+      return Status::InvalidParam(fmt::format(
+          "filesystem block size ({}) must be a multiple of write buffer "
+          "page size ({})",
+          fs_info_.block_size, FLAGS_vfs_write_buffer_page_size));
+    }
+
+    const uint64_t max_chunk_pages =
+        (static_cast<uint64_t>(fs_info_.chunk_size) +
+         FLAGS_vfs_write_buffer_page_size - 1) /
+        FLAGS_vfs_write_buffer_page_size;
+    const uint64_t write_buffer_capacity_pages =
+        write_buffer_total_bytes / FLAGS_vfs_write_buffer_page_size;
+    if (max_chunk_pages > write_buffer_capacity_pages) {
+      return Status::InvalidParam(fmt::format(
+          "filesystem chunk size ({}) requires up to {} write buffer pages, "
+          "exceeding write buffer capacity ({} pages, {} bytes)",
+          fs_info_.chunk_size, max_chunk_pages, write_buffer_capacity_pages,
+          write_buffer_total_bytes));
     }
   }
 
@@ -320,9 +358,19 @@ Status VFSHubImpl::Start(bool skip_mount) {
     }
   }
 
+  {
+    write_pressure_executor_ =
+        std::make_unique<ExecutorImpl>(kWritePressureExecutorName, 1);
+    if (!write_pressure_executor_->Start()) {
+      return Status::Internal("write pressure executor start fail");
+    }
+  }
+
   write_buffer_manager_ = std::make_unique<WriteMemPool>(
-      FLAGS_vfs_write_buffer_total_mb * 1024 * 1024,
-      FLAGS_vfs_write_buffer_page_size);
+      write_buffer_total_bytes, FLAGS_vfs_write_buffer_page_size);
+  write_pressure_controller_ = std::make_unique<WritePressureController>(
+      writer_table_.get(), write_pressure_executor_.get());
+  write_buffer_manager_->SetPressureObserver(write_pressure_controller_.get());
 
   // read mempool (the read-path buffer accountant; replaces ReadBufferManager)
   {
@@ -427,8 +475,25 @@ Status VFSHubImpl::Stop(bool skip_unmount) {
     uid_gid_mapper_->StopWatching();
   }
 
+  // Close page admission first so blocked foreground writers wake and no new
+  // leases can enter teardown. Existing page owners may still release.
+  if (write_buffer_manager_ != nullptr) {
+    write_buffer_manager_->Close();
+    write_buffer_manager_->SetPressureObserver(nullptr);
+  }
+
   if (compactor_ != nullptr) {
     compactor_->Stop();
+  }
+
+  // Drain the event-driven flush round before HandleManager performs the final
+  // synchronous writer flush. This prevents overlapping pressure and shutdown
+  // flush ownership.
+  if (write_pressure_controller_ != nullptr) {
+    write_pressure_controller_->StopAndDrain();
+  }
+  if (write_pressure_executor_ != nullptr) {
+    write_pressure_executor_->Stop();
   }
 
   Status handle_stop_status;

--- a/src/client/vfs/hub/vfs_hub.h
+++ b/src/client/vfs/hub/vfs_hub.h
@@ -47,6 +47,7 @@ namespace client {
 namespace vfs {
 
 class WriterTable;  // forward decl; full include lives in vfs_hub.cc
+class WritePressureController;
 class ReaderRegistry;
 
 class VFSHub {
@@ -271,7 +272,9 @@ class VFSHubImpl : public VFSHub {
 
   std::unique_ptr<Executor> flush_executor_;
   std::unique_ptr<Executor> cb_executor_;
+  std::unique_ptr<Executor> write_pressure_executor_;
   std::unique_ptr<WriteMemPool> write_buffer_manager_;
+  std::unique_ptr<WritePressureController> write_pressure_controller_;
   std::unique_ptr<ReadMemPool> read_mem_pool_;
   std::unique_ptr<ReadMemPoolVars>
       read_mem_pool_vars_;  // after pool: dtor first

--- a/src/client/vfs/metasystem/local/metasystem.cc
+++ b/src/client/vfs/metasystem/local/metasystem.cc
@@ -1808,7 +1808,8 @@ mds::FsInfoEntry LocalMetaSystem::GenFsInfo() {
   fs_info.set_block_size(kBlockSize);
   fs_info.set_chunk_size(kChunkSize);
   fs_info.set_enable_dir_stats(false);
-  fs_info.set_owner(std::getenv("USER"));
+  const char* owner = std::getenv("USER");
+  fs_info.set_owner(owner == nullptr ? "" : owner);
   fs_info.set_capacity(INT64_MAX);
   fs_info.set_recycle_time_hour(24);
   fs_info.set_create_time_s(utils::Timestamp());

--- a/src/client/vfs/vfs_impl.cc
+++ b/src/client/vfs/vfs_impl.cc
@@ -709,11 +709,9 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
 
   s = handle->resources.writer->Write(SpanScope::GetContext(span), buf, size,
                                       offset, out_wsize);
-  // Use *out_wsize, not size: writer->Write may short-write (OK with
-  // *out_wsize < size) when the page pool is exhausted mid-write. Metadata must
-  // reflect only what is durable -- MetaSystem::Write extends the inode length
-  // to offset + len, so passing the full size would claim bytes that were never
-  // written (reads past the durable prefix would see a phantom hole).
+  // Use *out_wsize, not size: shutdown or a sticky writer failure can stop a
+  // multi-chunk write after a successful prefix. Metadata must reflect only
+  // bytes accepted by the writer.
   if (s.ok() && *out_wsize > 0) {
     s = meta_system_->Write(SpanScope::GetContext(span), ino, buf, offset,
                             *out_wsize, fh);
@@ -723,10 +721,7 @@ Status VFSImpl::Write(ContextSPtr ctx, Ino ino, const char* buf, uint64_t size,
                                       static_cast<int64_t>(*out_wsize));
   }
 
-  // No status logging here: VFSImpl returns Status without logging per-op
-  // outcomes (like the other ops); the uniform status + out_wsize record lives
-  // in ClientSession's access log, the pool-pressure locality in SliceWriter,
-  // and the failure rate in the vfs_write_buffer_alloc_fail_num metric.
+  // ClientSession's access log records status + out_wsize uniformly.
   return s;
 }
 

--- a/src/common/blockaccess/rados/rados_accesser.cc
+++ b/src/common/blockaccess/rados/rados_accesser.cc
@@ -55,7 +55,7 @@ DEFINE_bool(rados_enable_admin_socket, true,
             "enable librados admin socket for objecter_requests/perf dump "
             "introspection; socket goes to the dingofs run dir alongside "
             "fd_comm_socket: GetDefaultDir(run)/rados.<pid>.asok "
-            "(root -> /var/dingofs/run, non-root -> $HOME/.dingofs/run)");
+            "(root -> /var/dingo/run, non-root -> $HOME/.dingo/run)");
 
 namespace {
 
@@ -169,8 +169,8 @@ bool RadosAccesser::Init() {
   }
 
   // librados admin socket (default on): same dir as dingofs fd_comm_socket via
-  // GetDefaultDir(kSocketDir) -- root -> /var/dingofs/run, non-root ->
-  // $HOME/.dingofs/run -- so it follows whoever runs the process. Keyed by pid.
+  // GetDefaultDir(kSocketDir) -- root -> /var/dingo/run, non-root ->
+  // $HOME/.dingo/run -- so it follows whoever runs the process. Keyed by pid.
   // Non-fatal: a failure here only loses introspection, never blocks mount.
   if (FLAGS_rados_enable_admin_socket) {
     const std::string socket_dir = GetDefaultDir(kSocketDir);

--- a/src/common/directory.h
+++ b/src/common/directory.h
@@ -39,8 +39,8 @@ static const std::string kSocketDir = "run";
 // Base directory for all dingofs runtime data (log/cache/meta/data/run).
 // Resolution order (highest priority first):
 //   1. $DINGOFS_BASE_DIR environment variable, if set and non-empty.
-//   2. /var/dingofs when running as root (getuid() == 0).
-//   3. $HOME/.dingofs otherwise.
+//   2. /var/dingo when running as root (getuid() == 0).
+//   3. $HOME/.dingo otherwise.
 //
 // This is a function (not a static const) so that callers invoked during
 // static initialization — e.g. DEFINE_string(cache_dir, GetDefaultDir(...))

--- a/src/common/helper.h
+++ b/src/common/helper.h
@@ -292,7 +292,7 @@ class Helper {
     return home_dir;
   }
 
-  // parse ~/.dingofs/path to /home/user/.dingofs/path
+  // parse ~/.dingo/path to /home/user/.dingo/path
   static std::string ExpandPath(const std::string& path) {
     // only expand a leading "~" (i.e. "~" or "~/..."), do not touch '~'
     // appearing elsewhere in the path.

--- a/src/common/writemempool/CMakeLists.txt
+++ b/src/common/writemempool/CMakeLists.txt
@@ -16,6 +16,7 @@
 add_library(dingofs_write_mempool
     cpu_local.cc
     write_page_pool.cc
+    write_page_lease.cc
     write_mem_pool.cc
 )
 target_link_libraries(dingofs_write_mempool

--- a/src/common/writemempool/bench/write_mem_pool_bench.cc
+++ b/src/common/writemempool/bench/write_mem_pool_bench.cc
@@ -26,10 +26,12 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
 #include "cache/common/memory_pool.h"
+#include "common/writemempool/write_mem_pool.h"
 #include "common/writemempool/write_page_pool.h"
 
 DEFINE_uint32(threads, 1, "Number of allocation threads.");
@@ -40,8 +42,9 @@ DEFINE_uint32(alloc_batches_per_release, 1,
               "to model four 1MiB writes filling one 4MiB block.");
 DEFINE_uint64(page_size, 64 * 1024, "Page size in bytes.");
 DEFINE_bool(touch_pages, true, "Memset every acquired page.");
-DEFINE_string(implementation, "write_page_pool",
-              "write_page_pool or legacy_single.");
+DEFINE_string(implementation, "write_mem_pool",
+              "write_mem_pool, write_page_pool, serialized_write_page_pool, "
+              "or legacy_single.");
 DEFINE_bool(pin_threads, false, "Pin worker N to logical CPU N.");
 DEFINE_uint32(inflight_batches, 1,
               "Batches held before release; use > LLC/page batch for "
@@ -51,6 +54,8 @@ DEFINE_bool(cross_thread_release, false,
 DEFINE_int64(pressure_free_pages, -1,
              "Pre-acquire pages so only this many remain free; -1 disables "
              "the exhaustion-pressure mode.");
+DEFINE_uint32(latency_sample_stride, 100,
+              "Record every Nth allocation latency; 0 disables sampling.");
 
 namespace {
 
@@ -82,7 +87,9 @@ int main(int argc, char** argv) {
   CHECK_GT(FLAGS_inflight_batches, 0);
   CHECK_GE(FLAGS_pressure_free_pages, -1);
   CHECK_GE(FLAGS_page_size, sizeof(uint32_t));
-  CHECK(FLAGS_implementation == "write_page_pool" ||
+  CHECK(FLAGS_implementation == "write_mem_pool" ||
+        FLAGS_implementation == "write_page_pool" ||
+        FLAGS_implementation == "serialized_write_page_pool" ||
         FLAGS_implementation == "legacy_single");
 
   CHECK_LE(
@@ -96,24 +103,45 @@ int main(int argc, char** argv) {
       4096, working_pages * std::max<uint32_t>(4, FLAGS_inflight_batches) * 2);
   CHECK_LE(pool_pages, INT64_MAX / FLAGS_page_size);
 
-  auto page_pool =
-      FLAGS_implementation == "write_page_pool"
-          ? dingofs::WritePagePool::Create(FLAGS_page_size, pool_pages)
-          : nullptr;
-  auto legacy_pool =
-      FLAGS_implementation == "legacy_single"
-          ? dingofs::MemoryPool::Create(FLAGS_page_size, pool_pages)
-          : nullptr;
-  CHECK(page_pool != nullptr || legacy_pool != nullptr);
+  dingofs::WritePagePoolUPtr page_pool;
+  std::unique_ptr<dingofs::WriteMemPool> write_mem_pool;
+  std::unique_ptr<dingofs::MemoryPool> legacy_pool;
+  if (FLAGS_implementation == "write_mem_pool") {
+    write_mem_pool = std::make_unique<dingofs::WriteMemPool>(
+        pool_pages * FLAGS_page_size, FLAGS_page_size);
+  } else if (FLAGS_implementation == "write_page_pool" ||
+             FLAGS_implementation == "serialized_write_page_pool") {
+    page_pool = dingofs::WritePagePool::Create(FLAGS_page_size, pool_pages);
+  } else {
+    legacy_pool = dingofs::MemoryPool::Create(FLAGS_page_size, pool_pages);
+  }
+  CHECK(write_mem_pool != nullptr || page_pool != nullptr ||
+        legacy_pool != nullptr);
+  const bool serialize_page_pool =
+      FLAGS_implementation == "serialized_write_page_pool";
+  std::mutex page_pool_materialize_mutex;
 
   std::vector<char*> pressure_hold;
   if (FLAGS_pressure_free_pages >= 0) {
     CHECK_LE(static_cast<uint64_t>(FLAGS_pressure_free_pages), pool_pages);
+    if (write_mem_pool != nullptr) {
+      CHECK_GE(static_cast<uint64_t>(FLAGS_pressure_free_pages),
+               working_pages * FLAGS_inflight_batches)
+          << "blocking WriteMemPool benchmark must leave enough pages for "
+             "every in-flight lease";
+    }
     const size_t hold_count =
         static_cast<size_t>(pool_pages - FLAGS_pressure_free_pages);
     pressure_hold.resize(hold_count);
     size_t held = 0;
-    if (page_pool != nullptr) {
+    if (write_mem_pool != nullptr) {
+      dingofs::WritePageLease lease;
+      const dingofs::Status status =
+          write_mem_pool->Acquire(hold_count, &lease);
+      CHECK(status.ok()) << status.ToString();
+      lease.Take(hold_count, pressure_hold.data());
+      held = hold_count;
+    } else if (page_pool != nullptr) {
       held = page_pool->RequireBatch(pressure_hold.data(), hold_count);
     } else {
       while (held < hold_count) {
@@ -128,6 +156,7 @@ int main(int argc, char** argv) {
   std::atomic<bool> start{false};
   std::atomic<uint64_t> failures{0};
   std::atomic<uint64_t> successful_pages{0};
+  std::vector<std::vector<uint64_t>> acquire_latencies_ns(FLAGS_threads);
   std::vector<std::thread> workers;
   workers.reserve(FLAGS_threads * (FLAGS_cross_thread_release ? 2 : 1));
 
@@ -159,7 +188,9 @@ int main(int argc, char** argv) {
           while (slot.state.load(std::memory_order_acquire) != 1) {
             std::this_thread::yield();
           }
-          if (page_pool != nullptr) {
+          if (write_mem_pool != nullptr) {
+            write_mem_pool->Release(slot.pages.data(), slot.count);
+          } else if (page_pool != nullptr) {
             page_pool->ReleaseBatch(slot.pages.data(), slot.count);
           } else {
             for (size_t i = 0; i < slot.count; ++i) {
@@ -175,6 +206,47 @@ int main(int argc, char** argv) {
       if (FLAGS_pin_threads) {
         PinToCpu(thread);
       }
+      uint64_t allocation_index = 0;
+      auto acquire_pages = [&](char** pages) {
+        const bool sample =
+            FLAGS_latency_sample_stride != 0 &&
+            allocation_index++ % FLAGS_latency_sample_stride == 0;
+        const auto begin = sample ? std::chrono::steady_clock::now()
+                                  : std::chrono::steady_clock::time_point{};
+        size_t acquired = 0;
+        if (write_mem_pool != nullptr) {
+          dingofs::WritePageLease lease;
+          const dingofs::Status status =
+              write_mem_pool->Acquire(FLAGS_batch_pages, &lease);
+          if (status.ok()) {
+            lease.Take(FLAGS_batch_pages, pages);
+            acquired = FLAGS_batch_pages;
+          }
+        } else if (page_pool != nullptr) {
+          if (serialize_page_pool) {
+            std::lock_guard<std::mutex> lock(page_pool_materialize_mutex);
+            acquired = page_pool->RequireBatch(pages, FLAGS_batch_pages);
+          } else {
+            acquired = page_pool->RequireBatch(pages, FLAGS_batch_pages);
+          }
+        } else {
+          while (acquired < FLAGS_batch_pages) {
+            char* page = legacy_pool->Require();
+            if (page == nullptr) break;
+            pages[acquired++] = page;
+          }
+        }
+        if (sample) {
+          acquire_latencies_ns[thread].push_back(
+              std::chrono::duration_cast<std::chrono::nanoseconds>(
+                  std::chrono::steady_clock::now() - begin)
+                  .count());
+        }
+        if (acquired != FLAGS_batch_pages) {
+          failures.fetch_add(1, std::memory_order_relaxed);
+        }
+        return acquired;
+      };
       if (FLAGS_cross_thread_release) {
         while (!start.load(std::memory_order_acquire)) {
           std::this_thread::yield();
@@ -189,21 +261,7 @@ int main(int argc, char** argv) {
           size_t count = 0;
           for (uint32_t batch = 0; batch < FLAGS_alloc_batches_per_release;
                ++batch) {
-            size_t batch_count = 0;
-            if (page_pool != nullptr) {
-              batch_count = page_pool->RequireBatch(slot.pages.data() + count,
-                                                    FLAGS_batch_pages);
-            } else {
-              while (batch_count < FLAGS_batch_pages) {
-                char* page = legacy_pool->Require();
-                if (page == nullptr) break;
-                slot.pages[count + batch_count++] = page;
-              }
-            }
-            count += batch_count;
-            if (batch_count != FLAGS_batch_pages) {
-              failures.fetch_add(1, std::memory_order_relaxed);
-            }
+            count += acquire_pages(slot.pages.data() + count);
           }
           successful_pages.fetch_add(count, std::memory_order_relaxed);
           slot.count = count;
@@ -233,21 +291,7 @@ int main(int argc, char** argv) {
           size_t count = 0;
           for (uint32_t allocation = 0;
                allocation < FLAGS_alloc_batches_per_release; ++allocation) {
-            size_t batch_count = 0;
-            if (page_pool != nullptr) {
-              batch_count = page_pool->RequireBatch(batch_pages + count,
-                                                    FLAGS_batch_pages);
-            } else {
-              while (batch_count < FLAGS_batch_pages) {
-                char* page = legacy_pool->Require();
-                if (page == nullptr) break;
-                batch_pages[count + batch_count++] = page;
-              }
-            }
-            count += batch_count;
-            if (batch_count != FLAGS_batch_pages) {
-              failures.fetch_add(1, std::memory_order_relaxed);
-            }
+            count += acquire_pages(batch_pages + count);
           }
           successful_pages.fetch_add(count, std::memory_order_relaxed);
           counts[batch] = count;
@@ -262,7 +306,9 @@ int main(int argc, char** argv) {
         for (uint32_t batch = 0; batch < window; ++batch) {
           char** batch_pages =
               pages.data() + (static_cast<size_t>(batch) * pages_per_release);
-          if (page_pool != nullptr) {
+          if (write_mem_pool != nullptr) {
+            write_mem_pool->Release(batch_pages, counts[batch]);
+          } else if (page_pool != nullptr) {
             page_pool->ReleaseBatch(batch_pages, counts[batch]);
           } else {
             for (size_t i = 0; i < counts[batch]; ++i) {
@@ -292,13 +338,29 @@ int main(int argc, char** argv) {
   const uint64_t completed_pages =
       successful_pages.load(std::memory_order_relaxed);
 
-  if (page_pool != nullptr) {
+  if (write_mem_pool != nullptr) {
+    write_mem_pool->Release(pressure_hold.data(), pressure_hold.size());
+    CHECK_EQ(write_mem_pool->GetUsedBytes(), 0);
+  } else if (page_pool != nullptr) {
     page_pool->ReleaseBatch(pressure_hold.data(), pressure_hold.size());
   } else {
     for (char* page : pressure_hold) {
       legacy_pool->Release(page);
     }
   }
+
+  std::vector<uint64_t> latencies;
+  for (auto& thread_latencies : acquire_latencies_ns) {
+    latencies.insert(latencies.end(), thread_latencies.begin(),
+                     thread_latencies.end());
+  }
+  std::sort(latencies.begin(), latencies.end());
+  const auto percentile_ns = [&latencies](uint32_t percentile) {
+    if (latencies.empty()) return uint64_t{0};
+    const size_t index =
+        (latencies.size() - 1) * static_cast<size_t>(percentile) / 100;
+    return latencies[index];
+  };
 
   LOG(INFO) << "implementation=" << FLAGS_implementation
             << " threads=" << FLAGS_threads
@@ -311,6 +373,12 @@ int main(int argc, char** argv) {
             << " inflight_batches=" << FLAGS_inflight_batches
             << " cross_thread_release=" << FLAGS_cross_thread_release
             << " pressure_free_pages=" << FLAGS_pressure_free_pages
+            << " latency_sample_stride=" << FLAGS_latency_sample_stride
+            << " acquire_latency_samples=" << latencies.size()
+            << " acquire_p50_ns=" << percentile_ns(50)
+            << " acquire_p95_ns=" << percentile_ns(95)
+            << " acquire_p99_ns=" << percentile_ns(99)
+            << " acquire_max_ns=" << (latencies.empty() ? 0 : latencies.back())
             << " allocation_requests_per_sec=" << allocation_requests / seconds
             << " release_groups_per_sec=" << release_groups / seconds
             << " ns_per_requested_page=" << seconds * 1e9 / pages

--- a/src/common/writemempool/write_mem_pool.cc
+++ b/src/common/writemempool/write_mem_pool.cc
@@ -18,8 +18,11 @@
 
 #include <glog/logging.h>
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
-
+#include <mutex>
 namespace dingofs {
 namespace {
 
@@ -45,27 +48,291 @@ WriteMemPool::WriteMemPool(int64_t total_bytes, int64_t page_size)
     : total_bytes_(total_bytes),
       page_size_(page_size),
       page_pool_(CreatePagePool(total_bytes, page_size)),
-      capacity_pages_("vfs_write_buffer_capacity_pages",
-                      static_cast<int64_t>(page_pool_->BufferCount())),
+      capacity_pages_(page_pool_->BufferCount()),
+      admission_state_(capacity_pages_),
+      capacity_pages_var_("vfs_write_buffer_capacity_pages",
+                          static_cast<int64_t>(capacity_pages_)),
       used_pages_var_("vfs_write_buffer_used_pages", UsedPages, this),
       used_bytes_var_("vfs_write_buffer_used_bytes", UsedBytes, this),
-      alloc_fail_num_("vfs_write_buffer_alloc_fail_num") {}
+      waiter_count_var_("vfs_write_buffer_waiter_count", WaiterCount, this),
+      oldest_waiter_us_var_("vfs_write_buffer_oldest_waiter_us", OldestWaiterUs,
+                            this),
+      acquire_wait_num_("vfs_write_buffer_acquire_wait_num"),
+      acquire_stop_num_("vfs_write_buffer_acquire_stop_num"),
+      try_acquire_busy_num_("vfs_write_buffer_try_acquire_busy_num") {}
 
-size_t WriteMemPool::TryAllocateBatch(size_t count, char** pages) {
-  const size_t allocated = page_pool_->RequireBatch(pages, count);
-  if (allocated != 0) {
-    used_pages_ << static_cast<int64_t>(allocated);
+WriteMemPool::~WriteMemPool() { Close(); }
+
+WriteMemPool::AdmissionResult WriteMemPool::TryReserveFast(size_t count) {
+  uint64_t state = admission_state_.load(std::memory_order_acquire);
+  for (;;) {
+    if ((state & kBroken) != 0) return AdmissionResult::kBroken;
+    if ((state & kClosed) != 0) return AdmissionResult::kClosed;
+    if ((state & kContended) != 0 || AvailablePages(state) < count) {
+      return AdmissionResult::kUnavailable;
+    }
+    if (admission_state_.compare_exchange_weak(state, state - count,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_acquire)) {
+      return AdmissionResult::kGranted;
+    }
   }
-  if (allocated != count) {
-    alloc_fail_num_ << 1;
-  }
-  return allocated;
 }
 
-void WriteMemPool::DeAllocateBatch(char* const* pages, size_t count) {
+bool WriteMemPool::ReserveContendedLocked(size_t count) {
+  uint64_t state = admission_state_.load(std::memory_order_acquire);
+  for (;;) {
+    CHECK_NE(state & kContended, 0);
+    if ((state & (kClosed | kBroken)) != 0 || AvailablePages(state) < count) {
+      return false;
+    }
+    if (admission_state_.compare_exchange_weak(state, state - count,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_acquire)) {
+      return true;
+    }
+  }
+}
+
+void WriteMemPool::ClearContendedLocked() {
+  CHECK(waiters_.empty());
+  uint64_t state = admission_state_.load(std::memory_order_acquire);
+  while ((state & kContended) != 0 &&
+         !admission_state_.compare_exchange_weak(state, state & ~kContended,
+                                                 std::memory_order_release,
+                                                 std::memory_order_acquire)) {
+  }
+}
+
+Status WriteMemPool::MaterializeLease(size_t count, WritePageLease* lease) {
+  WritePageLease::Pages pages;
+  pages.resize(count);
+  const size_t allocated = page_pool_->RequireBatchExact(pages.data(), count);
+  if (allocated != count) {
+    if (allocated != 0) {
+      page_pool_->ReleaseBatch(pages.data(), allocated);
+    }
+    BreakPool(count);
+    return Status::Internal(
+        "write page allocator violated exact admission reservation");
+  }
+  *lease = WritePageLease(this, std::move(pages));
+  return Status::OK();
+}
+
+Status WriteMemPool::Acquire(size_t count, WritePageLease* lease) {
+  CHECK_NOTNULL(lease);
+  CHECK(lease->Empty());
+  if (count == 0) return Status::OK();
+  if (count > capacity_pages_) {
+    return Status::NoSpace("write request exceeds page pool capacity");
+  }
+
+  switch (TryReserveFast(count)) {
+    case AdmissionResult::kGranted:
+      return MaterializeLease(count, lease);
+    case AdmissionResult::kClosed:
+      acquire_stop_num_ << 1;
+      return Status::Stop("write page pool closed");
+    case AdmissionResult::kBroken:
+      return Status::Internal("write page pool broken");
+    case AdmissionResult::kUnavailable:
+      return AcquireSlow(count, lease);
+  }
+  LOG(FATAL) << "unreachable admission result";
+  return Status::Internal("unreachable admission result");
+}
+
+Status WriteMemPool::AcquireSlow(size_t count, WritePageLease* lease) {
+  Waiter waiter(count);
+  bool notify_first_waiter = false;
+  std::unique_lock<std::mutex> lock(waiter_mutex_);
+  admission_state_.fetch_or(kContended, std::memory_order_acq_rel);
+
+  const uint64_t state = admission_state_.load(std::memory_order_acquire);
+  if ((state & kBroken) != 0) {
+    ClearContendedLocked();
+    return Status::Internal("write page pool broken");
+  }
+  if ((state & kClosed) != 0) {
+    ClearContendedLocked();
+    acquire_stop_num_ << 1;
+    return Status::Stop("write page pool closed");
+  }
+
+  if (waiters_.empty() && ReserveContendedLocked(count)) {
+    ClearContendedLocked();
+    lock.unlock();
+    return MaterializeLease(count, lease);
+  }
+
+  notify_first_waiter = waiters_.empty();
+  waiters_.push_back(&waiter);
+  pressured_.store(true, std::memory_order_release);
+  acquire_wait_num_ << 1;
+
+  if (notify_first_waiter) {
+    lock.unlock();
+    NotifyPressure();
+    lock.lock();
+  }
+
+  waiter.cv.wait(lock,
+                 [&] { return waiter.result != Waiter::Result::kWaiting; });
+  if (waiter.result == Waiter::Result::kStopped) {
+    acquire_stop_num_ << 1;
+    return Status::Stop("write page pool closed");
+  }
+  if (waiter.result == Waiter::Result::kBroken) {
+    return Status::Internal("write page pool broken");
+  }
+  CHECK(waiter.result == Waiter::Result::kGranted);
+  lock.unlock();
+  return MaterializeLease(count, lease);
+}
+
+Status WriteMemPool::TryAcquire(size_t count, WritePageLease* lease) {
+  CHECK_NOTNULL(lease);
+  CHECK(lease->Empty());
+  if (count == 0) return Status::OK();
+  if (count > capacity_pages_) {
+    return Status::NotFit("write request exceeds page pool capacity");
+  }
+
+  switch (TryReserveFast(count)) {
+    case AdmissionResult::kGranted:
+      return MaterializeLease(count, lease);
+    case AdmissionResult::kClosed:
+      return Status::Stop("write page pool closed");
+    case AdmissionResult::kBroken:
+      return Status::Internal("write page pool broken");
+    case AdmissionResult::kUnavailable:
+      try_acquire_busy_num_ << 1;
+      return Status::NotFit("write page capacity temporarily unavailable");
+  }
+  LOG(FATAL) << "unreachable admission result";
+  return Status::Internal("unreachable admission result");
+}
+
+bool WriteMemPool::GrantWaitersLocked() {
+  while (!waiters_.empty()) {
+    Waiter* waiter = waiters_.front();
+    if (!ReserveContendedLocked(waiter->need)) break;
+    waiters_.pop_front();
+    waiter->result = Waiter::Result::kGranted;
+    waiter->cv.notify_one();
+  }
+  const bool still_pressured = !waiters_.empty();
+  pressured_.store(still_pressured, std::memory_order_release);
+  if (!still_pressured) {
+    ClearContendedLocked();
+  }
+  return still_pressured;
+}
+
+void WriteMemPool::Release(char* const* pages, size_t count) {
   if (count == 0) return;
+
+  // Physical pages become reusable before admission capacity is published.
   page_pool_->ReleaseBatch(pages, count);
-  used_pages_ << -static_cast<int64_t>(count);
+  const uint64_t old =
+      admission_state_.fetch_add(count, std::memory_order_acq_rel);
+  CHECK_LE(AvailablePages(old) + count, capacity_pages_);
+
+  if ((old & kContended) == 0) {
+    return;
+  }
+
+  bool still_pressured = false;
+  {
+    std::lock_guard<std::mutex> lock(waiter_mutex_);
+    still_pressured = GrantWaitersLocked();
+  }
+  if (still_pressured) {
+    NotifyPressure();
+  }
+}
+
+void WriteMemPool::BreakPool(size_t reserved_count) {
+  std::lock_guard<std::mutex> lock(waiter_mutex_);
+  uint64_t state = admission_state_.load(std::memory_order_acquire);
+  for (;;) {
+    CHECK_LE(AvailablePages(state) + reserved_count, capacity_pages_);
+    const uint64_t desired = (state + reserved_count) | kBroken | kContended;
+    if (admission_state_.compare_exchange_weak(state, desired,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_acquire)) {
+      break;
+    }
+  }
+  pressured_.store(false, std::memory_order_release);
+  for (Waiter* waiter : waiters_) {
+    waiter->result = Waiter::Result::kBroken;
+    waiter->cv.notify_one();
+  }
+  waiters_.clear();
+  ClearContendedLocked();
+}
+
+void WriteMemPool::Close() {
+  std::lock_guard<std::mutex> lock(waiter_mutex_);
+  uint64_t state = admission_state_.load(std::memory_order_acquire);
+  for (;;) {
+    if ((state & kClosed) != 0) return;
+    if (admission_state_.compare_exchange_weak(
+            state, state | kClosed | kContended, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+      break;
+    }
+  }
+  pressured_.store(false, std::memory_order_release);
+  for (Waiter* waiter : waiters_) {
+    waiter->result = Waiter::Result::kStopped;
+    waiter->cv.notify_one();
+  }
+  waiters_.clear();
+  ClearContendedLocked();
+}
+
+void WriteMemPool::SetPressureObserver(WritePressureObserver* observer) {
+  std::unique_lock<std::mutex> lock(pressure_observer_mutex_);
+  if (observer != nullptr) {
+    CHECK_EQ(pressure_observer_, nullptr);
+    CHECK_EQ(pressure_observer_calls_, 0);
+    pressure_observer_ = observer;
+    return;
+  }
+
+  pressure_observer_ = nullptr;
+  pressure_observer_cv_.wait(lock,
+                             [this] { return pressure_observer_calls_ == 0; });
+}
+
+void WriteMemPool::NotifyPressure() {
+  WritePressureObserver* observer = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(pressure_observer_mutex_);
+    observer = pressure_observer_;
+    if (observer == nullptr) return;
+    ++pressure_observer_calls_;
+  }
+
+  observer->OnWritePressure();
+
+  {
+    std::lock_guard<std::mutex> lock(pressure_observer_mutex_);
+    CHECK_GT(pressure_observer_calls_, 0);
+    --pressure_observer_calls_;
+    if (pressure_observer_calls_ == 0) {
+      pressure_observer_cv_.notify_all();
+    }
+  }
+}
+
+void WriteMemPool::NotifyDirtyPublished() {
+  if (IsPressured()) {
+    NotifyPressure();
+  }
 }
 
 int64_t WriteMemPool::GetPageSize() const { return page_size_; }
@@ -73,19 +340,9 @@ int64_t WriteMemPool::GetPageSize() const { return page_size_; }
 int64_t WriteMemPool::GetTotalBytes() const { return total_bytes_; }
 
 int64_t WriteMemPool::GetUsedBytes() const {
-  return page_size_ * used_pages_.get_value();
-}
-
-double WriteMemPool::GetUsageRatio() const {
-  int64_t total = GetTotalBytes();
-  if (total == 0) {
-    return 0.0;
-  }
-  return static_cast<double>(GetUsedBytes()) / total;
-}
-
-bool WriteMemPool::IsHighPressure(double threshold) const {
-  return GetUsageRatio() >= threshold;
+  const uint64_t state = admission_state_.load(std::memory_order_acquire);
+  return page_size_ *
+         static_cast<int64_t>(capacity_pages_ - AvailablePages(state));
 }
 
 char* WriteMemPool::BaseAddr() const { return page_pool_->BaseAddr(); }
@@ -95,5 +352,31 @@ size_t WriteMemPool::BufferSize() const { return page_pool_->BufferSize(); }
 size_t WriteMemPool::BufferCount() const { return page_pool_->BufferCount(); }
 
 size_t WriteMemPool::TotalSize() const { return page_pool_->TotalSize(); }
+
+int64_t WriteMemPool::UsedBytes(void* arg) {
+  return static_cast<WriteMemPool*>(arg)->GetUsedBytes();
+}
+
+int64_t WriteMemPool::UsedPages(void* arg) {
+  auto* pool = static_cast<WriteMemPool*>(arg);
+  const uint64_t state = pool->admission_state_.load(std::memory_order_acquire);
+  return static_cast<int64_t>(pool->capacity_pages_ - AvailablePages(state));
+}
+
+int64_t WriteMemPool::WaiterCount(void* arg) {
+  auto* pool = static_cast<WriteMemPool*>(arg);
+  std::lock_guard<std::mutex> lock(pool->waiter_mutex_);
+  return static_cast<int64_t>(pool->waiters_.size());
+}
+
+int64_t WriteMemPool::OldestWaiterUs(void* arg) {
+  auto* pool = static_cast<WriteMemPool*>(arg);
+  std::lock_guard<std::mutex> lock(pool->waiter_mutex_);
+  if (pool->waiters_.empty()) return 0;
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now() -
+             pool->waiters_.front()->queued_at)
+      .count();
+}
 
 }  // namespace dingofs

--- a/src/common/writemempool/write_mem_pool.h
+++ b/src/common/writemempool/write_mem_pool.h
@@ -19,79 +19,131 @@
 
 #include <sys/types.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
 #include <cstdint>
+#include <deque>
+#include <mutex>
 
 #include "bvar/passive_status.h"
 #include "bvar/reducer.h"
 #include "bvar/status.h"
+#include "common/status.h"
+#include "common/writemempool/write_page_lease.h"
 #include "common/writemempool/write_page_pool.h"
+#include "common/writemempool/write_pressure_observer.h"
 
 namespace dingofs {
 
 class WriteMemPool {
  public:
   explicit WriteMemPool(int64_t total_bytes, int64_t page_size);
+  ~WriteMemPool();
 
-  ~WriteMemPool() = default;
+  WriteMemPool(const WriteMemPool&) = delete;
+  WriteMemPool& operator=(const WriteMemPool&) = delete;
 
-  // Try-style capacity semantics: never waits for pages to be returned and
-  // does not use a capacity wait queue. Internal synchronization may be
-  // briefly contended. Each call only consumes pages currently available in
-  // the backing pool, then returns the pages acquired so far; the caller owns
-  // rollback and any later retry.
-  size_t TryAllocateBatch(size_t count, char** pages);
+  // FIFO, exact-capacity admission. The caller blocks without holding any
+  // FileWriter/ChunkWriter/SliceWriter lock until all requested pages can be
+  // granted, the pool closes, or an internal allocator invariant breaks.
+  Status Acquire(size_t count, WritePageLease* lease);
 
-  // Returns exactly `count` pairwise-distinct outstanding pages previously
-  // obtained from this pool. Duplicate, stale, or foreign pages violate the
-  // contract and may corrupt the underlying intrusive free lists.
-  void DeAllocateBatch(char* const* pages, size_t count);
+  // Non-blocking exact admission for best-effort work such as compaction.
+  // It never bypasses queued FIFO waiters.
+  Status TryAcquire(size_t count, WritePageLease* lease);
+
+  // Returns exactly count pairwise-distinct pages previously transferred from
+  // a lease. Valid leases may still call Release after Close.
+  void Release(char* const* pages, size_t count);
+
+  // Stops admission and wakes every ungranted Acquire with Status::Stop.
+  // Existing leases and page owners remain valid and must release normally.
+  void Close();
+
+  // Registering requires no observer to be installed. Clearing prevents new
+  // callbacks and waits for every in-flight callback to return. The observer
+  // must remain alive until clearing completes and must not clear itself.
+  void SetPressureObserver(WritePressureObserver* observer);
+  void NotifyDirtyPublished();
+  bool IsPressured() const {
+    return pressured_.load(std::memory_order_acquire);
+  }
 
   int64_t GetPageSize() const;
-
   int64_t GetTotalBytes() const;
-
   int64_t GetUsedBytes() const;
 
-  double GetUsageRatio() const;
-
-  bool IsHighPressure(double threshold = 0.8) const;
-
-  // RDMA-ready: expose the complete fixed-page arena geometry for MR
-  // registration, buffer descriptor construction, and address-to-index
-  // conversion.
   char* BaseAddr() const;
   size_t BufferSize() const;
   size_t BufferCount() const;
   size_t TotalSize() const;
 
  private:
-  static int64_t UsedBytes(void* arg) {
-    auto* manager = reinterpret_cast<WriteMemPool*>(arg);
-    return manager->GetUsedBytes();
+  friend class WriteMemPoolTestPeer;
+  enum class AdmissionResult : uint8_t {
+    kGranted,
+    kUnavailable,
+    kClosed,
+    kBroken
+  };
+  static constexpr uint64_t kAvailableMask = UINT32_MAX;
+  static constexpr uint64_t kContended = uint64_t{1} << 32;
+  static constexpr uint64_t kClosed = uint64_t{1} << 33;
+  static constexpr uint64_t kBroken = uint64_t{1} << 34;
+
+  struct Waiter {
+    explicit Waiter(size_t requested)
+        : need(requested), queued_at(std::chrono::steady_clock::now()) {}
+
+    enum class Result : uint8_t { kWaiting, kGranted, kStopped, kBroken };
+
+    const size_t need;
+    const std::chrono::steady_clock::time_point queued_at;
+    std::condition_variable cv;
+    Result result{Result::kWaiting};
+  };
+
+  AdmissionResult TryReserveFast(size_t count);
+  bool ReserveContendedLocked(size_t count);
+  void ClearContendedLocked();
+  bool GrantWaitersLocked();
+  Status AcquireSlow(size_t count, WritePageLease* lease);
+  Status MaterializeLease(size_t count, WritePageLease* lease);
+  void BreakPool(size_t reserved_count);
+  void NotifyPressure();
+  static size_t AvailablePages(uint64_t state) {
+    return static_cast<size_t>(state & kAvailableMask);
   }
 
-  static int64_t UsedPages(void* arg) {
-    auto* manager = reinterpret_cast<WriteMemPool*>(arg);
-    return manager->used_pages_.get_value();
-  }
+  static int64_t UsedBytes(void* arg);
+  static int64_t UsedPages(void* arg);
+  static int64_t WaiterCount(void* arg);
+  static int64_t OldestWaiterUs(void* arg);
 
   const int64_t total_bytes_{0};
   const int64_t page_size_{0};
-
-  // Outstanding pages. bvar::Adder keeps updates sharded per thread; reads
-  // aggregate only on throttle checks and bvar sampling.
-  bvar::Adder<int64_t> used_pages_;
-
   WritePagePoolUPtr page_pool_;
+  const size_t capacity_pages_{0};
+  std::atomic<uint64_t> admission_state_{0};
 
-  // Capacity / usage. PassiveStatus is sampled on /vars dump (off the hot
-  // path); updates use the sharded reducer above.
-  bvar::Status<int64_t> capacity_pages_;
+  mutable std::mutex waiter_mutex_;
+  std::deque<Waiter*> waiters_;
+  std::atomic_bool pressured_{false};
+  std::mutex pressure_observer_mutex_;
+  std::condition_variable pressure_observer_cv_;
+  WritePressureObserver* pressure_observer_{nullptr};
+  size_t pressure_observer_calls_{0};
+
+  bvar::Status<int64_t> capacity_pages_var_;
   bvar::PassiveStatus<int64_t> used_pages_var_;
   bvar::PassiveStatus<int64_t> used_bytes_var_;
-
-  // Count of allocation requests that were not fully satisfied.
-  bvar::Adder<int64_t> alloc_fail_num_;
+  bvar::PassiveStatus<int64_t> waiter_count_var_;
+  bvar::PassiveStatus<int64_t> oldest_waiter_us_var_;
+  bvar::Adder<int64_t> acquire_wait_num_;
+  bvar::Adder<int64_t> acquire_stop_num_;
+  bvar::Adder<int64_t> try_acquire_busy_num_;
 };
 
 }  // namespace dingofs

--- a/src/common/writemempool/write_page_lease.cc
+++ b/src/common/writemempool/write_page_lease.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/writemempool/write_page_lease.h"
+
+#include <glog/logging.h>
+
+#include <utility>
+
+#include "common/writemempool/write_mem_pool.h"
+
+namespace dingofs {
+
+WritePageLease::~WritePageLease() { Reset(); }
+
+WritePageLease::WritePageLease(WritePageLease&& other) noexcept
+    : pool_(std::exchange(other.pool_, nullptr)),
+      pages_(std::move(other.pages_)) {
+  other.pages_.clear();
+}
+
+WritePageLease& WritePageLease::operator=(WritePageLease&& other) noexcept {
+  if (this == &other) return *this;
+  Reset();
+  pool_ = std::exchange(other.pool_, nullptr);
+  pages_ = std::move(other.pages_);
+  other.pages_.clear();
+  return *this;
+}
+
+void WritePageLease::Take(size_t count, char** pages) {
+  CHECK_LE(count, pages_.size());
+  if (count == 0) return;
+  CHECK_NOTNULL(pages);
+  for (size_t i = 0; i < count; ++i) {
+    pages[i] = pages_.back();
+    pages_.pop_back();
+  }
+}
+
+void WritePageLease::Reset() {
+  if (pool_ != nullptr && !pages_.empty()) {
+    pool_->Release(pages_.data(), pages_.size());
+  }
+  pages_.clear();
+  pool_ = nullptr;
+}
+
+}  // namespace dingofs

--- a/src/common/writemempool/write_page_lease.h
+++ b/src/common/writemempool/write_page_lease.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PAGE_LEASE_H_
+#define DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PAGE_LEASE_H_
+
+#include <cstddef>
+#include <utility>
+
+#include "absl/container/inlined_vector.h"
+
+namespace dingofs {
+
+class WriteMemPool;
+
+// Move-only ownership of pages admitted by WriteMemPool. The lease returns
+// every page not transferred with Take() when it is destroyed. A lease must
+// not outlive its WriteMemPool.
+class WritePageLease {
+ public:
+  WritePageLease() = default;
+  ~WritePageLease();
+
+  WritePageLease(const WritePageLease&) = delete;
+  WritePageLease& operator=(const WritePageLease&) = delete;
+  WritePageLease(WritePageLease&& other) noexcept;
+  WritePageLease& operator=(WritePageLease&& other) noexcept;
+
+  // Transfers exactly count pages to the caller. Acquire/TryAcquire callers
+  // must size the lease for the write's worst-case page need.
+  void Take(size_t count, char** pages);
+  size_t Size() const { return pages_.size(); }
+  bool Empty() const { return pages_.empty(); }
+
+ private:
+  friend class WriteMemPool;
+  static constexpr size_t kInlinePages = 64;
+  using Pages = absl::InlinedVector<char*, kInlinePages>;
+
+  WritePageLease(WriteMemPool* pool, Pages pages)
+      : pool_(pool), pages_(std::move(pages)) {}
+  void Reset();
+
+  WriteMemPool* pool_{nullptr};
+  Pages pages_;
+};
+
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PAGE_LEASE_H_

--- a/src/common/writemempool/write_page_pool.cc
+++ b/src/common/writemempool/write_page_pool.cc
@@ -45,6 +45,7 @@ WritePagePool::WritePagePool(char* base, size_t page_size, size_t page_count)
       next_(std::make_unique<uint32_t[]>(page_count)) {
   cache_count_ = CpuLocalCacheCount();
   caches_ = std::make_unique<Cache[]>(cache_count_);
+  materializer_slots_ = std::make_unique<MaterializerSlot[]>(cache_count_);
   for (uint32_t i = 0; i < cache_count_; ++i) {
     caches_[i].next_refill_shard = i % kNumShards;
   }
@@ -124,6 +125,79 @@ bool WritePagePool::RefillCache(Cache* cache) {
 size_t WritePagePool::RequireBatch(char** pages, size_t count) {
   return RequireBatchFromCache(pages, count,
                                CurrentCpuLocalCache(cache_count_));
+}
+
+uint32_t WritePagePool::EnterMaterializer() {
+  const uint32_t slot = CurrentCpuLocalCache(cache_count_);
+  for (;;) {
+    WaitUntilMaterializationUnblocked();
+    materializer_slots_[slot].active.fetch_add(1, std::memory_order_acq_rel);
+    if (!materialization_blocked_.load(std::memory_order_acquire)) {
+      return slot;
+    }
+    ExitMaterializer(slot);
+  }
+}
+
+void WritePagePool::ExitMaterializer(uint32_t slot) {
+  const uint32_t old =
+      materializer_slots_[slot].active.fetch_sub(1, std::memory_order_acq_rel);
+  CHECK_GT(old, 0);
+  if (old == 1 && materialization_blocked_.load(std::memory_order_acquire)) {
+    std::lock_guard<std::mutex> lock(materialization_wait_mutex_);
+    materialization_cv_.notify_all();
+  }
+}
+
+bool WritePagePool::AllMaterializersIdle() const {
+  for (uint32_t slot = 0; slot < cache_count_; ++slot) {
+    if (materializer_slots_[slot].active.load(std::memory_order_acquire) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void WritePagePool::WaitUntilMaterializationUnblocked() {
+  if (!materialization_blocked_.load(std::memory_order_acquire)) {
+    return;
+  }
+  std::unique_lock<std::mutex> lock(materialization_wait_mutex_);
+  materialization_cv_.wait(lock, [this] {
+    return !materialization_blocked_.load(std::memory_order_acquire);
+  });
+}
+
+size_t WritePagePool::RequireBatchAfterQuiesce(char** pages, size_t count,
+                                               size_t acquired) {
+  std::lock_guard<std::mutex> fallback_lock(materialization_fallback_mutex_);
+  std::unique_lock<std::mutex> wait_lock(materialization_wait_mutex_);
+  materialization_blocked_.store(true, std::memory_order_release);
+  materialization_cv_.wait(wait_lock,
+                           [this] { return AllMaterializersIdle(); });
+  wait_lock.unlock();
+
+  acquired += RequireBatchFromCache(pages + acquired, count - acquired,
+                                    CurrentCpuLocalCache(cache_count_));
+
+  wait_lock.lock();
+  materialization_blocked_.store(false, std::memory_order_release);
+  wait_lock.unlock();
+  materialization_cv_.notify_all();
+  return acquired;
+}
+
+size_t WritePagePool::RequireBatchExact(char** pages, size_t count) {
+  if (count == 0) return 0;
+  CHECK_NOTNULL(pages);
+
+  const uint32_t slot = EnterMaterializer();
+  size_t acquired = RequireBatchFromCache(pages, count, slot);
+  ExitMaterializer(slot);
+  if (acquired == count) {
+    return acquired;
+  }
+  return RequireBatchAfterQuiesce(pages, count, acquired);
 }
 
 size_t WritePagePool::RequireBatchFromCache(char** pages, size_t count,

--- a/src/common/writemempool/write_page_pool.h
+++ b/src/common/writemempool/write_page_pool.h
@@ -18,6 +18,8 @@
 #define DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PAGE_POOL_H_
 
 #include <array>
+#include <atomic>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -36,6 +38,12 @@ class WritePagePool {
   // Acquires up to `count` pages and stores them in pages[0..return_value).
   // A short result is allowed; only the returned prefix becomes outstanding.
   size_t RequireBatch(char** pages, size_t count);
+
+  // Materializes exactly `count` pages already reserved by an external
+  // admission controller. Concurrent cache movement may force a quiescent
+  // retry; a short result after that retry means the reservation invariant is
+  // broken, and only the returned prefix becomes outstanding.
+  size_t RequireBatchExact(char** pages, size_t count);
 
   // Returns exactly `count` outstanding pages to this pool. Every entry must
   // have been returned by this pool, entries must be pairwise distinct, and
@@ -71,6 +79,10 @@ class WritePagePool {
     uint32_t size{0};
     uint32_t next_refill_shard{0};
     std::array<uint32_t, kCacheCapacity> entries{};
+  };
+
+  struct alignas(64) MaterializerSlot {
+    std::atomic<uint32_t> active{0};
   };
 
   struct Chain {
@@ -111,6 +123,11 @@ class WritePagePool {
   size_t TakeFromCache(Cache* cache, char** pages, size_t count);
   size_t RequireBatchFromCache(char** pages, size_t count,
                                uint32_t cache_index);
+  uint32_t EnterMaterializer();
+  void ExitMaterializer(uint32_t slot);
+  bool AllMaterializersIdle() const;
+  void WaitUntilMaterializationUnblocked();
+  size_t RequireBatchAfterQuiesce(char** pages, size_t count, size_t acquired);
 
   char* base_;
   size_t page_size_;
@@ -120,6 +137,11 @@ class WritePagePool {
   std::array<Shard, kNumShards> shards_;
   uint32_t cache_count_{0};
   std::unique_ptr<Cache[]> caches_;
+  std::unique_ptr<MaterializerSlot[]> materializer_slots_;
+  std::atomic<bool> materialization_blocked_{false};
+  std::mutex materialization_fallback_mutex_;
+  std::mutex materialization_wait_mutex_;
+  std::condition_variable materialization_cv_;
 };
 
 }  // namespace dingofs

--- a/src/common/writemempool/write_pressure_observer.h
+++ b/src/common/writemempool/write_pressure_observer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PRESSURE_OBSERVER_H_
+#define DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PRESSURE_OBSERVER_H_
+
+namespace dingofs {
+
+class WritePressureObserver {
+ public:
+  virtual ~WritePressureObserver() = default;
+
+  // Called without the WriteMemPool mutex. Implementations must return
+  // promptly and dispatch expensive work to their own executor.
+  virtual void OnWritePressure() = 0;
+};
+
+}  // namespace dingofs
+
+#endif  // DINGOFS_SRC_COMMON_WRITEMEMPOOL_WRITE_PRESSURE_OBSERVER_H_

--- a/test/unit/client/vfs/compaction/test_compactor.cc
+++ b/test/unit/client/vfs/compaction/test_compactor.cc
@@ -697,11 +697,9 @@ TEST_F(CompactorTest, ForceCompact_NonZeroChunkAndOffset_BytesPreserved) {
   }
 }
 
-// 22. A write failure (page pool exhausted) must abort the compaction with an
-// error, upload nothing, and trigger no cleanup — nothing was ever uploaded.
-TEST_F(CompactorTest, ForceCompact_WritePoolExhausted_FailsWithoutUpload) {
-  // 64 KiB pool cannot back a 4 MiB block: SliceWriter::Write fails in the
-  // reserve phase and rolls back before any upload is submitted.
+// 22. Compaction capacity admission is non-blocking and precedes its dense
+// read. A miss must return NotFit without heap/read/upload work.
+TEST_F(CompactorTest, ForceCompact_WritePoolBusy_SkipsDenseRead) {
   WriteMemPool tiny_pool(64 * 1024, 4096);
   ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(&tiny_pool));
 
@@ -709,6 +707,7 @@ TEST_F(CompactorTest, ForceCompact_WritePoolExhausted_FailsWithoutUpload) {
   ON_CALL(*mock_hub_, GetBlockAccesser()).WillByDefault(Return(&accesser));
   EXPECT_CALL(*mock_hub_, GetBlockAccesser()).Times(AnyNumber());
   EXPECT_CALL(accesser, BatchDelete(_)).Times(0);
+  EXPECT_CALL(*mock_block_store_, RangeAsync).Times(0);
   EXPECT_CALL(*mock_block_store_, PutAsync).Times(0);
 
   std::vector<Slice> slices = {dingofs::client::vfs::test::MakeSlice(
@@ -716,7 +715,7 @@ TEST_F(CompactorTest, ForceCompact_WritePoolExhausted_FailsWithoutUpload) {
   std::vector<Slice> out;
   Status s = compactor_->ForceCompact(ctx_, /*ino=*/503, /*chunk_index=*/0,
                                       slices, out);
-  EXPECT_TRUE(s.IsNoSpace()) << s.ToString();
+  EXPECT_TRUE(s.IsNotFit()) << s.ToString();
   EXPECT_TRUE(out.empty());
   EXPECT_EQ(tiny_pool.GetUsedBytes(), 0);
 }

--- a/test/unit/client/vfs/data/test_block_data.cc
+++ b/test/unit/client/vfs/data/test_block_data.cc
@@ -23,7 +23,6 @@
 
 #include "client/vfs/data/slice/block_data.h"
 #include "client/vfs/data/slice/common.h"
-#include "common/status.h"
 #include "common/trace/trace_manager.h"
 #include "common/writemempool/write_mem_pool.h"
 #include "test/unit/client/vfs/test_base.h"
@@ -35,13 +34,14 @@ namespace vfs {
 using ::testing::AnyNumber;
 using ::testing::Return;
 
-// Small geometry so tests stay cheap: 16 KiB block / 4 KiB page = 4 pages.
-static constexpr int64_t kPageSize = 4096;
-static constexpr int64_t kBlockSize = 4 * kPageSize;  // 4 pages
-static constexpr uint64_t kChunkSize = 64 * 1024 * 1024;
-static constexpr uint64_t kFsId = 1;
-static constexpr uint64_t kIno = 100;
-static constexpr uint64_t kChunkIndex = 0;
+namespace {
+
+constexpr int64_t kPageSize = 4096;
+constexpr int64_t kBlockSize = 4 * kPageSize;
+constexpr uint64_t kChunkSize = 64 * 1024 * 1024;
+constexpr uint64_t kFsId = 1;
+constexpr uint64_t kIno = 100;
+constexpr uint64_t kChunkIndex = 0;
 
 class BlockDataTest : public test::VFSTestBase {
  protected:
@@ -50,162 +50,76 @@ class BlockDataTest : public test::VFSTestBase {
     ON_CALL(*mock_hub_, GetTraceManager())
         .WillByDefault(Return(trace_manager_.get()));
     EXPECT_CALL(*mock_hub_, GetTraceManager()).Times(AnyNumber());
-
     context_ = std::make_unique<SliceDataContext>(
         kFsId, kIno, kChunkIndex, kChunkSize, kBlockSize, kPageSize);
   }
 
-  // Build a pool with `slots` pages of kPageSize.
-  std::unique_ptr<WriteMemPool> MakePool(int slots) {
-    return std::make_unique<WriteMemPool>(
-        static_cast<int64_t>(slots) * kPageSize, kPageSize);
+  std::unique_ptr<WriteMemPool> MakePool(int pages) {
+    return std::make_unique<WriteMemPool>(pages * kPageSize, kPageSize);
   }
 
   std::unique_ptr<BlockData> MakeBlock(WriteMemPool* pool,
                                        int32_t block_offset = 0) {
-    return std::make_unique<BlockData>(*context_, mock_hub_, pool,
-                                       /*block_index=*/0, block_offset);
+    return std::make_unique<BlockData>(*context_, mock_hub_, pool, 0,
+                                       block_offset);
+  }
+
+  WritePageLease Acquire(WriteMemPool* pool, size_t pages) {
+    WritePageLease lease;
+    EXPECT_TRUE(pool->Acquire(pages, &lease).ok());
+    return lease;
   }
 
   std::unique_ptr<TraceManager> trace_manager_;
   std::unique_ptr<SliceDataContext> context_;
 };
 
-// ReservePages allocates the pages a write needs, records the new ones, and
-// leaves len_ untouched (reserve != apply).
-TEST_F(BlockDataTest, ReservePages_Success_RecordsNewPages_NoLenBump) {
+TEST_F(BlockDataTest, ReservePagesConsumesLeaseWithoutChangingLength) {
   auto pool = MakePool(4);
   auto block = MakeBlock(pool.get());
+  auto lease = Acquire(pool.get(), 3);
 
-  std::vector<uint32_t> created;
-  Status s =
-      block->ReservePages(/*size=*/3 * kPageSize, /*block_offset=*/0, &created);
-  ASSERT_TRUE(s.ok()) << s.ToString();
-  EXPECT_EQ(created.size(), 3u);
-  EXPECT_EQ(block->Len(), 0);  // reserve does not bump len_
+  block->ReservePages(3 * kPageSize, 0, &lease);
+
+  EXPECT_TRUE(lease.Empty());
+  EXPECT_EQ(block->Len(), 0);
   EXPECT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
 }
 
-// A reserve that outgrows the pool returns NoSpace; it does NOT self-rollback
-// (the SliceWriter transaction owns cross-block undo), so the pages it managed
-// to take stay recorded for the caller to roll back.
-TEST_F(BlockDataTest, ReservePages_Exhausted_ReturnsNoSpace_NoSelfRollback) {
-  auto pool = MakePool(2);
-  auto block = MakeBlock(pool.get());
-
-  std::vector<uint32_t> created;
-  Status s =
-      block->ReservePages(/*size=*/3 * kPageSize, /*block_offset=*/0, &created);
-  EXPECT_TRUE(s.IsNoSpace()) << s.ToString();
-  EXPECT_EQ(created.size(), 2u);  // took 2 before the 3rd missed
-  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);  // not self-rolled-back
-}
-
-// Pages already present (e.g. a partially-filled straddle page) are not
-// re-allocated and not recorded, so a later RollbackPages can't free them.
-TEST_F(BlockDataTest, ReservePages_SkipsExistingPages) {
+TEST_F(BlockDataTest, ExistingPageConsumesOnlyMissingLeasePage) {
   auto pool = MakePool(4);
   auto block = MakeBlock(pool.get());
+  auto first = Acquire(pool.get(), 1);
+  block->ReservePages(kPageSize, 0, &first);
+  ASSERT_TRUE(first.Empty());
 
-  std::vector<uint32_t> first;
-  ASSERT_TRUE(block->ReservePages(kPageSize, 0, &first).ok());
-  ASSERT_EQ(first.size(), 1u);
+  auto second = Acquire(pool.get(), 1);
+  block->ReservePages(2 * kPageSize, 0, &second);
 
-  // Reserve [0, 2 pages): page0 already exists -> only page1 is new.
-  std::vector<uint32_t> second;
-  ASSERT_TRUE(block->ReservePages(2 * kPageSize, 0, &second).ok());
-  EXPECT_EQ(second.size(), 1u);
-  EXPECT_EQ(second[0], 1u);
+  EXPECT_TRUE(second.Empty());
   EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
 }
 
-TEST_F(BlockDataTest, ExistingPagePartialBatchRollbackKeepsExistingPage) {
-  auto pool = MakePool(2);
+TEST_F(BlockDataTest, UnusedLeasePagesReturnAutomatically) {
+  auto pool = MakePool(4);
   auto block = MakeBlock(pool.get());
-
-  std::vector<uint32_t> existing;
-  ASSERT_TRUE(block->ReservePages(kPageSize, 0, &existing).ok());
-  ASSERT_EQ(existing, std::vector<uint32_t>({0}));
-  ASSERT_EQ(pool->GetUsedBytes(), kPageSize);
-
-  // Page 0 already exists. Only one pool page remains, so page 1 is returned
-  // as the successful prefix and page 2 causes a short allocation.
-  std::vector<uint32_t> created;
-  Status status = block->ReservePages(3 * kPageSize, 0, &created);
-  ASSERT_TRUE(status.IsNoSpace()) << status.ToString();
-  ASSERT_EQ(created, std::vector<uint32_t>({1}));
-  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
-
-  block->RollbackPages(created);
+  {
+    auto lease = Acquire(pool.get(), 3);
+    block->ReservePages(kPageSize, 0, &lease);
+    EXPECT_EQ(lease.Size(), 2);
+    EXPECT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
+  }
   EXPECT_EQ(pool->GetUsedBytes(), kPageSize);
-
-  // The pre-existing page must remain usable after rolling back the partial
-  // batch, and a same-offset retry must not hit a contiguity CHECK.
-  std::vector<uint32_t> retry_created;
-  ASSERT_TRUE(block->ReservePages(kPageSize, 0, &retry_created).ok());
-  EXPECT_TRUE(retry_created.empty());
-  std::vector<char> data(kPageSize, 'r');
-  block->ApplyWrite(ctx_, data.data(), data.size(), 0);
-  std::vector<char> copied(data.size());
-  block->ToIOBuffer().CopyTo(copied.data(), copied.size());
-  EXPECT_EQ(copied, data);
 }
 
-// RollbackPages frees exactly the named pages and nothing else.
-TEST_F(BlockDataTest, RollbackPages_FreesOnlyNamedPages) {
-  auto pool = MakePool(4);
-  auto block = MakeBlock(pool.get());
-
-  std::vector<uint32_t> created;
-  ASSERT_TRUE(block->ReservePages(3 * kPageSize, 0, &created).ok());
-  ASSERT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
-
-  // Roll back only page index 2 -> 2 pages remain.
-  block->RollbackPages({created.back()});
-  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
-
-  // Roll back the rest -> back to empty.
-  block->RollbackPages({created[0], created[1]});
-  EXPECT_EQ(pool->GetUsedBytes(), 0);
-}
-
-TEST_F(BlockDataTest, EmptyRollbackIsNoOp) {
-  auto pool = MakePool(2);
-  auto block = MakeBlock(pool.get());
-
-  block->RollbackPages({});
-  EXPECT_EQ(pool->GetUsedBytes(), 0);
-}
-
-// ApplyWrite memcpys into already-reserved pages and bumps len_, and must NOT
-// allocate -- the pool is drained dry before ApplyWrite and it still succeeds.
-TEST_F(BlockDataTest, ApplyWrite_NoAllocation_AfterReserve) {
-  auto pool = MakePool(2);
-  auto block = MakeBlock(pool.get());
-
-  const int32_t size = 2 * kPageSize;
-  std::vector<uint32_t> created;
-  ASSERT_TRUE(block->ReservePages(size, 0, &created).ok());
-  ASSERT_EQ(pool->GetUsedBytes(), size);  // pool now fully drained
-
-  std::vector<char> buf(size, 'Z');
-  block->ApplyWrite(ctx_, buf.data(), size, 0);
-
-  EXPECT_EQ(block->Len(), size);
-  EXPECT_EQ(pool->GetUsedBytes(), size);  // ApplyWrite did not allocate
-  // Data is durable in the pages.
-  EXPECT_EQ(block->ToIOBuffer().Size(), static_cast<size_t>(size));
-}
-
-TEST_F(BlockDataTest, MultiPageUnalignedWritePreservesByteOrder) {
+TEST_F(BlockDataTest, ApplyWriteUsesReservedPagesAndPreservesBytes) {
   auto pool = MakePool(4);
   constexpr int32_t kStart = 137;
   constexpr int32_t kSize = 2 * kPageSize + 777;
   auto block = MakeBlock(pool.get(), kStart);
-
-  std::vector<uint32_t> created;
-  ASSERT_TRUE(block->ReservePages(kSize, kStart, &created).ok());
-  ASSERT_EQ(created.size(), 3);
+  auto lease = Acquire(pool.get(), 3);
+  block->ReservePages(kSize, kStart, &lease);
+  ASSERT_TRUE(lease.Empty());
 
   std::vector<char> input(kSize);
   for (size_t i = 0; i < input.size(); ++i) {
@@ -213,53 +127,28 @@ TEST_F(BlockDataTest, MultiPageUnalignedWritePreservesByteOrder) {
   }
   block->ApplyWrite(ctx_, input.data(), input.size(), kStart);
 
+  EXPECT_EQ(block->Len(), kSize);
+  EXPECT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
   IOBuffer output = block->ToIOBuffer();
   ASSERT_EQ(output.Size(), input.size());
-  ASSERT_EQ(output.BackingBlockNum(), created.size());
+  ASSERT_EQ(output.BackingBlockNum(), 3);
   std::vector<char> copied(input.size());
   output.CopyTo(copied.data(), copied.size());
   EXPECT_EQ(copied, input);
 }
 
-TEST_F(BlockDataTest, DestructorReturnsAllPagesInOneBatch) {
+TEST_F(BlockDataTest, DestructorReturnsOwnedPages) {
   auto pool = MakePool(4);
   {
     auto block = MakeBlock(pool.get());
-    std::vector<uint32_t> created;
-    ASSERT_TRUE(block->ReservePages(3 * kPageSize, 0, &created).ok());
+    auto lease = Acquire(pool.get(), 3);
+    block->ReservePages(3 * kPageSize, 0, &lease);
     ASSERT_EQ(pool->GetUsedBytes(), 3 * kPageSize);
   }
   EXPECT_EQ(pool->GetUsedBytes(), 0);
 }
 
-// The reserve -> rollback -> reserve+apply sequence (what SliceWriter drives
-// per block) is atomic: a reserve larger than the pool leaves len_==0,
-// RollbackPages returns every page, and a same-offset reserve+apply afterwards
-// is clean (no contiguity CHECK trip).
-TEST_F(BlockDataTest, ReserveRollback_ThenReserveApply_SameOffsetClean) {
-  auto pool = MakePool(2);
-  auto block = MakeBlock(pool.get());
-
-  // Reserve more than the pool holds -> NoSpace, len untouched.
-  std::vector<uint32_t> created;
-  Status s = block->ReservePages(3 * kPageSize, 0, &created);
-  EXPECT_TRUE(s.IsNoSpace()) << s.ToString();
-  EXPECT_EQ(block->Len(), 0);
-
-  // Roll back the partial reservation -> pool fully returned.
-  block->RollbackPages(created);
-  EXPECT_EQ(pool->GetUsedBytes(), 0);
-  EXPECT_EQ(block->Len(), 0);
-
-  // Same offset now reserves + applies cleanly (2 pages fit).
-  std::vector<uint32_t> created2;
-  ASSERT_TRUE(block->ReservePages(2 * kPageSize, 0, &created2).ok());
-  std::vector<char> buf(2 * kPageSize, 'y');
-  block->ApplyWrite(ctx_, buf.data(), 2 * kPageSize, 0);
-  EXPECT_EQ(block->Len(), 2 * kPageSize);
-  EXPECT_EQ(pool->GetUsedBytes(), 2 * kPageSize);
-}
-
+}  // namespace
 }  // namespace vfs
 }  // namespace client
 }  // namespace dingofs

--- a/test/unit/client/vfs/data/test_chunk_writer.cc
+++ b/test/unit/client/vfs/data/test_chunk_writer.cc
@@ -19,8 +19,12 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <functional>
 #include <future>
+#include <mutex>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "client/vfs/data/writer/chunk_writer.h"
@@ -29,6 +33,7 @@
 #include "common/writemempool/write_mem_pool.h"
 #include "test/unit/client/vfs/test_base.h"
 #include "test/unit/client/vfs/test_common.h"
+#include "utils/scoped_cleanup.h"
 
 namespace dingofs {
 namespace client {
@@ -38,8 +43,10 @@ using dingofs::client::vfs::test::AsyncWaiter;
 using dingofs::client::vfs::test::VFSTestBase;
 using ::testing::_;
 using ::testing::AnyNumber;
+using ::testing::DoAll;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::SetArgPointee;
 
 class ChunkWriterTest : public VFSTestBase {
  protected:
@@ -57,6 +64,21 @@ class ChunkWriterTest : public VFSTestBase {
                                           uint64_t chunk_index = 0,
                                           uint64_t fh = 1) {
     return std::make_unique<ChunkWriter>(mock_hub_, ino, chunk_index);
+  }
+
+  Status Write(const std::unique_ptr<ChunkWriter>& writer, const char* buf,
+               int32_t size, int32_t chunk_offset) {
+    WriteMemPool* pool = mock_hub_->GetWriteMemPool();
+    const uint64_t page_size = pool->GetPageSize();
+    const size_t page_need =
+        static_cast<size_t>(((static_cast<uint64_t>(chunk_offset) % page_size) +
+                             static_cast<uint64_t>(size) + page_size - 1) /
+                            page_size);
+    WritePageLease lease;
+    Status status = pool->Acquire(page_need, &lease);
+    if (!status.ok()) return status;
+    writer->Write(ctx_, buf, size, chunk_offset, &lease);
+    return Status::OK();
   }
 
   const uint64_t kIno = 100;
@@ -78,7 +100,7 @@ TEST_F(ChunkWriterTest, SingleWrite_WriteSliceCalled) {
   auto writer = MakeWriter();
 
   const char buf[] = "hello";
-  Status s = writer->Write(ctx_, buf, sizeof(buf), /*chunk_offset=*/0);
+  Status s = Write(writer, buf, sizeof(buf), /*chunk_offset=*/0);
   EXPECT_TRUE(s.ok());
 
   AsyncWaiter waiter;
@@ -106,8 +128,8 @@ TEST_F(ChunkWriterTest, ContiguousWrites_AppendToSlice) {
 
   const char data[8] = "abcdefg";
   // Write two contiguous 4-byte chunks: [0,4) then [4,8).
-  Status s1 = writer->Write(ctx_, data, 4, 0);
-  Status s2 = writer->Write(ctx_, data + 4, 4, 4);
+  Status s1 = Write(writer, data, 4, 0);
+  Status s2 = Write(writer, data + 4, 4, 4);
   EXPECT_TRUE(s1.ok());
   EXPECT_TRUE(s2.ok());
 
@@ -138,8 +160,8 @@ TEST_F(ChunkWriterTest, NonContiguousWrites_MultipleSlices) {
 
   const char data[4] = "abc";
   // Gap of 4 MiB between writes forces separate slices.
-  Status s1 = writer->Write(ctx_, data, 4, 0);
-  Status s2 = writer->Write(ctx_, data, 4, 8 * 1024 * 1024);
+  Status s1 = Write(writer, data, 4, 0);
+  Status s2 = Write(writer, data, 4, 8 * 1024 * 1024);
   EXPECT_TRUE(s1.ok());
   EXPECT_TRUE(s2.ok());
 
@@ -175,7 +197,7 @@ TEST_F(ChunkWriterTest, FlushAsync_WriteSliceError_Propagated) {
   auto writer = MakeWriter();
 
   const char buf[] = "data";
-  writer->Write(ctx_, buf, sizeof(buf), 0);
+  Write(writer, buf, sizeof(buf), 0);
 
   AsyncWaiter waiter;
   waiter.Expect(1);
@@ -199,7 +221,7 @@ TEST_F(ChunkWriterTest, ErrorStatus_Sticky_AfterFirstError) {
   auto writer = MakeWriter();
 
   const char buf[] = "test";
-  writer->Write(ctx_, buf, sizeof(buf), 0);
+  Write(writer, buf, sizeof(buf), 0);
 
   // First flush fails.
   AsyncWaiter waiter1;
@@ -228,7 +250,7 @@ TEST_F(ChunkWriterTest, MultipleFlushAsync_AllComplete) {
   auto writer = MakeWriter();
 
   const char buf[] = "x";
-  writer->Write(ctx_, buf, 1, 0);
+  Write(writer, buf, 1, 0);
 
   constexpr int kFlushes = 3;
   AsyncWaiter waiter;
@@ -261,7 +283,7 @@ TEST_F(ChunkWriterTest, ConcurrentWrites_NoDeadlock) {
       // Stay within chunk bounds.
       if (offset + kWriteSize > kChunkSz) return;
       std::vector<char> buf(kWriteSize, static_cast<char>('a' + i));
-      Status s = writer->Write(ctx_, buf.data(), kWriteSize, offset);
+      Status s = Write(writer, buf.data(), kWriteSize, offset);
       if (s.ok()) {
         success_count.fetch_add(1, std::memory_order_relaxed);
       }
@@ -304,7 +326,7 @@ TEST_F(ChunkWriterTest, Stop_WaitsForFlush) {
   auto writer = MakeWriter();
 
   const char buf[] = "stop test";
-  ASSERT_TRUE(writer->Write(ctx_, buf, sizeof(buf), 0).ok());
+  ASSERT_TRUE(Write(writer, buf, sizeof(buf), 0).ok());
 
   AsyncWaiter waiter;
   waiter.Expect(1);
@@ -334,6 +356,150 @@ TEST_F(ChunkWriterTest, Stop_WaitsForFlush) {
   stop.get();
 }
 
+// A failed flush makes DoSyncFlush return without enqueueing its FIFO sentinel.
+// Stop must still wait for an older in-flight task, then wake on queue drain
+// rather than on the old one-second polling interval.
+TEST_F(ChunkWriterTest, Stop_FailedFlushWaitsForInflightTaskAndWakesOnDrain) {
+#ifdef NDEBUG
+  GTEST_SKIP() << "Deterministic Stop staging requires TEST_SYNC_POINT.";
+#else
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool first_put_held = false;
+  bool second_put_held = false;
+  bool first_flush_done = false;
+  bool second_flush_done = false;
+  bool stop_wait_entered = false;
+  int put_calls = 0;
+  int write_slice_calls = 0;
+  Status first_flush_status;
+  Status second_flush_status;
+  StatusCallback first_put_callback;
+  StatusCallback second_put_callback;
+
+  ON_CALL(*mock_block_store_, PutAsync)
+      .WillByDefault(Invoke([&](ContextSPtr, PutReq, StatusCallback cb) {
+        bool unexpected = false;
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          ++put_calls;
+          if (put_calls == 1) {
+            first_put_callback = std::move(cb);
+            first_put_held = true;
+          } else if (put_calls == 2) {
+            second_put_callback = std::move(cb);
+            second_put_held = true;
+          } else {
+            unexpected = true;
+          }
+          cv.notify_all();
+        }
+        if (unexpected) {
+          ADD_FAILURE() << "Unexpected extra PutAsync call";
+          cb(Status::OK());
+        }
+      }));
+
+  ON_CALL(*mock_meta_system_, WriteSlice)
+      .WillByDefault([&](auto, auto, auto, auto, const std::vector<Slice>&) {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++write_slice_calls;
+        if (write_slice_calls == 1) {
+          return Status::Internal("first flush failed");
+        }
+        return Status::OK();
+      });
+
+  auto writer = MakeWriter();
+  const char first[] = "first";
+  ASSERT_TRUE(Write(writer, first, sizeof(first), 0).ok());
+  writer->FlushAsync([&](Status status) {
+    std::lock_guard<std::mutex> lock(mutex);
+    first_flush_status = std::move(status);
+    first_flush_done = true;
+    cv.notify_all();
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return first_put_held; }));
+  }
+
+  const char second[] = "second";
+  ASSERT_TRUE(Write(writer, second, sizeof(second), 4096).ok());
+  writer->FlushAsync([&](Status status) {
+    std::lock_guard<std::mutex> lock(mutex);
+    second_flush_status = std::move(status);
+    second_flush_done = true;
+    cv.notify_all();
+  });
+
+  StatusCallback fail_first_flush;
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return second_put_held; }));
+    fail_first_flush = std::move(first_put_callback);
+  }
+  ASSERT_TRUE(static_cast<bool>(fail_first_flush));
+  fail_first_flush(Status::OK());
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return first_flush_done; }));
+    ASSERT_FALSE(first_flush_status.ok());
+  }
+
+  SyncPoint::GetInstance()->SetCallBack(
+      "ChunkWriter::Stop:before_wait_flush_queue", [&](void*) {
+        std::lock_guard<std::mutex> lock(mutex);
+        stop_wait_entered = true;
+        cv.notify_all();
+      });
+  SyncPoint::GetInstance()->EnableProcessing();
+  auto sync_point_cleanup = MakeScopedCleanup([] {
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+  });
+
+  auto stop = std::async(std::launch::async, [&writer] { writer->Stop(); });
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    const bool reached_wait = cv.wait_for(lock, std::chrono::seconds(5),
+                                          [&] { return stop_wait_entered; });
+    EXPECT_TRUE(reached_wait);
+  }
+  EXPECT_EQ(stop.wait_for(std::chrono::milliseconds(0)),
+            std::future_status::timeout);
+
+  StatusCallback release_put;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    release_put = std::move(second_put_callback);
+  }
+  ASSERT_TRUE(static_cast<bool>(release_put));
+  release_put(Status::OK());
+
+  // All async stages are synchronized above. This 750 ms bound only
+  // distinguishes notification from the former fixed one-second sleep.
+  EXPECT_EQ(stop.wait_for(std::chrono::milliseconds(750)),
+            std::future_status::ready)
+      << "Stop was not notified when flush_queue_ became empty";
+  ASSERT_EQ(stop.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  stop.get();
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(5),
+                            [&] { return second_flush_done; }));
+    EXPECT_FALSE(second_flush_status.ok());
+  }
+
+#endif
+}
+
 // 10. TriggerFlush (called automatically when a slice fills up) does not crash
 //     and invokes WriteSlice.
 TEST_F(ChunkWriterTest, TriggerFlush_NoCrash) {
@@ -348,7 +514,7 @@ TEST_F(ChunkWriterTest, TriggerFlush_NoCrash) {
 
   // Write a modest amount and then explicitly trigger flush.
   const char buf[] = "trigger";
-  writer->Write(ctx_, buf, sizeof(buf), 0);
+  Write(writer, buf, sizeof(buf), 0);
   writer->TriggerFlush();
 
   // Allow async tasks to drain.
@@ -394,7 +560,7 @@ TEST_F(ChunkWriterTest, ConcurrentWriteAndFlush_SeqOrdered) {
     for (int i = 0; i < kRounds; ++i) {
       uint64_t offset = static_cast<uint64_t>(i) * kWriteSize;
       std::vector<char> buf(kWriteSize, static_cast<char>('A' + i % 26));
-      Status s = writer->Write(ctx_, buf.data(), kWriteSize, offset);
+      Status s = Write(writer, buf.data(), kWriteSize, offset);
       EXPECT_TRUE(s.ok()) << "Write failed at round " << i;
     }
   });
@@ -466,12 +632,11 @@ TEST_F(ChunkWriterTest, FindWritable_Reverse_CreatesNew) {
   std::vector<char> buf2(2 * 1024 * 1024, 'B');
 
   // Forward write [4MB, 8MB).
-  Status s1 = writer->Write(ctx_, buf1.data(), k4MB, k4MB);
+  Status s1 = Write(writer, buf1.data(), k4MB, k4MB);
   EXPECT_TRUE(s1.ok());
 
   // Reverse adjacent write [2MB, 4MB) — target creates a new slice.
-  Status s2 =
-      writer->Write(ctx_, buf2.data(), 2 * 1024 * 1024, 2 * 1024 * 1024);
+  Status s2 = Write(writer, buf2.data(), 2 * 1024 * 1024, 2 * 1024 * 1024);
   EXPECT_TRUE(s2.ok());
 
   AsyncWaiter waiter;
@@ -504,11 +669,11 @@ TEST_F(ChunkWriterTest, FindWritable_Forward_Reuses) {
   std::vector<char> buf2(k4MB, 'B');
 
   // Forward write [0, 4MB).
-  Status s1 = writer->Write(ctx_, buf1.data(), k4MB, 0);
+  Status s1 = Write(writer, buf1.data(), k4MB, 0);
   EXPECT_TRUE(s1.ok());
 
   // Forward adjacent write [4MB, 8MB) — should reuse the same slice.
-  Status s2 = writer->Write(ctx_, buf2.data(), k4MB, k4MB);
+  Status s2 = Write(writer, buf2.data(), k4MB, k4MB);
   EXPECT_TRUE(s2.ok());
 
   AsyncWaiter waiter;
@@ -567,7 +732,7 @@ TEST_F(ChunkWriterTest, ConcurrentFlush_HoldsSliceMutexUntilQueuePush) {
 
   auto writer = MakeWriter();
   const char buf[] = "race-data";
-  ASSERT_TRUE(writer->Write(ctx_, buf, sizeof(buf), 0).ok());
+  ASSERT_TRUE(Write(writer, buf, sizeof(buf), 0).ok());
 
   // Coordinate T1 in the sync point.
   std::promise<void> t1_in_section;
@@ -639,155 +804,165 @@ TEST_F(ChunkWriterTest, ConcurrentFlush_HoldsSliceMutexUntilQueuePush) {
 #endif  // NDEBUG
 }
 
-// --- P2 failure-path: pool exhaustion (TryAllocateBatch returns short)
-// ---
+namespace {
 
-// A tiny pool makes exhaustion deterministic (TryAllocate never waits). A write
-// needing more pages than the pool has must fail with NoSpace AND roll back
-// every page it briefly took (BlockData reserve rollback) -- no leak.
-TEST_F(ChunkWriterTest, PoolExhaustion_WriteReturnsNoSpaceAndRollsBack) {
-  auto tiny_pool = std::make_unique<WriteMemPool>(4 * 4096, 4096);  // 4 slots
-  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny_pool.get()));
+// Test-only executor: every Execute call runs on its own thread. This lets
+// a test control the RELATIVE order of two independently submitted callbacks
+// (a single-threaded FIFO executor would serialize them and hide the race).
+class ThreadPerTaskExecutor : public Executor {
+ public:
+  bool Start() override { return true; }
+  ~ThreadPerTaskExecutor() override { Stop(); }
 
-  auto writer = MakeWriter();
-
-  // 8 pages (32 KiB) > 4-slot pool: BlockData::Write pass-1 fails on the 5th
-  // page, rolls back the 4 it took, and NoSpace propagates up the chain.
-  std::string buf(8 * 4096, 'x');
-  Status s = writer->Write(ctx_, buf.data(), static_cast<int32_t>(buf.size()),
-                           /*chunk_offset=*/0);
-  EXPECT_TRUE(s.IsNoSpace()) << "expected NoSpace, got: " << s.ToString();
-  EXPECT_EQ(tiny_pool->GetUsedBytes(), 0)
-      << "rollback leaked pages: used=" << tiny_pool->GetUsedBytes();
-}
-
-// Concurrent writers all hit the exhausted pool. The batch leader fails, and
-// EVERY queued writer must be woken with the batch status -- if batch wakeup is
-// broken a waiter blocks forever and join() hangs (test times out). Reaching
-// the assertions proves no deadlock and no lost writer.
-TEST_F(ChunkWriterTest, PoolExhaustion_ConcurrentWritersAllWokenNoDeadlock) {
-  auto tiny_pool = std::make_unique<WriteMemPool>(4 * 4096, 4096);
-  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny_pool.get()));
-
-  auto writer = MakeWriter();
-
-  constexpr int kThreads = 8;
-  std::atomic<int> nospace{0};
-  std::atomic<int> okcnt{0};
-  std::vector<std::thread> ts;
-  ts.reserve(kThreads);
-  for (int i = 0; i < kThreads; ++i) {
-    // Distinct 8 MiB-apart offsets -> independent slices, no contiguity clash.
-    ts.emplace_back([&, i] {
-      std::string buf(8 * 4096, 'x');
-      Status s =
-          writer->Write(ctx_, buf.data(), static_cast<int32_t>(buf.size()),
-                        /*chunk_offset=*/i * 8 * 1024 * 1024);
-      if (s.IsNoSpace()) {
-        nospace.fetch_add(1, std::memory_order_relaxed);
-      } else if (s.ok()) {
-        okcnt.fetch_add(1, std::memory_order_relaxed);
+  bool Stop() override {
+    std::vector<std::thread> threads;
+    {
+      std::lock_guard<std::mutex> lg(mutex_);
+      threads.swap(threads_);
+    }
+    for (auto& thread : threads) {
+      if (thread.joinable()) {
+        thread.join();
       }
-    });
+    }
+    return true;
   }
-  for (auto& t : ts) t.join();  // must not hang -- proves all writers woken
 
-  EXPECT_GT(nospace.load(), 0) << "expected writers to hit NoSpace";
-  EXPECT_EQ(nospace.load() + okcnt.load(), kThreads) << "a writer was lost";
-  EXPECT_EQ(tiny_pool->GetUsedBytes(), 0) << "rollback leaked pages";
-}
+  bool Execute(std::function<void()> func) override {
+    std::lock_guard<std::mutex> lg(mutex_);
+    threads_.emplace_back(std::move(func));
+    return true;
+  }
 
-// Per-writer regression: in a batch where early writers succeed and a later one
-// exhausts the pool, the successful writers MUST return OK -- their data
-// already landed in the buffer. A single shared batch status would clobber them
-// with NoSpace, the caller would retry the same range and double-write. 8
-// writers each take 1 page from a 4-slot pool: exactly 4 fit (and stay, nothing
-// is flushed), the rest get NoSpace. The fix keeps okcnt > 0; the pre-fix bug
-// made it 0 for any batch that mixed success + failure.
-TEST_F(ChunkWriterTest, PoolExhaustion_PartialBatch_SuccessfulWritersReturnOK) {
-  auto tiny_pool = std::make_unique<WriteMemPool>(4 * 4096, 4096);  // 4 slots
-  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny_pool.get()));
+  bool Schedule(std::function<void()> func, int delay_ms) override {
+    (void)func;
+    (void)delay_ms;
+    return false;
+  }
+
+  int ThreadNum() const override { return 0; }
+  int TaskNum() const override { return 0; }
+  std::string Name() const override { return "thread_per_task"; }
+
+ private:
+  std::mutex mutex_;
+  std::vector<std::thread> threads_;
+};
+
+}  // namespace
+
+// 12. Regression (ASAN): the post-commit dispatch lambda in
+//     TryCommitFlushTasks runs on the CBExecutor and may execute AFTER the
+//     ChunkWriter has been deleted (Stop's DoSyncFlush returns when its own
+//     task's cb fires; an earlier batch's lambda can still be mid-flight).
+//     Pre-fix the lambda captured `this` ([&]) and called GetErrorStatus()
+//     per task -- a use-after-free once the writer is freed. Post-fix the
+//     batch status is snapshotted before dispatch and captured by value.
+//
+//     Determinism strategy: ThreadPerTaskExecutor lets the test hold the
+//     FIRST task's user cb inside the earlier batch's lambda while Stop's
+//     own batch (empty slices -> direct cb, no executor dependency)
+//     completes and deletes the writer. Releasing the held cb then resumes
+//     the earlier lambda post-destruction.
+TEST_F(ChunkWriterTest, PostCommitLambda_RunsAfterDestroy_NoUseAfterFree) {
+  ON_CALL(*mock_meta_system_, NewSliceId(_, _, _))
+      .WillByDefault(DoAll(SetArgPointee<2>(71u), Return(Status::OK())));
+  ON_CALL(*mock_meta_system_, WriteSlice).WillByDefault(Return(Status::OK()));
+
+  std::mutex held_mtx;
+  std::condition_variable held_cv;
+  std::vector<StatusCallback> held_puts;
+  ON_CALL(*mock_block_store_, PutAsync(_, _, _))
+      .WillByDefault(Invoke([&](ContextSPtr, PutReq, StatusCallback cb) {
+        std::lock_guard<std::mutex> lg(held_mtx);
+        held_puts.push_back(std::move(cb));
+        held_cv.notify_all();
+      }));
+
+  ThreadPerTaskExecutor async_executor;
+  ON_CALL(*mock_hub_, GetCBExecutor()).WillByDefault(Return(&async_executor));
 
   auto writer = MakeWriter();
+  const char buf[] = "uaf-regression";
+  ASSERT_TRUE(Write(writer, buf, sizeof(buf), 0).ok());
 
-  constexpr int kThreads = 8;
-  std::atomic<int> nospace{0};
-  std::atomic<int> okcnt{0};
-  std::vector<std::thread> ts;
-  ts.reserve(kThreads);
-  for (int i = 0; i < kThreads; ++i) {
-    // 1 page each, distinct 8 MiB-apart offsets (independent slices).
-    ts.emplace_back([&, i] {
-      std::string buf(4096, 'x');
-      Status s =
-          writer->Write(ctx_, buf.data(), static_cast<int32_t>(buf.size()),
-                        /*chunk_offset=*/i * 8 * 1024 * 1024);
-      if (s.IsNoSpace()) {
-        nospace.fetch_add(1, std::memory_order_relaxed);
-      } else if (s.ok()) {
-        okcnt.fetch_add(1, std::memory_order_relaxed);
-      }
-    });
+  std::promise<void> first_cb_entered;
+  std::promise<void> release_first_cb;
+  auto release_shared = release_first_cb.get_future().share();
+  auto entered_future = first_cb_entered.get_future();
+  std::promise<void> second_cb_done;
+  auto second_future = second_cb_done.get_future();
+  bool first_cb_released = false;
+  auto async_cleanup = MakeScopedCleanup([&] {
+    if (!first_cb_released) {
+      release_first_cb.set_value();
+      first_cb_released = true;
+    }
+    std::vector<StatusCallback> pending_puts;
+    {
+      std::lock_guard<std::mutex> lg(held_mtx);
+      pending_puts.swap(held_puts);
+    }
+    for (auto& cb : pending_puts) {
+      cb(Status::OK());
+    }
+    async_executor.Stop();
+  });
+
+  // Batch member 1: blocks inside its user cb while the writer is deleted.
+  writer->FlushAsync([&](Status) {
+    first_cb_entered.set_value();
+    release_shared.wait();
+  });
+
+  // Batch member 2: empty-slice task, completes inline (its FlushTaskDone
+  // only marks done; it joins member 1's commit batch later).
+  writer->FlushAsync([&](Status) { second_cb_done.set_value(); });
+
+  // Both flush tasks are queued; the upload of the single slice is held.
+  {
+    std::unique_lock<std::mutex> lg(held_mtx);
+    ASSERT_TRUE(held_cv.wait_for(lg, std::chrono::seconds(5), [&] {
+      return !held_puts.empty();
+    })) << "PutAsync was never called";
   }
-  for (auto& t : ts) t.join();
 
-  EXPECT_GT(okcnt.load(), 0)
-      << "successful writers were clobbered with the batch failure status";
-  EXPECT_GT(nospace.load(), 0) << "expected some writers to hit NoSpace";
-  EXPECT_EQ(okcnt.load() + nospace.load(), kThreads) << "a writer was lost";
-  // Successful writers each hold exactly 1 page (not flushed); failed writers
-  // rolled back cleanly -- so used is precisely okcnt pages, nothing leaked.
-  EXPECT_EQ(tiny_pool->GetUsedBytes(),
-            static_cast<int64_t>(okcnt.load()) * 4096)
-      << "used should equal successful writers' pages with no leak";
-}
+  // Release the upload: member 1's batch [task1, task2] commits and its
+  // dispatch lambda blocks in member 1's user cb.
+  std::vector<StatusCallback> puts;
+  {
+    std::lock_guard<std::mutex> lg(held_mtx);
+    puts.swap(held_puts);
+  }
+  for (auto& cb : puts) {
+    cb(Status::OK());
+  }
+  ASSERT_EQ(entered_future.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready)
+      << "first batch's post-commit lambda never entered its user cb";
 
-// Cross-block atomicity regression. A single SliceWriter::Write that spans two
-// blocks where block0 reserves fully but block1 hits the exhausted pool must
-// roll back EVERYTHING (no half-write). Pre-fix, block0 was applied + len_ left
-// unbumped, so retrying the same offset re-entered an inconsistent BlockData
-// and tripped its contiguity CHECK (client abort). This asserts: NoSpace, zero
-// pool leak, AND that a retry at the same offset neither crashes nor wedges.
-TEST_F(ChunkWriterTest,
-       PoolExhaustion_CrossBlock_AtomicRollback_NoCrashOnRetry) {
-  // Derive geometry so the test follows the harness page size (and the fs block
-  // size) instead of hard-coding the pages-per-block count. context_.page_size
-  // == this pool's page (ChunkWriter takes it from GetWriteMemPool), so the
-  // page here is what BlockData actually allocates in.
-  constexpr int64_t kPage = 4096;
-  constexpr int64_t kBlockSize = 4 * 1024 * 1024;  // MakeTestFsInfo default
-  constexpr int64_t kBlockPages = kBlockSize / kPage;
+  // Destroy the writer: Stop's DoSyncFlush batch dispatches its own lambda
+  // (independent thread), its sync cb fires, Stop returns, writer freed.
+  // This must not hang: the queue-empty CV was notified before dispatch.
+  auto destroyed = std::async(std::launch::async, [&] { writer.reset(); });
+  const auto destroyed_while_callback_blocked =
+      destroyed.wait_for(std::chrono::seconds(5));
+  EXPECT_EQ(destroyed_while_callback_blocked, std::future_status::ready)
+      << "Stop hung while an earlier post-commit lambda was still parked";
 
-  // Pool holds exactly one block: block0 takes every page, block1's first page
-  // then fails.
-  auto pool = std::make_unique<WriteMemPool>(kBlockPages * kPage, kPage);
-  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(pool.get()));
+  // Always release the parked callback before any fatal assertion or future
+  // destruction, so a failing regression test cannot hang or terminate.
+  release_first_cb.set_value();
+  first_cb_released = true;
+  ASSERT_EQ(destroyed.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+  ASSERT_EQ(destroyed_while_callback_blocked, std::future_status::ready);
 
-  auto writer = MakeWriter();
-
-  // block_size + 1 page spans block0 (full) + block1 (1 page) -> one page more
-  // than the pool has.
-  const int32_t kWriteSize = static_cast<int32_t>(kBlockSize + kPage);
-  std::string buf(kWriteSize, 'x');
-
-  Status s1 = writer->Write(ctx_, buf.data(), kWriteSize, /*chunk_offset=*/0);
-  EXPECT_TRUE(s1.IsNoSpace()) << "expected NoSpace, got: " << s1.ToString();
-  EXPECT_EQ(pool->GetUsedBytes(), 0)
-      << "cross-block rollback must free block0's reserved pages";
-
-  // Retry SAME offset: must not abort (the pre-fix crash) and must fail
-  // cleanly.
-  Status s2 = writer->Write(ctx_, buf.data(), kWriteSize, /*chunk_offset=*/0);
-  EXPECT_TRUE(s2.IsNoSpace());
-  EXPECT_EQ(pool->GetUsedBytes(), 0);
-
-  // A write that fits (1 page) at the same offset now succeeds, proving slice
-  // state stayed consistent (End() == 0, no phantom len_).
-  std::string small(kPage, 'y');
-  Status s3 = writer->Write(ctx_, small.data(), static_cast<int32_t>(kPage),
-                            /*chunk_offset=*/0);
-  EXPECT_TRUE(s3.ok()) << s3.ToString();
-  EXPECT_EQ(pool->GetUsedBytes(), kPage);
+  // The parked lambda now continues past the writer's death. The second
+  // task's cb must still fire with the snapshotted batch status.
+  ASSERT_EQ(second_future.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready)
+      << "second task's user cb never fired after the writer was deleted";
 }
 
 }  // namespace vfs

--- a/test/unit/client/vfs/data/test_file_writer.cc
+++ b/test/unit/client/vfs/data/test_file_writer.cc
@@ -105,33 +105,6 @@ TEST_F(FileWriterTest, Write_CrossingChunkBoundary) {
   FlushCloseAndRelease(w);
 }
 
-// 2b. Cross-chunk pool exhaustion is a POSIX short write: chunk0 succeeds,
-//     chunk1 hits the exhausted pool. FileWriter must return OK with
-//     out_wsize == the chunk0 prefix (not an error that discards it), so the
-//     caller advances and re-issues the rest.
-TEST_F(FileWriterTest, Write_CrossChunk_PoolExhaustion_ShortWrite) {
-  // 1-page pool: chunk0's page fits, chunk1's page then fails.
-  auto tiny = std::make_unique<WriteMemPool>(4096, 4096);
-  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny.get()));
-
-  auto* w = MakeOpenWriter();
-
-  const uint64_t chunk_size = mock_hub_->GetFsInfo().chunk_size;
-  // 8 bytes straddling the chunk 0/1 boundary: 4 bytes in each chunk.
-  constexpr uint64_t kWriteSize = 8;
-  uint64_t offset = chunk_size - 4;
-
-  std::vector<char> buf(kWriteSize, 'X');
-  uint64_t wsize = 0;
-  Status s = w->Write(ctx_, buf.data(), kWriteSize, offset, &wsize);
-
-  // Short write: OK, only the 4 bytes that landed in chunk 0.
-  EXPECT_TRUE(s.ok()) << s.ToString();
-  EXPECT_EQ(wsize, 4u);
-
-  FlushCloseAndRelease(w);
-}
-
 // 2c. First chunk itself exhausts the pool: zero bytes land, so the write is a
 //     hard failure -- NoSpace + out_wsize == 0 (not a short write).
 TEST_F(FileWriterTest, Write_FirstChunkNoSpace_ReturnsNoSpaceZeroWsize) {

--- a/test/unit/client/vfs/data/test_flush_tasks.cc
+++ b/test/unit/client/vfs/data/test_flush_tasks.cc
@@ -73,6 +73,22 @@ class FlushTasksTest : public test::VFSTestBase {
     EXPECT_CALL(*mock_hub_, GetTraceManager()).Times(AnyNumber());
   }
 
+  template <typename WriterPtr>
+  Status Write(const WriterPtr& writer, const char* buf, int32_t size,
+               int32_t chunk_offset) {
+    WriteMemPool* pool = mock_hub_->GetWriteMemPool();
+    const uint64_t page_size = pool->GetPageSize();
+    const size_t page_need =
+        static_cast<size_t>(((static_cast<uint64_t>(chunk_offset) % page_size) +
+                             static_cast<uint64_t>(size) + page_size - 1) /
+                            page_size);
+    WritePageLease lease;
+    Status status = pool->Acquire(page_need, &lease);
+    if (!status.ok()) return status;
+    writer->Write(ctx_, buf, size, chunk_offset, &lease);
+    return Status::OK();
+  }
+
   std::unique_ptr<TraceManager> trace_manager_;
 };
 
@@ -117,7 +133,7 @@ TEST_F(FlushTasksTest, ChunkFlushTask_AllSlices_Success) {
     uint64_t chunk_off = static_cast<uint64_t>(i) * kPageSize;
     auto sw = std::make_shared<SliceWriter>(ctx, mock_hub_, chunk_off);
     std::vector<char> buf(kPageSize, static_cast<char>('A' + i));
-    ASSERT_TRUE(sw->Write(ctx_, buf.data(), kPageSize, chunk_off).ok());
+    ASSERT_TRUE(Write(sw, buf.data(), kPageSize, chunk_off).ok());
     slices.emplace(seq, sw);
   }
 
@@ -148,7 +164,7 @@ TEST_F(FlushTasksTest, ChunkFlushTask_SliceFail_Propagated) {
   uint64_t seq = ctx.seq;
   auto sw = std::make_shared<SliceWriter>(ctx, mock_hub_, 0);
   std::vector<char> buf(kPageSize, 'F');
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), kPageSize, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), kPageSize, 0).ok());
 
   std::map<uint64_t, SliceWriterPtr> slices;
   slices.emplace(seq, sw);
@@ -190,7 +206,7 @@ TEST_F(FlushTasksTest, ChunkFlushTask_Concurrent_ExactlyOnce) {
     uint64_t chunk_off = static_cast<uint64_t>(i) * kPageSize;
     auto sw = std::make_shared<SliceWriter>(ctx, mock_hub_, chunk_off);
     std::vector<char> buf(kPageSize, static_cast<char>('a' + i));
-    ASSERT_TRUE(sw->Write(ctx_, buf.data(), kPageSize, chunk_off).ok());
+    ASSERT_TRUE(Write(sw, buf.data(), kPageSize, chunk_off).ok());
     slices.emplace(seq, sw);
   }
 
@@ -239,7 +255,7 @@ TEST_F(FlushTasksTest, FileFlushTask_AllSuccess_CallbackCalledOnce) {
                                             static_cast<uint64_t>(i));
     std::vector<char> buf(kPageSize, static_cast<char>('A' + i));
     uint64_t chunk_off = 0;
-    ASSERT_TRUE(cw->Write(ctx_, buf.data(), kPageSize, chunk_off).ok());
+    ASSERT_TRUE(Write(cw, buf.data(), kPageSize, chunk_off).ok());
     writers_map.emplace(static_cast<uint64_t>(i), cw.get());
     owned_writers.push_back(std::move(cw));
   }
@@ -269,7 +285,7 @@ TEST_F(FlushTasksTest, FileFlushTask_OneChunkFail_ErrorPropagated) {
 
   auto cw = std::make_unique<ChunkWriter>(mock_hub_, kIno, 0);
   std::vector<char> buf(kPageSize, 'E');
-  ASSERT_TRUE(cw->Write(ctx_, buf.data(), kPageSize, 0).ok());
+  ASSERT_TRUE(Write(cw, buf.data(), kPageSize, 0).ok());
 
   std::unordered_map<int64_t, ChunkWriter*> writers_map;
   writers_map.emplace(0u, cw.get());
@@ -322,7 +338,7 @@ TEST_F(FlushTasksTest, FileFlushTask_Concurrent_ExactlyOnce) {
     auto cw = std::make_unique<ChunkWriter>(mock_hub_, kIno,
                                             static_cast<uint64_t>(i));
     std::vector<char> buf(kPageSize, static_cast<char>('a' + i));
-    ASSERT_TRUE(cw->Write(ctx_, buf.data(), kPageSize, 0).ok());
+    ASSERT_TRUE(Write(cw, buf.data(), kPageSize, 0).ok());
     writers_map.emplace(static_cast<uint64_t>(i), cw.get());
     owned_writers.push_back(std::move(cw));
   }

--- a/test/unit/client/vfs/data/test_slice_writer.cc
+++ b/test/unit/client/vfs/data/test_slice_writer.cc
@@ -93,6 +93,21 @@ class SliceWriterTest : public test::VFSTestBase {
     return std::vector<char>(size, '\0');
   }
 
+  Status Write(const SliceWriterPtr& writer, const char* buf, int32_t size,
+               int32_t chunk_offset) {
+    WriteMemPool* pool = mock_hub_->GetWriteMemPool();
+    const uint64_t page_size = pool->GetPageSize();
+    const size_t page_need =
+        static_cast<size_t>(((static_cast<uint64_t>(chunk_offset) % page_size) +
+                             static_cast<uint64_t>(size) + page_size - 1) /
+                            page_size);
+    WritePageLease lease;
+    Status status = pool->Acquire(page_need, &lease);
+    if (!status.ok()) return status;
+    writer->Write(ctx_, buf, size, chunk_offset, &lease);
+    return Status::OK();
+  }
+
   std::unique_ptr<TraceManager> trace_manager_;
   std::unique_ptr<SliceDataContext> context_;
   SliceWriterPtr sw_;
@@ -101,7 +116,7 @@ class SliceWriterTest : public test::VFSTestBase {
 // 1. Write 4096 bytes at offset 0; verify Len() == 4096.
 TEST_F(SliceWriterTest, Write_Basic_LengthUpdated) {
   auto buf = MakeBuf(4096);
-  Status s = sw_->Write(ctx_, buf.data(), 4096, 0);
+  Status s = Write(sw_, buf.data(), 4096, 0);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(sw_->Len(), 4096u);
 }
@@ -112,19 +127,17 @@ TEST_F(SliceWriterTest, Write_MultiBlock_BoundaryAlignment) {
   // block boundary and should touch two blocks.
   uint64_t write_size = kBlockSize + 1024;
   auto buf = MakeBuf(write_size);
-  Status s = sw_->Write(ctx_, buf.data(), write_size, 0);
+  Status s = Write(sw_, buf.data(), write_size, 0);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(sw_->Len(), write_size);
   // End should be chunk_offset + write_size
   EXPECT_EQ(sw_->End(), write_size);
 }
 
-// 2b. Cross-block pool exhaustion: SliceWriter::Write must be atomic. A write
-//     spanning two blocks where the pool only covers the first must roll back
-//     fully (Len() unchanged, zero leak), and a same-offset retry must not trip
-//     BlockData's contiguity CHECK (the pre-fix half-write crash).
-TEST_F(SliceWriterTest, Write_CrossBlock_PoolExhaustion_AtomicRollback) {
-  // Pool holds exactly one block's pages; block0 takes them all, block1 fails.
+// 2b. An oversized request is rejected by admission before SliceWriter sees
+// it. The slice remains untouched and a later fitting write can use offset 0.
+TEST_F(SliceWriterTest, Write_OversizedAdmissionLeavesSliceUntouched) {
+  // Pool holds exactly one block's pages.
   const int64_t block_pages = kBlockSize / kPageSize;
   auto tiny =
       std::make_unique<WriteMemPool>(block_pages * kPageSize, kPageSize);
@@ -134,24 +147,24 @@ TEST_F(SliceWriterTest, Write_CrossBlock_PoolExhaustion_AtomicRollback) {
   auto sw = std::make_shared<SliceWriter>(*context_, mock_hub_,
                                           /*chunk_offset=*/0);
 
-  // block_size + 1 page spans block0 (full) + block1 (1 page) -> 1 page short.
+  // block_size + 1 page cannot be admitted atomically.
   const int32_t write_size = static_cast<int32_t>(kBlockSize + kPageSize);
   auto buf = MakeBuf(write_size);
 
-  Status s1 = sw->Write(ctx_, buf.data(), write_size, 0);
+  Status s1 = Write(sw, buf.data(), write_size, 0);
   EXPECT_TRUE(s1.IsNoSpace()) << s1.ToString();
-  EXPECT_EQ(sw->Len(), 0u) << "failed write must not bump slice len";
-  EXPECT_EQ(tiny->GetUsedBytes(), 0) << "block0's reserved pages must be freed";
+  EXPECT_EQ(sw->Len(), 0u);
+  EXPECT_EQ(tiny->GetUsedBytes(), 0);
 
   // Retry same offset: clean, no abort.
-  Status s2 = sw->Write(ctx_, buf.data(), write_size, 0);
+  Status s2 = Write(sw, buf.data(), write_size, 0);
   EXPECT_TRUE(s2.IsNoSpace());
   EXPECT_EQ(sw->Len(), 0u);
   EXPECT_EQ(tiny->GetUsedBytes(), 0);
 
   // A fitting 1-page write at the same offset now succeeds (state consistent).
   auto small = MakeBuf(kPageSize);
-  Status s3 = sw->Write(ctx_, small.data(), kPageSize, 0);
+  Status s3 = Write(sw, small.data(), kPageSize, 0);
   EXPECT_TRUE(s3.ok()) << s3.ToString();
   EXPECT_EQ(sw->Len(), kPageSize);
 }
@@ -167,7 +180,7 @@ TEST_F(SliceWriterTest, FlushAsync_BasicSuccess) {
           [](ContextSPtr, PutReq, StatusCallback cb) { cb(Status::OK()); }));
 
   auto buf = MakeBuf(4096);
-  ASSERT_TRUE(sw_->Write(ctx_, buf.data(), 4096, 0).ok());
+  ASSERT_TRUE(Write(sw_, buf.data(), 4096, 0).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -206,11 +219,10 @@ TEST_F(SliceWriterTest, FlushAsync_PutPayloadPreservesCrossBlockByteOrder) {
         cb(Status::OK());
       }));
 
-  ASSERT_TRUE(sw_->Write(ctx_, input.data(), first_size, 0).ok());
-  ASSERT_TRUE(sw_
-                  ->Write(ctx_, input.data() + first_size,
-                          total_size - first_size, first_size)
-                  .ok());
+  ASSERT_TRUE(Write(sw_, input.data(), first_size, 0).ok());
+  ASSERT_TRUE(
+      Write(sw_, input.data() + first_size, total_size - first_size, first_size)
+          .ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -224,7 +236,8 @@ TEST_F(SliceWriterTest, FlushAsync_PutPayloadPreservesCrossBlockByteOrder) {
   ASSERT_EQ(uploaded.size(), 2);
   ASSERT_EQ(uploaded[0].size(), kBlockSize);
   ASSERT_EQ(uploaded[1].size(), input.size() - kBlockSize);
-  EXPECT_TRUE(std::equal(uploaded[0].begin(), uploaded[0].end(), input.begin()));
+  EXPECT_TRUE(
+      std::equal(uploaded[0].begin(), uploaded[0].end(), input.begin()));
   EXPECT_TRUE(std::equal(uploaded[1].begin(), uploaded[1].end(),
                          input.begin() + kBlockSize));
 }
@@ -253,7 +266,7 @@ TEST_F(SliceWriterTest, FlushAsync_PagesLiveUntilUploadCallback) {
   for (size_t i = 0; i < input.size(); ++i) {
     input[i] = static_cast<char>((i * 29 + 7) % 253);
   }
-  ASSERT_TRUE(sw_->Write(ctx_, input.data(), input.size(), 0).ok());
+  ASSERT_TRUE(Write(sw_, input.data(), input.size(), 0).ok());
   ASSERT_GT(write_buf_mgr_->GetUsedBytes(), 0);
 
   test::AsyncWaiter waiter;
@@ -295,7 +308,7 @@ TEST_F(SliceWriterTest, FlushAsync_CommitSlice_CorrectFields) {
 
   uint64_t write_size = 8192;
   auto buf = MakeBuf(write_size);
-  ASSERT_TRUE(sw_->Write(ctx_, buf.data(), write_size, 0).ok());
+  ASSERT_TRUE(Write(sw_, buf.data(), write_size, 0).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -320,7 +333,7 @@ TEST_F(SliceWriterTest, FlushAsync_NewSliceId_Fails) {
       .WillOnce(Return(Status::IoError("id allocation failed")));
 
   auto buf = MakeBuf(4096);
-  ASSERT_TRUE(sw_->Write(ctx_, buf.data(), 4096, 0).ok());
+  ASSERT_TRUE(Write(sw_, buf.data(), 4096, 0).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -341,7 +354,7 @@ TEST_F(SliceWriterTest, FlushAsync_BlockStore_PutAsync_Fails) {
       }));
 
   auto buf = MakeBuf(4096);
-  ASSERT_TRUE(sw_->Write(ctx_, buf.data(), 4096, 0).ok());
+  ASSERT_TRUE(Write(sw_, buf.data(), 4096, 0).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -364,7 +377,7 @@ TEST_F(SliceWriterTest, FlushAsync_OnlyCalledOnce) {
           [](ContextSPtr, PutReq, StatusCallback cb) { cb(Status::OK()); }));
 
   auto buf = MakeBuf(4096);
-  ASSERT_TRUE(sw_->Write(ctx_, buf.data(), 4096, 0).ok());
+  ASSERT_TRUE(Write(sw_, buf.data(), 4096, 0).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -391,7 +404,7 @@ TEST_F(SliceWriterTest, Write_ZeroData_FlushSucceeds) {
           [](ContextSPtr, PutReq, StatusCallback cb) { cb(Status::OK()); }));
 
   auto buf = MakeZeroBuf(4096);
-  ASSERT_TRUE(sw_->Write(ctx_, buf.data(), 4096, 0).ok());
+  ASSERT_TRUE(Write(sw_, buf.data(), 4096, 0).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -412,8 +425,8 @@ TEST_F(SliceWriterTest, GetWrittenLength_CorrectValue) {
   auto buf1 = MakeBuf(first, 'X');
   auto buf2 = MakeBuf(second, 'Y');
 
-  ASSERT_TRUE(sw_->Write(ctx_, buf1.data(), first, 0).ok());
-  ASSERT_TRUE(sw_->Write(ctx_, buf2.data(), second, first).ok());
+  ASSERT_TRUE(Write(sw_, buf1.data(), first, 0).ok());
+  ASSERT_TRUE(Write(sw_, buf2.data(), second, first).ok());
 
   EXPECT_EQ(sw_->Len(), first + second);
   EXPECT_EQ(sw_->End(), first + second);
@@ -454,6 +467,21 @@ class SliceWriterSliceRelativeTest : public test::VFSTestBase {
     return std::vector<char>(size, val);
   }
 
+  Status Write(const SliceWriterPtr& writer, const char* buf, int32_t size,
+               int32_t chunk_offset) {
+    WriteMemPool* pool = mock_hub_->GetWriteMemPool();
+    const uint64_t page_size = pool->GetPageSize();
+    const size_t page_need =
+        static_cast<size_t>(((static_cast<uint64_t>(chunk_offset) % page_size) +
+                             static_cast<uint64_t>(size) + page_size - 1) /
+                            page_size);
+    WritePageLease lease;
+    Status status = pool->Acquire(page_need, &lease);
+    if (!status.ok()) return status;
+    writer->Write(ctx_, buf, size, chunk_offset, &lease);
+    return Status::OK();
+  }
+
   std::unique_ptr<TraceManager> trace_manager_;
   std::unique_ptr<SliceDataContext> context_;
 };
@@ -481,7 +509,7 @@ TEST_F(SliceWriterSliceRelativeTest, Write_SliceRelative_StartsFromZero) {
       .WillOnce(DoAll(SetArgPointee<2>(100u), Return(Status::OK())));
 
   auto buf = MakeBuf(kWriteSize);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), kWriteSize, kStartOffset).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), kWriteSize, kStartOffset).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -520,7 +548,7 @@ TEST_F(SliceWriterSliceRelativeTest, Write_MultiBlock_Sequential) {
       .WillOnce(DoAll(SetArgPointee<2>(101u), Return(Status::OK())));
 
   auto buf = MakeBuf(kWriteSize);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), kWriteSize, kStartOffset).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), kWriteSize, kStartOffset).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -543,7 +571,7 @@ TEST_F(SliceWriterSliceRelativeTest, Write_MultipleSmallWrites_SameBlock) {
 
   for (int i = 0; i < 4; ++i) {
     auto buf = MakeBuf(kSmallSize, 'A' + i);
-    ASSERT_TRUE(sw->Write(ctx_, buf.data(), kSmallSize, i * kSmallSize).ok());
+    ASSERT_TRUE(Write(sw, buf.data(), kSmallSize, i * kSmallSize).ok());
   }
   EXPECT_EQ(sw->Len(), static_cast<int32_t>(4 * kSmallSize));
 
@@ -581,8 +609,8 @@ TEST_F(SliceWriterSliceRelativeTest, Write_SmallWrites_CrossBoundary) {
 
   auto buf1 = MakeBuf(k3MB, 'X');
   auto buf2 = MakeBuf(k2MB, 'Y');
-  ASSERT_TRUE(sw->Write(ctx_, buf1.data(), k3MB, 0).ok());
-  ASSERT_TRUE(sw->Write(ctx_, buf2.data(), k2MB, k3MB).ok());
+  ASSERT_TRUE(Write(sw, buf1.data(), k3MB, 0).ok());
+  ASSERT_TRUE(Write(sw, buf2.data(), k2MB, k3MB).ok());
   EXPECT_EQ(sw->Len(), k3MB + k2MB);
 
   std::vector<uint32_t> captured_indices;
@@ -633,7 +661,7 @@ TEST_F(SliceWriterSliceRelativeTest, Flush_LastBlock_ActualSize) {
       .WillOnce(DoAll(SetArgPointee<2>(104u), Return(Status::OK())));
 
   auto buf = MakeBuf(kWriteSize);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), kWriteSize, kStartOffset).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), kWriteSize, kStartOffset).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -664,7 +692,7 @@ TEST_F(SliceWriterSliceRelativeTest, Write_SingleBlockLessThanBlockSize) {
       .WillOnce(DoAll(SetArgPointee<2>(105u), Return(Status::OK())));
 
   auto buf = MakeBuf(100, 'Z');
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 100, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 100, 0).ok());
   EXPECT_EQ(sw->Len(), 100);
 
   test::AsyncWaiter waiter;
@@ -687,12 +715,11 @@ TEST_F(SliceWriterSliceRelativeTest, Write_ReverseWrite_CheckFails) {
 
   // First write at offset 4MB (the starting chunk_offset).
   auto buf1 = MakeBuf(k4MB);
-  ASSERT_TRUE(sw->Write(ctx_, buf1.data(), k4MB, k4MB).ok());
+  ASSERT_TRUE(Write(sw, buf1.data(), k4MB, k4MB).ok());
 
   // Reverse write: [2MB, 4MB) prepends to the slice — target rejects this.
   auto buf2 = MakeBuf(2 * 1024 * 1024);
-  EXPECT_DEATH(sw->Write(ctx_, buf2.data(), 2 * 1024 * 1024, 2 * 1024 * 1024),
-               "");
+  EXPECT_DEATH(Write(sw, buf2.data(), 2 * 1024 * 1024, 2 * 1024 * 1024), "");
 }
 
 // Forward-gap write should be rejected: SliceWriter enforces
@@ -702,10 +729,10 @@ TEST_F(SliceWriterSliceRelativeTest, Write_ForwardGap_CheckFails) {
   auto sw = MakeSliceWriter(k4MB);
 
   auto buf1 = MakeBuf(k4MB);
-  ASSERT_TRUE(sw->Write(ctx_, buf1.data(), k4MB, k4MB).ok());
+  ASSERT_TRUE(Write(sw, buf1.data(), k4MB, k4MB).ok());
   // End() is now 8MB. Writing at 10MB leaves a 2MB hole -> reject.
   auto buf2 = MakeBuf(k4MB);
-  EXPECT_DEATH(sw->Write(ctx_, buf2.data(), k4MB, 10 * 1024 * 1024), "");
+  EXPECT_DEATH(Write(sw, buf2.data(), k4MB, 10 * 1024 * 1024), "");
 }
 
 // First Write at wrong starting offset should be rejected
@@ -716,7 +743,7 @@ TEST_F(SliceWriterSliceRelativeTest, Write_WrongStartOffset_CheckFails) {
 
   // Slice starts at 4MB; writing at 0 / 2MB / 6MB are all != End() -> reject.
   auto buf = MakeBuf(k4MB);
-  EXPECT_DEATH(sw->Write(ctx_, buf.data(), k4MB, 0), "");
+  EXPECT_DEATH(Write(sw, buf.data(), k4MB, 0), "");
 }
 
 // ChunkOffset() is const after construction: multiple forward writes never
@@ -731,7 +758,7 @@ TEST_F(SliceWriterSliceRelativeTest, ChunkOffset_StableAfterWrites) {
   int32_t off = kStart;
   for (int i = 0; i < 8; ++i) {
     auto buf = MakeBuf(k1MB, 'A' + i);
-    ASSERT_TRUE(sw->Write(ctx_, buf.data(), k1MB, off).ok());
+    ASSERT_TRUE(Write(sw, buf.data(), k1MB, off).ok());
     off += k1MB;
     EXPECT_EQ(sw->ChunkOffset(), kStart) << "after write " << i;
     EXPECT_EQ(sw->End(), off) << "after write " << i;
@@ -752,7 +779,7 @@ TEST_F(SliceWriterSliceRelativeTest, GetCommitSlice_CorrectFields) {
           [](ContextSPtr, PutReq, StatusCallback cb) { cb(Status::OK()); }));
 
   auto buf = MakeBuf(kWriteSize);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), kWriteSize, kStartOffset).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), kWriteSize, kStartOffset).ok());
 
   test::AsyncWaiter waiter;
   waiter.Expect(1);
@@ -819,6 +846,21 @@ class SliceWriterStreamingTest : public test::VFSTestBase {
     return std::vector<char>(size, val);
   }
 
+  Status Write(const SliceWriterPtr& writer, const char* buf, int32_t size,
+               int32_t chunk_offset) {
+    WriteMemPool* pool = mock_hub_->GetWriteMemPool();
+    const uint64_t page_size = pool->GetPageSize();
+    const size_t page_need =
+        static_cast<size_t>(((static_cast<uint64_t>(chunk_offset) % page_size) +
+                             static_cast<uint64_t>(size) + page_size - 1) /
+                            page_size);
+    WritePageLease lease;
+    Status status = pool->Acquire(page_need, &lease);
+    if (!status.ok()) return status;
+    writer->Write(ctx_, buf, size, chunk_offset, &lease);
+    return Status::OK();
+  }
+
   std::unique_ptr<TraceManager> trace_manager_;
   std::unique_ptr<SliceDataContext> context_;
 };
@@ -845,7 +887,7 @@ TEST_F(SliceWriterStreamingTest, UT1_FlushUpTo_OnlyFullBlocks) {
 
   // Write 10MB = 2 full blocks (4MB each) + 2MB partial
   auto buf = MakeBuf(10 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 10 * 1024 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 10 * 1024 * 1024, 0).ok());
   WaitCBExecutorIdle();
 
   // After Write: streaming uploaded block[0] and block[1]
@@ -905,7 +947,7 @@ TEST_F(SliceWriterStreamingTest, UT2_SliceId_DelayedArrival_CatchUp) {
 
   // Write 8MB = 2 full blocks. slice_id_==0, FlushUpTo skips.
   auto buf1 = MakeBuf(8 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf1.data(), 8 * 1024 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf1.data(), 8 * 1024 * 1024, 0).ok());
 
   {
     std::lock_guard<std::mutex> lk(mu);
@@ -919,8 +961,7 @@ TEST_F(SliceWriterStreamingTest, UT2_SliceId_DelayedArrival_CatchUp) {
   // Write 4MB more. FlushUpTo(12MB) catches up: block[0](end=4<=12),
   // block[1](end=8<=12), block[2](end=12<=12) — all uploaded.
   auto buf2 = MakeBuf(4 * 1024 * 1024);
-  ASSERT_TRUE(
-      sw->Write(ctx_, buf2.data(), 4 * 1024 * 1024, 8 * 1024 * 1024).ok());
+  ASSERT_TRUE(Write(sw, buf2.data(), 4 * 1024 * 1024, 8 * 1024 * 1024).ok());
   WaitCBExecutorIdle();
 
   {
@@ -964,7 +1005,7 @@ TEST_F(SliceWriterStreamingTest, UT3_UploadError_Propagation) {
 
   // Write 8MB = 2 blocks. block[0] OK, block[1] fails.
   auto buf = MakeBuf(8 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 8 * 1024 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 8 * 1024 * 1024, 0).ok());
   WaitCBExecutorIdle();
 
   test::AsyncWaiter waiter;
@@ -994,7 +1035,7 @@ TEST_F(SliceWriterStreamingTest, UT5_SmallFile_NoStreamingUpload) {
   WaitWriteBackgroundExecutorIdle();
 
   auto buf = MakeBuf(100 * 1024);  // 100KB
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 100 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 100 * 1024, 0).ok());
   WaitCBExecutorIdle();
 
   // No PutAsync during Write (len_ < block_size)
@@ -1038,7 +1079,7 @@ TEST_F(SliceWriterStreamingTest, UT6_MultipleWrites_StreamingOneByOne) {
   const int32_t kBSize = 4 * 1024 * 1024;
   for (int i = 0; i < 4; i++) {
     auto buf = MakeBuf(kBSize, 'A' + i);
-    ASSERT_TRUE(sw->Write(ctx_, buf.data(), kBSize, i * kBSize).ok());
+    ASSERT_TRUE(Write(sw, buf.data(), kBSize, i * kBSize).ok());
     WaitCBExecutorIdle();
     // Each Write should trigger exactly one streaming upload
     EXPECT_EQ(put_count.load(), i + 1) << "After Write #" << i;
@@ -1088,7 +1129,7 @@ TEST_F(SliceWriterStreamingTest, UT7_SliceId_PreallocFail_SyncFallback) {
 
   // Write 8MB = 2 blocks. FlushUpTo skips (alloc_failed).
   auto buf = MakeBuf(8 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 8 * 1024 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 8 * 1024 * 1024, 0).ok());
   WaitCBExecutorIdle();
 
   {
@@ -1138,7 +1179,7 @@ TEST_F(SliceWriterStreamingTest, UT8_SingleWrite_MultiBlockFlushUpTo) {
 
   // 10MB = 2 full blocks (4MB each) + 2MB partial
   auto buf = MakeBuf(10 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 10 * 1024 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 10 * 1024 * 1024, 0).ok());
   WaitCBExecutorIdle();
 
   {
@@ -1182,7 +1223,7 @@ TEST_F(SliceWriterStreamingTest, UT9_ConcurrentCallbacks_ThreadSafe) {
 
   // 20MB = 4 full blocks + 4MB partial. FlushUpTo uploads block[0..3].
   auto buf = MakeBuf(20 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 20 * 1024 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 20 * 1024 * 1024, 0).ok());
 
   // Wait for 4 PutAsync callbacks to be held
   while (true) {
@@ -1244,7 +1285,7 @@ TEST_F(SliceWriterStreamingTest, UT10_MixedStreamAndFlushResidual) {
 
   // 6MB = 1 full block (4MB) + 2MB partial
   auto buf = MakeBuf(6 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), 6 * 1024 * 1024, 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), 6 * 1024 * 1024, 0).ok());
   WaitCBExecutorIdle();
 
   // block[0] streamed during Write
@@ -1294,7 +1335,7 @@ TEST_F(SliceWriterStreamingTest, UT12_WaitingAllLateErrorPropagates) {
   WaitWriteBackgroundExecutorIdle();
 
   auto buf = MakeBuf(100 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), buf.size(), 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), buf.size(), 0).ok());
 
   test::AsyncWaiter flush_waiter;
   flush_waiter.Expect(1);
@@ -1349,7 +1390,7 @@ TEST_F(SliceWriterStreamingTest,
   WaitWriteBackgroundExecutorIdle();
 
   auto buf = MakeBuf(8 * 1024 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), buf.size(), 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), buf.size(), 0).ok());
 
   StatusCallback failed = take_callback(0);
   ASSERT_TRUE(static_cast<bool>(failed));
@@ -1401,7 +1442,7 @@ TEST_F(SliceWriterStreamingTest,
   std::weak_ptr<SliceWriter> weak_writer = sw;
   WaitWriteBackgroundExecutorIdle();
   auto buf = MakeBuf(100 * 1024);
-  ASSERT_TRUE(sw->Write(ctx_, buf.data(), buf.size(), 0).ok());
+  ASSERT_TRUE(Write(sw, buf.data(), buf.size(), 0).ok());
 
   test::AsyncWaiter callback_waiter;
   callback_waiter.Expect(1);

--- a/test/unit/client/vfs/data/test_write_pressure_controller.cc
+++ b/test/unit/client/vfs/data/test_write_pressure_controller.cc
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <string>
+
+#include "client/vfs/data/write_pressure_controller.h"
+#include "client/vfs/data/writer_table.h"
+#include "utils/executor/executor.h"
+
+namespace dingofs {
+namespace client {
+namespace vfs {
+namespace {
+
+class ManualExecutor final : public Executor {
+ public:
+  bool Start() override {
+    running_ = true;
+    return true;
+  }
+  bool Stop() override {
+    running_ = false;
+    return true;
+  }
+  bool Execute(std::function<void()> func) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!running_) return false;
+    if (reject_execute_once_) {
+      reject_execute_once_ = false;
+      return false;
+    }
+    tasks_.push_back(std::move(func));
+    return true;
+  }
+  bool Schedule(std::function<void()> func, int delay_ms) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!running_) return false;
+    tasks_.push_back(std::move(func));
+    return true;
+  }
+  int ThreadNum() const override { return 1; }
+  int TaskNum() const override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return static_cast<int>(tasks_.size());
+  }
+  std::string Name() const override { return "manual"; }
+
+  void RejectNextExecute() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    reject_execute_once_ = true;
+  }
+
+  void RunOne() {
+    std::function<void()> task;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      ASSERT_FALSE(tasks_.empty());
+      task = std::move(tasks_.front());
+      tasks_.pop_front();
+    }
+    task();
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  bool running_{false};
+  bool reject_execute_once_{false};
+  std::deque<std::function<void()>> tasks_;
+};
+
+TEST(WritePressureControllerTest, CoalescesEventsBeforeRoundRuns) {
+  WriterTable table(nullptr);
+  ASSERT_TRUE(table.Start().ok());
+  ManualExecutor executor;
+  ASSERT_TRUE(executor.Start());
+  WritePressureController controller(&table, &executor);
+
+  controller.OnWritePressure();
+  controller.OnWritePressure();
+  controller.OnWritePressure();
+  EXPECT_EQ(executor.TaskNum(), 1);
+
+  executor.RunOne();
+  EXPECT_EQ(executor.TaskNum(), 0);
+
+  controller.StopAndDrain();
+  controller.OnWritePressure();
+  EXPECT_EQ(executor.TaskNum(), 0);
+  table.Stop();
+}
+
+TEST(WritePressureControllerTest, RetriesFirstRejectedSubmit) {
+  WriterTable table(nullptr);
+  ASSERT_TRUE(table.Start().ok());
+  ManualExecutor executor;
+  ASSERT_TRUE(executor.Start());
+  executor.RejectNextExecute();
+  WritePressureController controller(&table, &executor);
+
+  controller.OnWritePressure();
+  ASSERT_EQ(executor.TaskNum(), 1) << "bounded retry must be scheduled";
+
+  executor.RunOne();
+  ASSERT_EQ(executor.TaskNum(), 1) << "retry must submit the flush round";
+  executor.RunOne();
+  EXPECT_EQ(executor.TaskNum(), 0);
+
+  controller.StopAndDrain();
+  table.Stop();
+}
+
+TEST(WritePressureControllerTest, StopWaitsForQueuedRoundToRetire) {
+  WriterTable table(nullptr);
+  ASSERT_TRUE(table.Start().ok());
+  ManualExecutor executor;
+  ASSERT_TRUE(executor.Start());
+  WritePressureController controller(&table, &executor);
+
+  controller.OnWritePressure();
+  ASSERT_EQ(executor.TaskNum(), 1);
+
+  auto stopped = std::async(std::launch::async, [&] {
+    controller.StopAndDrain();
+    return true;
+  });
+  EXPECT_EQ(stopped.wait_for(std::chrono::milliseconds(20)),
+            std::future_status::timeout);
+
+  executor.RunOne();
+  EXPECT_EQ(stopped.wait_for(std::chrono::seconds(1)),
+            std::future_status::ready);
+  EXPECT_TRUE(stopped.get());
+  table.Stop();
+}
+
+}  // namespace
+}  // namespace vfs
+}  // namespace client
+}  // namespace dingofs

--- a/test/unit/client/vfs/data/test_writer_table.cc
+++ b/test/unit/client/vfs/data/test_writer_table.cc
@@ -21,10 +21,14 @@
 #include <condition_variable>
 #include <future>
 #include <mutex>
+#include <utility>
+#include <vector>
 
+#include "client/vfs/data/write_pressure_controller.h"
 #include "client/vfs/data/writer/file_writer.h"
 #include "client/vfs/data/writer_table.h"
 #include "test/unit/client/vfs/test_base.h"
+#include "utils/executor/thread/executor_impl.h"
 
 namespace dingofs {
 namespace client {
@@ -161,6 +165,104 @@ TEST_F(WriterTableTest, FlushAll_ErrorDoesNotSkipRemainingWriters) {
   table_->ReleaseWriter(w2);
 }
 
+TEST_F(WriterTableTest, PressureFlushReturnsPagesAndUnblocksFifoWriter) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool tiny_pool(kPage, kPage);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(&tiny_pool));
+
+  ExecutorImpl pressure_executor("test_write_pressure", 1);
+  ASSERT_TRUE(pressure_executor.Start());
+  WritePressureController controller(table_.get(), &pressure_executor);
+  tiny_pool.SetPressureObserver(&controller);
+
+  FileWriter* first = table_->AcquireWriter(210);
+  FileWriter* second = table_->AcquireWriter(211);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+
+  std::vector<char> first_buf(kPage, 'a');
+  uint64_t first_written = 0;
+  ASSERT_TRUE(
+      first->Write(ctx_, first_buf.data(), first_buf.size(), 0, &first_written)
+          .ok());
+  ASSERT_EQ(first_written, first_buf.size());
+  ASSERT_EQ(tiny_pool.GetUsedBytes(), kPage);
+
+  std::vector<char> second_buf(kPage, 'b');
+  auto blocked_write = std::async(std::launch::async, [&] {
+    uint64_t written = 0;
+    Status status =
+        second->Write(ctx_, second_buf.data(), second_buf.size(), 0, &written);
+    return std::make_pair(status, written);
+  });
+
+  ASSERT_EQ(blocked_write.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+  auto [status, written] = blocked_write.get();
+  EXPECT_TRUE(status.ok()) << status.ToString();
+  EXPECT_EQ(written, second_buf.size());
+
+  ASSERT_TRUE(table_->FlushAll().ok());
+  tiny_pool.Close();
+  tiny_pool.SetPressureObserver(nullptr);
+  controller.StopAndDrain();
+  ASSERT_TRUE(pressure_executor.Stop());
+
+  table_->ReleaseWriter(first);
+  table_->ReleaseWriter(second);
+  EXPECT_EQ(tiny_pool.GetUsedBytes(), 0);
+}
+
+TEST_F(WriterTableTest, PressureFlushSeesPartialChunkBeforeNextAdmission) {
+  constexpr int64_t kPage = 4096;
+  constexpr uint64_t kChunk = 2 * kPage;
+  ON_CALL(*mock_hub_, GetFsInfo())
+      .WillByDefault(Return(test::MakeTestFsInfo(kChunk, kChunk)));
+
+  WriteMemPool tiny_pool(kChunk, kPage);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(&tiny_pool));
+
+  ExecutorImpl pressure_executor("test_write_pressure_cross_chunk", 1);
+  ASSERT_TRUE(pressure_executor.Start());
+  WritePressureController controller(table_.get(), &pressure_executor);
+  tiny_pool.SetPressureObserver(&controller);
+
+  FileWriter* writer = table_->AcquireWriter(212);
+  ASSERT_NE(writer, nullptr);
+
+  // The first page ends chunk 0 but leaves a partial slice, so ChunkWriter
+  // cannot trigger its full-chunk flush. Chunk 1 then needs both pool pages
+  // while only one is free and must rely on pressure flush for progress.
+  std::vector<char> buf(3 * kPage, 'x');
+  auto write = std::async(std::launch::async, [&] {
+    uint64_t written = 0;
+    Status status =
+        writer->Write(ctx_, buf.data(), buf.size(), kPage, &written);
+    return std::make_pair(status, written);
+  });
+
+  const auto completion = write.wait_for(std::chrono::seconds(1));
+  if (completion != std::future_status::ready) {
+    tiny_pool.Close();
+  }
+  EXPECT_EQ(completion, std::future_status::ready)
+      << "a completed partial chunk must become visible to pressure flush "
+         "before the next chunk waits for admission";
+
+  auto [status, written] = write.get();
+  EXPECT_TRUE(status.ok()) << status.ToString();
+  EXPECT_EQ(written, buf.size());
+
+  EXPECT_TRUE(writer->Flush().ok());
+  EXPECT_EQ(tiny_pool.GetUsedBytes(), 0);
+
+  tiny_pool.Close();
+  tiny_pool.SetPressureObserver(nullptr);
+  controller.StopAndDrain();
+  EXPECT_TRUE(pressure_executor.Stop());
+  table_->ReleaseWriter(writer);
+}
+
 TEST_F(WriterTableTest, FlushAllPinsWriterAgainstLastConcurrentRelease) {
   auto* w = table_->AcquireWriter(203);
   ASSERT_NE(w, nullptr);
@@ -234,7 +336,7 @@ TEST_F(WriterTableTest, ReleaseNullptr_NoOp) {
 // must not leave the table in an inconsistent state.
 TEST_F(WriterTableTest, Stop_Idempotent) {
   table_->Stop();
-  table_->Stop();   // second call must be safe
+  table_->Stop();  // second call must be safe
   EXPECT_EQ(table_->AcquireWriter(400), nullptr);
 }
 

--- a/test/unit/client/vfs/metasystem/test_mds_metasystem_flush.cc
+++ b/test/unit/client/vfs/metasystem/test_mds_metasystem_flush.cc
@@ -139,16 +139,19 @@ TEST(MDSMetaSystemFlushTest, FailedAttemptTerminatesCurrentFlush) {
   auto retry = std::async(std::launch::async,
                           [&]() { return metasystem.Flush(ctx, kIno, kFh); });
   const auto retry_deadline = std::chrono::steady_clock::now() + 1s;
-  while ((task->Retries() == 0 || task->WaiterCount() == 0) &&
+  while (task->Retries() == 0 &&
          std::chrono::steady_clock::now() < retry_deadline) {
     std::this_thread::yield();
   }
   ASSERT_EQ(task->Retries(), 1);
-  ASSERT_GT(task->WaiterCount(), 0);
 
-  MDSMetaSystemTestPeer::CompleteForCleanup(metasystem, kIno, task);
+  // No MDS is reachable in this unit test, so the retried write-slice bthread
+  // fails its RPC and the explicit Flush propagates that error.  Waiting on the
+  // future also joins the detached bthread: its SetDone is what unblocks
+  // AsyncFlushSlice's Wait, so the metasystem is never destroyed while the
+  // bthread still dereferences `this`.
   ASSERT_EQ(retry.wait_for(1s), std::future_status::ready);
-  EXPECT_TRUE(retry.get().ok());
+  EXPECT_FALSE(retry.get().ok());
 }
 
 TEST(MDSMetaSystemFlushTest, ConcurrentWriteDoesNotExtendActiveFlush) {

--- a/test/unit/client/vfs/mock/mock_meta_system.h
+++ b/test/unit/client/vfs/mock/mock_meta_system.h
@@ -55,6 +55,8 @@ class MockMetaSystem : public MetaSystem {
               (override));
   MOCK_METHOD(Status, Flush, (ContextSPtr ctx, Ino ino, uint64_t fh),
               (override));
+  MOCK_METHOD(Status, RollbackWriteLength,
+              (ContextSPtr ctx, Ino ino, uint64_t fh), (override));
   MOCK_METHOD(Status, Close, (ContextSPtr ctx, Ino ino, uint64_t fh),
               (override));
   MOCK_METHOD(Status, ReadSlice,

--- a/test/unit/client/vfs/test_base.h
+++ b/test/unit/client/vfs/test_base.h
@@ -196,12 +196,15 @@ class VFSTestBase : public ::testing::Test {
           return Status::OK();
         });
     ON_CALL(*mock_meta_system_, Flush).WillByDefault(Return(Status::OK()));
+    ON_CALL(*mock_meta_system_, RollbackWriteLength)
+        .WillByDefault(Return(Status::OK()));
     ON_CALL(*mock_meta_system_, Close).WillByDefault(Return(Status::OK()));
     ON_CALL(*mock_meta_system_, Open).WillByDefault(Return(Status::OK()));
     EXPECT_CALL(*mock_meta_system_, NewSliceId).Times(AnyNumber());
     EXPECT_CALL(*mock_meta_system_, WriteSlice).Times(AnyNumber());
     EXPECT_CALL(*mock_meta_system_, ReadSlice).Times(AnyNumber());
     EXPECT_CALL(*mock_meta_system_, Flush).Times(AnyNumber());
+    EXPECT_CALL(*mock_meta_system_, RollbackWriteLength).Times(AnyNumber());
     EXPECT_CALL(*mock_meta_system_, Close).Times(AnyNumber());
     EXPECT_CALL(*mock_meta_system_, Open).Times(AnyNumber());
 

--- a/test/unit/client/vfs/test_vfs_impl.cc
+++ b/test/unit/client/vfs/test_vfs_impl.cc
@@ -15,18 +15,26 @@
  */
 
 #include <fcntl.h>
+#include <gflags/gflags.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <condition_variable>
+#include <future>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "client/vfs/components/uid_gid_mapper.h"
+#include "client/vfs/data/write_pressure_controller.h"
+#include "client/vfs/data/writer/file_writer.h"
 #include "client/vfs/data/writer_table.h"
 #include "client/vfs/data_buffer.h"
+#include "client/vfs/hub/vfs_hub.h"
 #include "client/vfs/metasystem/mds/rpc.h"
 #include "client/vfs/vfs_impl.h"
 #include "common/blockaccess/accesser_common.h"
@@ -86,6 +94,79 @@ class FakePasswdSource : public PasswdSource {
 };
 
 }  // namespace
+
+TEST(VFSHubImplTest, StartRejectsMisalignedWritePageSize) {
+  constexpr uint32_t kMisalignedPageSize = 8 * 1024 * 1024;
+  const uint32_t previous_page_size = FLAGS_vfs_write_buffer_page_size;
+  FLAGS_vfs_write_buffer_page_size = kMisalignedPageSize;
+  auto restore_page_size = MakeScopedCleanup(
+      [&]() { FLAGS_vfs_write_buffer_page_size = previous_page_size; });
+
+  VFSConfig config;
+  config.fs_name = "write-page-geometry-test";
+  config.metasystem_type = MetaSystemType::MEMORY;
+  TraceManager trace_manager;
+  VFSHubImpl hub(config, ClientId(), trace_manager);
+
+  Status status = hub.Start(/*skip_mount=*/true);
+  EXPECT_TRUE(status.IsInvalidParam()) << status.ToString();
+  EXPECT_NE(
+      status.ToString().find("must be a multiple of write buffer page size"),
+      std::string::npos);
+}
+
+TEST(VFSHubImplTest, StartRejectsNonIntegralWritePoolCapacity) {
+  constexpr uint64_t kNonIntegralTotalMb = 65;
+  constexpr uint32_t kPageSize = 4 * 1024 * 1024;
+  const uint64_t previous_total_mb = FLAGS_vfs_write_buffer_total_mb;
+  const uint32_t previous_page_size = FLAGS_vfs_write_buffer_page_size;
+  FLAGS_vfs_write_buffer_total_mb = kNonIntegralTotalMb;
+  FLAGS_vfs_write_buffer_page_size = kPageSize;
+  auto restore_flags = MakeScopedCleanup([&]() {
+    FLAGS_vfs_write_buffer_total_mb = previous_total_mb;
+    FLAGS_vfs_write_buffer_page_size = previous_page_size;
+  });
+
+  VFSConfig config;
+  config.fs_name = "write-pool-geometry-test";
+  config.metasystem_type = MetaSystemType::MEMORY;
+  TraceManager trace_manager;
+  VFSHubImpl hub(config, ClientId(), trace_manager);
+
+  Status status = hub.Start(/*skip_mount=*/true);
+  EXPECT_TRUE(status.IsInvalidParam()) << status.ToString();
+  EXPECT_NE(status.ToString().find(
+                "write buffer total size (68157440) must be a multiple of "
+                "page size (4194304)"),
+            std::string::npos);
+}
+
+TEST(VFSHubImplTest, StartRejectsChunkLargerThanWritePoolCapacity) {
+  constexpr uint64_t kWriteBufferTotalMb = 32;
+  constexpr uint32_t kPageSize = 4 * 1024 * 1024;
+  const uint64_t previous_total_mb = FLAGS_vfs_write_buffer_total_mb;
+  const uint32_t previous_page_size = FLAGS_vfs_write_buffer_page_size;
+  FLAGS_vfs_write_buffer_total_mb = kWriteBufferTotalMb;
+  FLAGS_vfs_write_buffer_page_size = kPageSize;
+  auto restore_flags = MakeScopedCleanup([&]() {
+    FLAGS_vfs_write_buffer_total_mb = previous_total_mb;
+    FLAGS_vfs_write_buffer_page_size = previous_page_size;
+  });
+
+  VFSConfig config;
+  config.fs_name = "write-pool-chunk-capacity-test";
+  config.metasystem_type = MetaSystemType::MEMORY;
+  TraceManager trace_manager;
+  VFSHubImpl hub(config, ClientId(), trace_manager);
+
+  Status status = hub.Start(/*skip_mount=*/true);
+  EXPECT_TRUE(status.IsInvalidParam()) << status.ToString();
+  EXPECT_NE(status.ToString().find(
+                "filesystem chunk size (67108864) requires up to 16 write "
+                "buffer pages, exceeding write buffer capacity (8 pages, "
+                "33554432 bytes)"),
+            std::string::npos);
+}
 
 class VFSImplTest : public test::VFSTestBase {
  protected:
@@ -251,53 +332,6 @@ TEST_F(VFSImplTest, Write_RejectsOffsetAtLimitBeforeBuffering) {
   vfs_->Release(ctx_, kIno, fh);
 }
 
-// --- 4b. Write short-write: metadata gets out_wsize, not the requested size.
-// On a cross-chunk write where the page pool is exhausted after chunk0, the
-// writer short-writes; VFSImpl must extend the inode length by only the durable
-// prefix (MetaSystem::Write sets length to offset+len), else reads past the
-// prefix would see a phantom hole. ---
-TEST_F(VFSImplTest, Write_ShortWrite_MetaGetsOutWsizeNotSize) {
-  // Locals ordered so writer_table (and the writer it owns) is destroyed before
-  // `tiny`: vfs_->Release below already tears the writer down synchronously,
-  // but this keeps the ordering safe regardless.
-  auto tiny = std::make_unique<WriteMemPool>(4096, 4096);  // 1 page
-  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
-
-  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(tiny.get()));
-  EXPECT_CALL(*mock_hub_, GetWriteMemPool()).Times(AnyNumber());
-  ON_CALL(*mock_hub_, GetWriterTable())
-      .WillByDefault(Return(writer_table.get()));
-  EXPECT_CALL(*mock_hub_, GetWriterTable()).Times(AnyNumber());
-
-  const uint64_t ino = 300;
-  ON_CALL(*mock_meta_system_, Open(_, ino, _, _, _))
-      .WillByDefault(Return(Status::OK()));
-  ON_CALL(*mock_meta_system_, Close(_, ino, _))
-      .WillByDefault(Return(Status::OK()));
-
-  uint64_t fh = 0;
-  ASSERT_TRUE(vfs_->Open(ctx_, ino, O_WRONLY, &fh, nullptr).ok());
-
-  // Capture the size MetaSystem::Write receives (arg index 4).
-  uint64_t meta_size = 0;
-  EXPECT_CALL(*mock_meta_system_, Write(_, ino, _, _, _, _))
-      .WillOnce(DoAll(SaveArg<4>(&meta_size), Return(Status::OK())));
-
-  const uint64_t chunk_size = mock_hub_->GetFsInfo().chunk_size;
-  const uint64_t offset = chunk_size - 4;  // 4 bytes chunk0, 4 bytes chunk1
-  std::vector<char> buf(8, 'X');
-  uint64_t wsize = 0;
-  Status s = vfs_->Write(ctx_, ino, buf.data(), buf.size(), offset, fh, &wsize);
-
-  EXPECT_TRUE(s.ok()) << s.ToString();
-  EXPECT_EQ(wsize, 4u);
-  EXPECT_EQ(meta_size, 4u)
-      << "metadata must extend by out_wsize (4), not the requested size (8)";
-
-  // Synchronously releases the handle -> writer -> frees pages into `tiny`.
-  vfs_->Release(ctx_, ino, fh);
-}
-
 // --- 4c. Metadata write fails after the data was already buffered. The writer
 // accepts the full write (out_wsize == size, data now dirty in its buffer), but
 // the inode metadata update fails, so VFSImpl::Write returns the error. The
@@ -334,6 +368,189 @@ TEST_F(VFSImplTest, Write_MetaWriteFails_ReturnsErrorAfterDataBuffered) {
                                   "metadata failed (data buffered)";
 
   vfs_->Release(ctx_, ino, fh);
+}
+
+// --- 4d. Cross-chunk write whose second chunk blocks on write-pool pressure
+// and whose pressure flush then fails asynchronously. Covers the full chain:
+// VFSImpl::Write -> FileWriter chunk loop (prefix chunk completes and
+// publishes its dirty generation) -> FIFO admission blocks the next chunk ->
+// real pressure chain (pool -> observer -> controller -> WriterTable) flushes
+// the dirty chunk -> block upload fails -> POSIX short write: Status OK with
+// out_wsize == completed prefix only. The unfinished chunk must never upload
+// or commit slice/metadata, the failure must be sticky for later Write/Flush,
+// and after Release every write-pool page, FIFO waiter, and pressure callback
+// must be drained. ---
+TEST_F(VFSImplTest, Write_PressureFlushFails_CrossChunkWriteReturnsShortWrite) {
+  // Geometry: 4KB pages, 8KB blocks, 16KB chunks, and a 4-page pool. A donor
+  // writer pins 2 pages with one sub-block write (6144 < 8192, so nothing
+  // streams and no page returns early). The cross-chunk write needs 1 page
+  // for the chunk-0 tail (granted, published) and 3 pages for the chunk-1
+  // head (blocked with 1 page free -> pressure).
+  constexpr int64_t kPage = 4096;
+  constexpr uint64_t kChunk = 4 * kPage;
+  constexpr uint64_t kBlock = 2 * kPage;
+  constexpr int64_t kPoolPages = 4;
+  constexpr uint64_t kPrefixSize = 2048;       // chunk-0 tail, 1 page
+  constexpr uint64_t kSuffixSize = 3 * kPage;  // chunk-1 head, 3 pages
+  constexpr uint64_t kCrossOffset = kChunk - kPrefixSize;
+  constexpr Ino kIno = 601;
+  constexpr Ino kInoDonor = 600;
+
+  gflags::FlagSaver flag_saver;
+  FLAGS_vfs_periodic_flush_interval_ms =
+      3600 * 1000;  // keep periodic flush out
+
+  // Local table + tiny pool + the real pressure-controller chain.
+  auto writer_table = std::make_unique<WriterTable>(mock_hub_);
+  ASSERT_TRUE(writer_table->Start().ok());
+  ON_CALL(*mock_hub_, GetWriterTable())
+      .WillByDefault(Return(writer_table.get()));
+  ON_CALL(*mock_hub_, GetFsInfo())
+      .WillByDefault(Return(test::MakeTestFsInfo(kChunk, kBlock)));
+
+  WriteMemPool tiny_pool(kPoolPages * kPage, kPage);
+  ON_CALL(*mock_hub_, GetWriteMemPool()).WillByDefault(Return(&tiny_pool));
+
+  ExecutorImpl pressure_executor("test_pressure_flush_fail", 1);
+  ASSERT_TRUE(pressure_executor.Start());
+  WritePressureController controller(writer_table.get(), &pressure_executor);
+  tiny_pool.SetPressureObserver(&controller);
+
+  // Every block upload completes inline with the same error (deterministic,
+  // no background timing). The cv turns "the pressure round reached the data
+  // plane" into an event the test can wait for.
+  std::mutex put_mutex;
+  std::condition_variable put_cv;
+  int put_async_calls = 0;
+  const Status kUploadError = Status::IoError("block store down");
+  ON_CALL(*mock_block_store_, PutAsync)
+      .WillByDefault([&](ContextSPtr, PutReq, StatusCallback cb) {
+        {
+          std::lock_guard<std::mutex> lock(put_mutex);
+          ++put_async_calls;
+        }
+        put_cv.notify_all();
+        cb(kUploadError);
+      });
+
+  ON_CALL(*mock_meta_system_, Open(_, kIno, _, _, _))
+      .WillByDefault(Return(Status::OK()));
+  ON_CALL(*mock_meta_system_, Close(_, kIno, _))
+      .WillByDefault(Return(Status::OK()));
+  // A failed flush must not commit slices -- in particular never for the
+  // unfinished chunk 1.
+  EXPECT_CALL(*mock_meta_system_, WriteSlice(_, _, _, _, _)).Times(0);
+
+  uint64_t fh = 0;
+  ASSERT_TRUE(vfs_->Open(ctx_, kIno, O_WRONLY, &fh, nullptr).ok());
+  // Metadata must record exactly the accepted prefix (WillOnce: exactly one
+  // call, with the short count as its size).
+  EXPECT_CALL(*mock_meta_system_,
+              Write(_, kIno, _, kCrossOffset, kPrefixSize, _))
+      .WillOnce(Return(Status::OK()));
+  EXPECT_CALL(*mock_meta_system_, RollbackWriteLength(_, kIno, fh))
+      .Times(2)
+      .WillRepeatedly(Return(Status::OK()));
+
+  // Donor writer: standalone (NOT in WriterTable). The pressure round waits
+  // for every table writer, so a table resident would stop StopAndDrain from
+  // proving the sticky status landed. It holds 2 dirty pages until the test
+  // explicitly fails its flush below.
+  auto* donor = new FileWriter(mock_hub_, kInoDonor);
+  donor->AcquireRef();
+  ASSERT_TRUE(donor->Open().ok());
+  std::vector<char> donor_buf(6144, 'd');
+  uint64_t donor_wsize = 0;
+  ASSERT_TRUE(
+      donor->Write(ctx_, donor_buf.data(), donor_buf.size(), 0, &donor_wsize)
+          .ok());
+  ASSERT_EQ(donor_wsize, donor_buf.size());
+  ASSERT_EQ(tiny_pool.GetUsedBytes(), 2 * kPage);
+
+  // The cross-chunk write under test.
+  std::vector<char> cross_buf(kPrefixSize + kSuffixSize, 'x');
+  auto write_result = std::async(std::launch::async, [&] {
+    uint64_t wsize = 0;
+    Status s = vfs_->Write(ctx_, kIno, cross_buf.data(), cross_buf.size(),
+                           kCrossOffset, fh, &wsize);
+    return std::make_pair(s, wsize);
+  });
+
+  // Phase 1: the pressure round flushed the blocked writer's dirty chunk 0
+  // and its upload failed. Waiting on the PutAsync event proves the pool ->
+  // observer -> controller -> WriterTable chain reached the data plane (the
+  // wait is bounded only as a deadlock guard; Close keeps the failing path
+  // tear-down-safe, mirroring the writer-table pressure tests).
+  bool round_reached_data_plane = false;
+  {
+    std::unique_lock<std::mutex> lock(put_mutex);
+    round_reached_data_plane = put_cv.wait_for(
+        lock, std::chrono::seconds(5), [&] { return put_async_calls >= 1; });
+  }
+  if (!round_reached_data_plane) tiny_pool.Close();
+  EXPECT_TRUE(round_reached_data_plane)
+      << "pressure round never flushed the dirty chunk-0 prefix";
+
+  // Phase 2: retire the round (and any coalesced follow-up round). The round
+  // callback runs strictly after FileWriter::FileFlushTaskDone called
+  // SetStatusIfBroken on the same thread, so returning here proves the sticky
+  // error is published while the write is still blocked: chunk-0's released
+  // page alone (2 free of 3 needed) cannot grant the FIFO waiter yet.
+  controller.StopAndDrain();
+
+  // Phase 3: fail the donor's flush. Its 2 pages return inside the upload
+  // completion on the single-threaded callback executor, which grants the
+  // blocked write before this synchronous Flush returns. The freshly granted
+  // lease must observe the sticky error and bail out without touching
+  // chunk 1 (the unused pages go back through the lease).
+  Status donor_flush_status = donor->Flush();
+  ASSERT_TRUE(donor_flush_status.IsIoError()) << donor_flush_status.ToString();
+  EXPECT_EQ(donor_flush_status.ToString(), kUploadError.ToString());
+
+  ASSERT_EQ(write_result.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+  auto [write_status, wsize] = write_result.get();
+  EXPECT_TRUE(write_status.ok()) << write_status.ToString();
+  EXPECT_EQ(wsize, kPrefixSize) << "short write: only the completed prefix";
+
+  // Sticky error: a later write fast-fails with zero bytes ...
+  char again = 'y';
+  uint64_t again_wsize = 12345;  // poison: fast-fail must reset it to 0
+  Status again_s =
+      vfs_->Write(ctx_, kIno, &again, 1, /*offset=*/0, fh, &again_wsize);
+  EXPECT_TRUE(again_s.IsIoError()) << again_s.ToString();
+  EXPECT_EQ(again_s.ToString(), kUploadError.ToString());
+  EXPECT_EQ(again_wsize, 0u);
+
+  // ... and Flush surfaces the original writeback failure, triggers length
+  // rollback, and does not retry uploads.
+  Status flush_s = vfs_->Flush(ctx_, kIno, fh);
+  EXPECT_TRUE(flush_s.IsIoError()) << flush_s.ToString();
+  EXPECT_EQ(flush_s.ToString(), kUploadError.ToString());
+
+  // Release triggers the second rollback and returns the same sticky failure,
+  // but the handle must still go away and the writer leave the table.
+  Status release_s = vfs_->Release(ctx_, kIno, fh);
+  EXPECT_TRUE(release_s.IsIoError()) << release_s.ToString();
+  EXPECT_EQ(release_s.ToString(), kUploadError.ToString());
+  EXPECT_EQ(writer_table->Size(), 0u);
+
+  donor->Close();
+  donor->ReleaseRef();
+
+  // Pool drained: pages returned, no queued FIFO waiter, no in-flight
+  // pressure callback (SetPressureObserver(nullptr) waits for them). Two
+  // uploads total means chunk 1 never uploaded a block.
+  EXPECT_EQ(tiny_pool.GetUsedBytes(), 0);
+  EXPECT_FALSE(tiny_pool.IsPressured());
+  {
+    std::lock_guard<std::mutex> lock(put_mutex);
+    EXPECT_EQ(put_async_calls, 2) << "chunk 1 must never upload a block";
+  }
+  tiny_pool.Close();
+  tiny_pool.SetPressureObserver(nullptr);
+  controller.StopAndDrain();
+  ASSERT_TRUE(pressure_executor.Stop());
 }
 
 // --- 5. GetAttr on .stats inode returns virtual attr ---

--- a/test/unit/common/test_logging.cc
+++ b/test/unit/common/test_logging.cc
@@ -62,12 +62,13 @@ TEST(DirectoryTest, GetBaseDirHonorsEnvOverride) {
   ::unsetenv("DINGOFS_BASE_DIR");
 }
 
-TEST(DirectoryTest, GetBaseDirFallsBackToHomeWhenEnvUnset) {
+TEST(DirectoryTest, GetBaseDirUsesUidSpecificDefaultWhenEnvUnset) {
   ::unsetenv("DINGOFS_BASE_DIR");
   if (::getuid() == 0) {
-    GTEST_SKIP() << "root falls back to /var/dingofs, not $HOME";
+    EXPECT_EQ(GetBaseDir(), "/var/dingo");
+  } else {
+    EXPECT_EQ(GetBaseDir(), Helper::GetHomeDir() + "/.dingo");
   }
-  EXPECT_EQ(GetBaseDir(), Helper::GetHomeDir() + "/.dingofs");
 }
 
 TEST(DirectoryTest, GetDefaultDirAppendsSubDir) {

--- a/test/unit/common/writemempool/test_write_mem_pool.cc
+++ b/test/unit/common/writemempool/test_write_mem_pool.cc
@@ -18,6 +18,10 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -25,7 +29,67 @@
 
 namespace dingofs {
 
-// ─── WriteMemPool ──────────────────────────────────────────────────────
+class WriteMemPoolTestPeer {
+ public:
+  static char* RemovePhysicalPage(WriteMemPool* pool) {
+    char* page = nullptr;
+    CHECK_EQ(pool->page_pool_->RequireBatch(&page, 1), 1);
+    return page;
+  }
+
+  static void ReturnPhysicalPage(WriteMemPool* pool, char* page) {
+    pool->page_pool_->ReleaseBatch(&page, 1);
+  }
+};
+namespace {
+
+using namespace std::chrono_literals;
+
+class CountingObserver : public WritePressureObserver {
+ public:
+  void OnWritePressure() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++event_count_;
+    cv_.notify_all();
+  }
+
+  bool WaitForEvent() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, 5s, [this] { return event_count_ != 0; });
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  int event_count_{0};
+};
+
+class BlockingObserver : public WritePressureObserver {
+ public:
+  void OnWritePressure() override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    entered_ = true;
+    cv_.notify_all();
+    cv_.wait(lock, [this] { return released_; });
+  }
+
+  bool WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, 5s, [this] { return entered_; });
+  }
+
+  void Release() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    released_ = true;
+    cv_.notify_all();
+  }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool entered_{false};
+  bool released_{false};
+};
 
 TEST(WriteMemPoolDeathTest, RejectsZeroPageSizeBeforeDivision) {
   EXPECT_DEATH({ WriteMemPool pool(4096, 0); }, "page_size > 0");
@@ -39,152 +103,220 @@ TEST(WriteMemPoolDeathTest, RejectsNonIntegralPageCapacity) {
   EXPECT_DEATH({ WriteMemPool pool(10 * 1024, 4096); }, "exact multiple");
 }
 
-TEST(WriteMemPoolTest, DeAllocateBatch_DecreasesUsed) {
-  constexpr int64_t kPageSize = 4096;
-  WriteMemPool mgr(kPageSize * 4, kPageSize);
+TEST(WriteMemPoolTest, GeometryAndLeaseAccounting) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(kPage * 4, kPage);
+  EXPECT_EQ(pool.GetPageSize(), kPage);
+  EXPECT_EQ(pool.GetTotalBytes(), kPage * 4);
+  EXPECT_EQ(pool.BufferCount(), 4);
+  EXPECT_EQ(pool.TotalSize(), kPage * 4);
+  EXPECT_NE(pool.BaseAddr(), nullptr);
 
+  {
+    WritePageLease lease;
+    ASSERT_TRUE(pool.Acquire(2, &lease).ok());
+    EXPECT_EQ(lease.Size(), 2);
+    EXPECT_EQ(pool.GetUsedBytes(), kPage * 2);
+  }
+  EXPECT_EQ(pool.GetUsedBytes(), 0);
+}
+
+TEST(WriteMemPoolTest, TakeTransfersPageOwnership) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(kPage * 2, kPage);
   char* page = nullptr;
-  ASSERT_EQ(mgr.TryAllocateBatch(1, &page), 1);
-  EXPECT_EQ(mgr.GetUsedBytes(), kPageSize);
-
-  mgr.DeAllocateBatch(&page, 1);
-  EXPECT_EQ(mgr.GetUsedBytes(), 0);
+  {
+    WritePageLease lease;
+    ASSERT_TRUE(pool.Acquire(1, &lease).ok());
+    lease.Take(1, &page);
+    EXPECT_TRUE(lease.Empty());
+  }
+  EXPECT_EQ(pool.GetUsedBytes(), kPage);
+  pool.Release(&page, 1);
+  EXPECT_EQ(pool.GetUsedBytes(), 0);
 }
 
-TEST(WriteMemPoolTest, GetPageSize_GetTotalBytes) {
-  constexpr int64_t kPageSize = 8192;
-  constexpr int64_t kTotal = kPageSize * 8;
-  WriteMemPool mgr(kTotal, kPageSize);
+TEST(WriteMemPoolTest, RemovingObserverWaitsForInFlightNotification) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(kPage, kPage);
+  BlockingObserver observer;
+  pool.SetPressureObserver(&observer);
 
-  EXPECT_EQ(mgr.GetPageSize(), kPageSize);
-  EXPECT_EQ(mgr.GetTotalBytes(), kTotal);
-  EXPECT_NE(mgr.BaseAddr(), nullptr);
-  EXPECT_EQ(mgr.BufferSize(), kPageSize);
-  EXPECT_EQ(mgr.BufferCount(), 8);
-  EXPECT_EQ(mgr.TotalSize(), kTotal);
+  WritePageLease held;
+  ASSERT_TRUE(pool.Acquire(1, &held).ok());
+  auto blocked = std::async(std::launch::async, [&] {
+    WritePageLease lease;
+    return pool.Acquire(1, &lease);
+  });
+  if (!observer.WaitUntilEntered()) {
+    observer.Release();
+    pool.Close();
+    FAIL() << "pressure notification did not start";
+  }
+
+  std::promise<void> unregister_started;
+  auto unregister = std::async(std::launch::async, [&] {
+    unregister_started.set_value();
+    pool.SetPressureObserver(nullptr);
+  });
+  unregister_started.get_future().wait();
+  EXPECT_EQ(unregister.wait_for(50ms), std::future_status::timeout);
+
+  observer.Release();
+  EXPECT_EQ(unregister.wait_for(5s), std::future_status::ready);
+  unregister.get();
+
+  pool.Close();
+  EXPECT_TRUE(blocked.get().IsStop());
 }
 
-TEST(WriteMemPoolTest, IsHighPressure_True_WhenAboveThreshold) {
-  constexpr int64_t kPageSize = 1024;
-  // 2 pages total; allocate 2 to hit 100% usage
-  WriteMemPool mgr(kPageSize * 2, kPageSize);
+TEST(WriteMemPoolTest, TryAcquireIsExactAndDoesNotBypassWaiter) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(kPage * 2, kPage);
+  CountingObserver observer;
+  pool.SetPressureObserver(&observer);
 
-  std::array<char*, 2> pages{};
-  ASSERT_EQ(mgr.TryAllocateBatch(pages.size(), pages.data()), pages.size());
+  WritePageLease held;
+  ASSERT_TRUE(pool.Acquire(2, &held).ok());
 
-  EXPECT_TRUE(mgr.IsHighPressure());
+  auto blocked = std::async(std::launch::async, [&] {
+    WritePageLease lease;
+    return pool.Acquire(2, &lease);
+  });
+  ASSERT_TRUE(observer.WaitForEvent());
 
-  mgr.DeAllocateBatch(pages.data(), pages.size());
+  WritePageLease opportunistic;
+  Status s = pool.TryAcquire(1, &opportunistic);
+  EXPECT_TRUE(s.IsNotFit()) << s.ToString();
+
+  held = WritePageLease();
+  EXPECT_TRUE(blocked.get().ok());
+  pool.SetPressureObserver(nullptr);
 }
 
-TEST(WriteMemPoolTest, Concurrent_AllocAndDealloc_FinalZero) {
-  constexpr int kThreads = 4;
-  constexpr int kIters = 200;
-  constexpr int64_t kPageSize = 4096;
+TEST(WriteMemPoolTest, FifoHeadIsNotBypassedBySmallerRequest) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(kPage * 3, kPage);
+  CountingObserver observer;
+  pool.SetPressureObserver(&observer);
 
-  WriteMemPool mgr(static_cast<int64_t>(kThreads) * kIters * kPageSize,
-                   kPageSize);
+  WritePageLease initial;
+  ASSERT_TRUE(pool.Acquire(3, &initial).ok());
+  std::array<char*, 3> pages{};
+  initial.Take(pages.size(), pages.data());
+
+  std::promise<void> first_acquired;
+  auto first_acquired_future = first_acquired.get_future();
+  std::promise<void> release_first;
+  auto release_first_future = release_first.get_future();
+  auto first = std::async(std::launch::async, [&] {
+    WritePageLease lease;
+    Status s = pool.Acquire(2, &lease);
+    first_acquired.set_value();
+    release_first_future.wait();
+    return s;
+  });
+  ASSERT_TRUE(observer.WaitForEvent());
+
+  auto second = std::async(std::launch::async, [&] {
+    WritePageLease lease;
+    return pool.Acquire(1, &lease);
+  });
+
+  pool.Release(pages.data(), 1);
+  EXPECT_EQ(second.wait_for(50ms), std::future_status::timeout);
+
+  pool.Release(pages.data() + 1, 1);
+  ASSERT_EQ(first_acquired_future.wait_for(5s), std::future_status::ready);
+  EXPECT_EQ(second.wait_for(50ms), std::future_status::timeout);
+  release_first.set_value();
+  EXPECT_TRUE(first.get().ok());
+  EXPECT_TRUE(second.get().ok());
+
+  pool.Release(pages.data() + 2, 1);
+  pool.SetPressureObserver(nullptr);
+}
+
+TEST(WriteMemPoolTest, CloseWakesQueuedAcquireAndRejectsNewAdmission) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(kPage, kPage);
+  CountingObserver observer;
+  pool.SetPressureObserver(&observer);
+  WritePageLease held;
+  ASSERT_TRUE(pool.Acquire(1, &held).ok());
+
+  auto blocked = std::async(std::launch::async, [&] {
+    WritePageLease lease;
+    return pool.Acquire(1, &lease);
+  });
+  ASSERT_TRUE(observer.WaitForEvent());
+  pool.Close();
+
+  Status waiting = blocked.get();
+  EXPECT_TRUE(waiting.IsStop()) << waiting.ToString();
+  WritePageLease rejected;
+  EXPECT_TRUE(pool.Acquire(1, &rejected).IsStop());
+}
+
+TEST(WriteMemPoolTest, OversizedRequestsFailWithoutQueueing) {
+  WriteMemPool pool(2 * 4096, 4096);
+  WritePageLease lease;
+  EXPECT_TRUE(pool.Acquire(3, &lease).IsNoSpace());
+  EXPECT_TRUE(pool.TryAcquire(3, &lease).IsNotFit());
+  EXPECT_FALSE(pool.IsPressured());
+}
+
+TEST(WriteMemPoolTest, ConcurrentAcquireAndReleaseReturnsToZero) {
+  constexpr int kThreads = 16;
+  constexpr int kIterations = 2000;
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(kThreads * kPage, kPage);
 
   std::vector<std::thread> threads;
-  threads.reserve(kThreads);
-  for (int t = 0; t < kThreads; ++t) {
-    threads.emplace_back([&mgr]() {
-      for (int i = 0; i < kIters; ++i) {
-        char* page = nullptr;
-        const size_t count = mgr.TryAllocateBatch(1, &page);
-        mgr.DeAllocateBatch(&page, count);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&] {
+      for (int j = 0; j < kIterations; ++j) {
+        WritePageLease lease;
+        Status status = pool.Acquire(1, &lease);
+        ASSERT_TRUE(status.ok()) << status.ToString();
       }
     });
   }
-  for (auto& th : threads) {
-    th.join();
-  }
-
-  EXPECT_EQ(mgr.GetUsedBytes(), 0);
+  for (auto& thread : threads) thread.join();
+  EXPECT_EQ(pool.GetUsedBytes(), 0);
 }
 
-// ─── TryAllocateBatch ──────────────────────────────────────────────────
-
-TEST(WriteMemPoolTest, TryAllocateBatch_ReturnsPage_IncreasesUsed) {
-  constexpr int64_t kPageSize = 4096;
-  WriteMemPool mgr(kPageSize * 4, kPageSize);
-
-  char* page = nullptr;
-  ASSERT_EQ(mgr.TryAllocateBatch(1, &page), 1);
-  EXPECT_EQ(mgr.GetUsedBytes(), kPageSize);
-
-  mgr.DeAllocateBatch(&page, 1);
-  EXPECT_EQ(mgr.GetUsedBytes(), 0);
-}
-
-TEST(WriteMemPoolTest, TryAllocateBatch_ReturnsShort_WhenExhausted_NoBlock) {
-  constexpr int64_t kPageSize = 4096;
-  WriteMemPool mgr(kPageSize * 2, kPageSize);  // 2 slots
-
+TEST(WriteMemPoolTest, ReleaseAfterCloseRestoresAccounting) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(2 * kPage, kPage);
+  WritePageLease lease;
+  ASSERT_TRUE(pool.Acquire(2, &lease).ok());
   std::array<char*, 2> pages{};
-  ASSERT_EQ(mgr.TryAllocateBatch(pages.size(), pages.data()), pages.size());
+  lease.Take(pages.size(), pages.data());
 
-  // Pool drained -- TryAllocateBatch returns immediately (no bounded wait) and
-  // used stays at capacity (a short result must not bump used_pages_).
-  char* extra = nullptr;
-  EXPECT_EQ(mgr.TryAllocateBatch(1, &extra), 0);
-  EXPECT_EQ(mgr.GetUsedBytes(), 2 * kPageSize);
+  pool.Close();
+  pool.Release(pages.data(), pages.size());
 
-  mgr.DeAllocateBatch(pages.data(), pages.size());
+  EXPECT_EQ(pool.GetUsedBytes(), 0);
+  WritePageLease rejected;
+  EXPECT_TRUE(pool.TryAcquire(1, &rejected).IsStop());
 }
 
-TEST(WriteMemPoolTest, EmptyBatchIsNoOp) {
-  constexpr int64_t kPageSize = 4096;
-  WriteMemPool mgr(kPageSize * 2, kPageSize);
+TEST(WriteMemPoolTest, StablePhysicalShortBreaksPool) {
+  constexpr int64_t kPage = 4096;
+  WriteMemPool pool(2 * kPage, kPage);
+  char* stolen = WriteMemPoolTestPeer::RemovePhysicalPage(&pool);
 
-  EXPECT_EQ(mgr.TryAllocateBatch(0, nullptr), 0);
-  mgr.DeAllocateBatch(nullptr, 0);
-  EXPECT_EQ(mgr.GetUsedBytes(), 0);
+  WritePageLease lease;
+  Status status = pool.Acquire(2, &lease);
+  EXPECT_TRUE(status.IsInternal()) << status.ToString();
+  EXPECT_TRUE(lease.Empty());
+  EXPECT_EQ(pool.GetUsedBytes(), 0);
+
+  WritePageLease rejected;
+  EXPECT_TRUE(pool.Acquire(1, &rejected).IsInternal());
+  WriteMemPoolTestPeer::ReturnPhysicalPage(&pool, stolen);
 }
 
-TEST(WriteMemPoolTest, CrossThreadBatchAccountingReturnsToZero) {
-  constexpr int64_t kPageSize = 4096;
-  constexpr size_t kMaxBatch = 64;
-  constexpr int kIterations = 2000;
-  constexpr std::array<size_t, 3> kBatchSizes = {1, 16, 64};
-  WriteMemPool mgr(kPageSize * 256, kPageSize);
-
-  struct TransferSlot {
-    // 0: producer may allocate; 1: releaser owns the returned prefix.
-    std::atomic<uint32_t> state{0};
-    size_t count{0};
-    std::array<char*, kMaxBatch> pages{};
-  } slot;
-  std::atomic<bool> short_allocation{false};
-
-  std::thread producer([&]() {
-    for (int iteration = 0; iteration < kIterations; ++iteration) {
-      while (slot.state.load(std::memory_order_acquire) != 0) {
-        std::this_thread::yield();
-      }
-      const size_t requested =
-          kBatchSizes[iteration % kBatchSizes.size()];
-      slot.count = mgr.TryAllocateBatch(requested, slot.pages.data());
-      if (slot.count != requested) {
-        short_allocation.store(true, std::memory_order_relaxed);
-      }
-      slot.state.store(1, std::memory_order_release);
-    }
-  });
-  std::thread releaser([&]() {
-    for (int iteration = 0; iteration < kIterations; ++iteration) {
-      while (slot.state.load(std::memory_order_acquire) != 1) {
-        std::this_thread::yield();
-      }
-      mgr.DeAllocateBatch(slot.pages.data(), slot.count);
-      slot.state.store(0, std::memory_order_release);
-    }
-  });
-
-  producer.join();
-  releaser.join();
-  EXPECT_FALSE(short_allocation.load(std::memory_order_relaxed));
-  EXPECT_EQ(mgr.GetUsedBytes(), 0);
-}
-
+}  // namespace
 }  // namespace dingofs

--- a/test/unit/common/writemempool/test_write_page_pool.cc
+++ b/test/unit/common/writemempool/test_write_page_pool.cc
@@ -287,7 +287,7 @@ TEST(WritePagePoolTest, ConcurrentBatchReleasePreservesAllPages) {
   EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
 }
 
-TEST(WritePagePoolTest, CrossThreadAllocateAndReleasePreservesInventory) {
+TEST(WritePagePoolTest, ExactCrossThreadAllocateAndReleasePreservesInventory) {
   constexpr size_t kPageSize = 64;
   constexpr size_t kPageCount = 4096;
   constexpr size_t kPairs = 2;
@@ -318,7 +318,7 @@ TEST(WritePagePoolTest, CrossThreadAllocateAndReleasePreservesInventory) {
         }
         const size_t requested =
             kBatchSizes[(iteration + pair) % kBatchSizes.size()];
-        slot.count = pool->RequireBatch(slot.pages.data(), requested);
+        slot.count = pool->RequireBatchExact(slot.pages.data(), requested);
         if (slot.count != requested) {
           short_allocation.store(true, std::memory_order_relaxed);
         }
@@ -339,6 +339,23 @@ TEST(WritePagePoolTest, CrossThreadAllocateAndReleasePreservesInventory) {
   for (auto& worker : workers) worker.join();
 
   EXPECT_FALSE(short_allocation.load(std::memory_order_relaxed));
+  EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
+}
+
+TEST(WritePagePoolTest, ExactReportsStableShortAfterQuiesce) {
+  constexpr size_t kPageCount = 16;
+  auto pool = WritePagePool::Create(/*page_size=*/64, kPageCount);
+  ASSERT_NE(pool, nullptr);
+
+  std::array<char*, kPageCount - 1> held{};
+  ASSERT_EQ(pool->RequireBatch(held.data(), held.size()), held.size());
+
+  std::array<char*, 2> exact{};
+  const size_t acquired = pool->RequireBatchExact(exact.data(), exact.size());
+  ASSERT_EQ(acquired, 1);
+
+  pool->ReleaseBatch(exact.data(), acquired);
+  pool->ReleaseBatch(held.data(), held.size());
   EXPECT_EQ(WritePagePoolTestPeer::FreePages(pool.get()), kPageCount);
 }
 


### PR DESCRIPTION
## What

- replace partial write-pool allocation with exact `WritePageLease` admission
- acquire write pages before entering `ChunkWriter` and `SliceWriter` locks
- reject filesystem block/write-page geometries that would under-admit pages
- validate that write-pool capacity is an integral number of pages before component startup
- add strict FIFO waiters and event-driven dirty-writer flushing under memory pressure
- make compaction use non-blocking write-page admission
- close and drain admission, pressure callbacks, and writer lifecycles during shutdown
- extend write-path, compaction, pressure-controller, and memory-pool tests

## Why

The previous write path could surface transient client memory pressure as ENOSPC after partial allocation. This WIP establishes an explicit admission boundary so writes either own all required pages before mutation or do not enter the writer path. Invalid pool geometry now returns `InvalidParam` instead of reaching the constructor `CHECK` and aborting the client.

## Write-admission contract

Foreground `Acquire()` intentionally has no timeout. Once admitted to the strict FIFO queue, a writer waits until its exact page reservation can be granted or the pool transitions to closed/broken. Transient client memory pressure must not be surfaced as ENOSPC. Shutdown closes the pool and wakes queued writers.

## WIP / known gaps

- define the permanent-`NotFit` behavior when a compaction range exceeds the entire write pool

This PR is intentionally Draft until that item is resolved.

## Verification

- rebased onto upstream `main` at `1c34148d4`
- `cmake --build build --target test_client test_common -j16`
- `build/bin/test/test_client`: 463 tests passed, including block/page and pool/page geometry startup validation
- `build/bin/test/test_common --gtest_filter='WriteMemPoolTest.*:WriteMemPoolDeathTest.*'`: 10 tests passed
- `git diff --check`

One earlier full `test_client` run exited with SIGSEGV while entering `MDSMetaSystemFlushTest.ConcurrentWriteDoesNotExtendActiveFlush`; that test passed in isolation and subsequent complete runs passed. The PR remains Draft while the compaction admission gap above is addressed.