### PR TITLE
feat(mds): enforce quota on chunk write

### DIFF
--- a/src/client/vfs/metasystem/mds/chunk.cc
+++ b/src/client/vfs/metasystem/mds/chunk.cc
@@ -335,8 +335,21 @@ bool CommitTask::Dump(Json::Value& value) {
   return true;
 }
 
+ChunkSet::ChunkSet(Ino ino, uint32_t chunk_size)
+    : ino_(ino),
+      chunk_size_(chunk_size),
+      last_active_s_(utils::Timestamp()) {
+  CHECK(bthread_mutex_init(&write_flush_mutex_, nullptr) == 0)
+      << "init write_flush_mutex_ fail.";
+}
+
+ChunkSet::~ChunkSet() {
+  CHECK(bthread_mutex_destroy(&write_flush_mutex_) == 0)
+      << "destroy write_flush_mutex_ fail.";
+}
+
 void ChunkSet::Append(uint32_t index, const std::vector<Slice>& slices) {
-  std::lock_guard<std::mutex> flush_guard(write_flush_mutex_);
+  std::lock_guard<bthread_mutex_t> flush_guard(write_flush_mutex_);
   utils::WriteLockGuard guard(lock_);
 
   auto it = chunk_map_.find(index);

--- a/src/client/vfs/metasystem/mds/chunk.h
+++ b/src/client/vfs/metasystem/mds/chunk.h
@@ -296,11 +296,8 @@ class CommitTask {
 // chunk set per file
 class ChunkSet {
  public:
-  ChunkSet(Ino ino, uint32_t chunk_size)
-      : ino_(ino),
-        chunk_size_(chunk_size),
-        last_active_s_(utils::Timestamp()) {}
-  ~ChunkSet() = default;
+  ChunkSet(Ino ino, uint32_t chunk_size);
+  ~ChunkSet();
 
   static ChunkSetSPtr New(Ino ino, uint32_t chunk_size) {
     return std::make_shared<ChunkSet>(ino, chunk_size);
@@ -311,7 +308,7 @@ class ChunkSet {
   // Serializes a metadata flush against new writes for this inode, so the set
   // being drained cannot grow indefinitely under a sustained concurrent
   // writer. Write operations take this mutex before updating the set.
-  using FlushGuard = std::unique_lock<std::mutex>;
+  using FlushGuard = std::unique_lock<bthread_mutex_t>;
   FlushGuard AcquireFlushGuard() { return FlushGuard(write_flush_mutex_); }
 
   uint64_t GetLastWriteSliceLength() const {
@@ -321,7 +318,7 @@ class ChunkSet {
 
   // write memo operationsm
   void SetLastWriteLength(uint64_t offset, uint64_t size) {
-    std::lock_guard<std::mutex> flush_guard(write_flush_mutex_);
+    std::lock_guard<bthread_mutex_t> flush_guard(write_flush_mutex_);
     utils::WriteLockGuard lk(lock_);
     last_write_length_ = std::max(last_write_length_, offset + size);
     last_write_time_ns_ = utils::TimestampNs();
@@ -432,7 +429,7 @@ class ChunkSet {
   const Ino ino_;
   const uint32_t chunk_size_;
 
-  mutable std::mutex write_flush_mutex_;
+  mutable bthread_mutex_t write_flush_mutex_;
   mutable utils::RWLock lock_;
 
   // record write file length by writeslice operation

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -672,15 +672,15 @@ Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
 
   if (!status.ok()) return status;
 
+  // update inode cache
+  InodeSPtr inode = PutInodeToCache(attr_entry);
+  file_session->SetInode(inode);
+
   if (mds::IsDeleted(attr_entry)) {
     LOG(WARNING) << fmt::format(
         "[meta.fs.{}.{}] open file skipped, file is deleted.", ino, fh);
     return Status::NotExist("file is deleted");
   }
-
-  // update inode cache
-  InodeSPtr inode = PutInodeToCache(attr_entry);
-  file_session->SetInode(inode);
 
   // truncate file, forget chunk memo and delete chunk cache
   // update chunk cache
@@ -1147,10 +1147,8 @@ Status MDSMetaSystem::Write(ContextSPtr, Ino ino, const char* buf,
   CHECK(file_session != nullptr)
       << fmt::format("file session is nullptr, ino({}) fh({}).", ino, fh);
 
-  {
-    auto& chunk_set = file_session->GetChunkSet();
-    chunk_set->SetLastWriteLength(offset, size);
-  }
+  auto& chunk_set = file_session->GetChunkSet();
+  chunk_set->SetLastWriteLength(offset, size);
 
   // update last modify time
   modify_time_memo_.Remember(ino);

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -391,9 +391,10 @@ Status FileSystem::GetPartitionFromStore(Context& ctx, Ino parent, const std::st
 
   UpsertInodeCache(attr_with_mutation, reason);
 
-  LOG_DEBUG << fmt::format("[fs.{}.{}.{}.{}][{}us] fetch partition, version({}) shard_boundaries({}) reason({}).",
-                           fs_id_, parent, method_name, request_id, duration.ElapsedUs(), attr.version(),
-                           ::dingofs::Helper::VectorToString(::dingofs::Helper::PbRepeatedToVector(attr.shard_boundaries())), reason);
+  LOG_DEBUG << fmt::format(
+      "[fs.{}.{}.{}.{}][{}us] fetch partition, version({}) shard_boundaries({}) reason({}).", fs_id_, parent,
+      method_name, request_id, duration.ElapsedUs(), attr.version(),
+      ::dingofs::Helper::VectorToString(::dingofs::Helper::PbRepeatedToVector(attr.shard_boundaries())), reason);
 
   return Status::OK();
 }
@@ -2820,8 +2821,17 @@ Status FileSystem::WriteSlice(Context& ctx, Ino ino, const std::vector<DeltaSlic
 
   utils::Duration duration;
 
+  auto check_quota_fn = [this](Trace& trace, Ino ino, uint64_t delta_bytes) -> Status {
+    // check quota
+    if (!quota_manager_.CheckQuota(trace, ino, delta_bytes, 0)) {
+      return Status(pb::error::EQUOTA_EXCEED, "exceed quota limit");
+    }
+
+    return Status::OK();
+  };
+
   // update backend store
-  UpsertChunkOperation operation(trace, GetFsInfo(), ino, delta_slices);
+  UpsertChunkOperation operation(trace, GetFsInfo(), ino, delta_slices, check_quota_fn);
 
   trace.RecordElapsedTime("prepare");
 

--- a/src/mds/filesystem/filesystem.h
+++ b/src/mds/filesystem/filesystem.h
@@ -161,6 +161,8 @@ class FileSystem : public std::enable_shared_from_this<FileSystem> {
     return fs_info_->GetPartitionType() == pb::mds::PartitionType::PARENT_ID_HASH_PARTITION;
   }
 
+  uint32_t ChunkSize() const { return fs_info_->GetChunkSize(); }
+
   bool CanServe(Context& ctx) { return ctx.IsBypassCache() ? true : can_serve_.load(std::memory_order_acquire); }
 
   // create root directory

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 #include "mds/filesystem/store_operation.h"
-#include "common/helper.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -36,6 +35,7 @@
 #include "bthread/bthread.h"
 #include "bthread/types.h"
 #include "common/const.h"
+#include "common/helper.h"
 #include "common/logging.h"
 #include "common/meta.h"
 #include "dingofs/error.pb.h"
@@ -1483,6 +1483,11 @@ Status UpsertChunkOperation::Run(TxnUPtr& txn) {
     txn->Put(inode_key, MetaCodec::EncodeInodeValue(attr));
   }
 
+  if (result_.delta_bytes > 0) {
+    status = check_quota_fn_(GetTrace(), ino_, result_.delta_bytes);
+    if (!status.ok()) return status;
+  }
+
   result_.attr = attr;
 
   return Status::OK();
@@ -1734,7 +1739,8 @@ Status FlushFileOperation::Run(TxnUPtr& txn) {
       attr = MetaCodec::DecodeInodeValue(kv.value);
 
     } else {
-      LOG(FATAL) << fmt::format("[operation.{}.{}] invalid key({}).", fs_id_, ino_, ::dingofs::Helper::StringToHex(kv.key));
+      LOG(FATAL) << fmt::format("[operation.{}.{}] invalid key({}).", fs_id_, ino_,
+                                ::dingofs::Helper::StringToHex(kv.key));
     }
   }
 
@@ -1867,7 +1873,8 @@ Status RmDirOperation::Run(TxnUPtr& txn) {
     } else if (kv.key == bucket_dentry_key) {
       trash_bucket_exist = true;
     } else {
-      LOG(FATAL) << fmt::format("[operation.{}.{}] invalid key({}).", fs_id, parent, ::dingofs::Helper::StringToHex(kv.key));
+      LOG(FATAL) << fmt::format("[operation.{}.{}] invalid key({}).", fs_id, parent,
+                                ::dingofs::Helper::StringToHex(kv.key));
     }
   }
   if (parent_attr.ino() == 0) {
@@ -2407,7 +2414,8 @@ Status RenameOperation::Run(TxnUPtr& txn) {
       trash_bucket_exist = true;
 
     } else {
-      LOG(FATAL) << fmt::format("[operation.{}.{}] invalid key({}).", fs_id_, old_parent_, ::dingofs::Helper::StringToHex(kv.key));
+      LOG(FATAL) << fmt::format("[operation.{}.{}] invalid key({}).", fs_id_, old_parent_,
+                                ::dingofs::Helper::StringToHex(kv.key));
     }
   }
   // kTrashInodeId is a virtual directory: no inode key in KV. Synthesize the

--- a/src/mds/filesystem/store_operation.h
+++ b/src/mds/filesystem/store_operation.h
@@ -921,11 +921,13 @@ class UpdateShardBoundariesOperation : public Operation {
   Result result_;
 };
 
+using CheckQuotaFn = std::function<Status(Trace& trace, Ino ino, uint64_t delta_bytes)>;
+
 class UpsertChunkOperation : public Operation {
  public:
   UpsertChunkOperation(Trace& trace, const FsInfoEntry fs_info, uint64_t ino,
-                       const std::vector<DeltaSliceEntry>& delta_slices)
-      : Operation(trace), fs_info_(fs_info), ino_(ino), delta_slices_(delta_slices) {};
+                       const std::vector<DeltaSliceEntry>& delta_slices, CheckQuotaFn& check_quota_fn)
+      : Operation(trace), fs_info_(fs_info), ino_(ino), delta_slices_(delta_slices), check_quota_fn_(check_quota_fn) {};
   ~UpsertChunkOperation() override = default;
 
   struct Result {
@@ -948,6 +950,8 @@ class UpsertChunkOperation : public Operation {
   const uint64_t ino_;
 
   const std::vector<DeltaSliceEntry> delta_slices_;
+
+  CheckQuotaFn check_quota_fn_;
 
   Result result_;
 };

--- a/src/mds/filesystem/store_operation.h
+++ b/src/mds/filesystem/store_operation.h
@@ -926,7 +926,7 @@ using CheckQuotaFn = std::function<Status(Trace& trace, Ino ino, uint64_t delta_
 class UpsertChunkOperation : public Operation {
  public:
   UpsertChunkOperation(Trace& trace, const FsInfoEntry fs_info, uint64_t ino,
-                       const std::vector<DeltaSliceEntry>& delta_slices, CheckQuotaFn& check_quota_fn)
+                       const std::vector<DeltaSliceEntry>& delta_slices, const CheckQuotaFn& check_quota_fn)
       : Operation(trace), fs_info_(fs_info), ino_(ino), delta_slices_(delta_slices), check_quota_fn_(check_quota_fn) {};
   ~UpsertChunkOperation() override = default;
 

--- a/src/tools/mds-cli/main.cc
+++ b/src/tools/mds-cli/main.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <fmt/format.h>
-#include "common/helper.h"
 #include <glog/logging.h>
 
 #include <string>
@@ -21,6 +20,7 @@
 
 #include "common/const.h"
 #include "common/flag.h"
+#include "common/helper.h"
 #include "gflags/gflags.h"
 #include "mds/common/codec.h"
 #include "mds/common/helper.h"
@@ -72,7 +72,7 @@ DEFINE_string(
     "header is degraded; alternative to --ino");
 DEFINE_uint64(parent, 0, "parent");
 DEFINE_string(parents, "", "parents");
-DEFINE_uint32(num, 1, "num");
+DEFINE_uint32(num, 3, "num");
 
 DEFINE_uint64(max_bytes, 1024 * 1024 * 1024, "max bytes");
 DEFINE_uint64(max_inodes, 1000000, "max inodes");


### PR DESCRIPTION
## Summary

Chunk writes now enforce quota inside the store transaction, and the client's metadata flush guard no longer blocks an OS thread.

## Changes

- `UpsertChunkOperation` takes a `CheckQuotaFn` and invokes it in `Run` when the write grows the file, returning `EQUOTA_EXCEED` before commit on overflow.
- `FileSystem::WriteSlice` builds that callback from `QuotaManager::CheckQuota`.
- `ChunkSet::write_flush_mutex_` switches from `std::mutex` to `bthread_mutex_t`, so the flush guard yields the bthread instead of blocking an OS thread.
- `DoOpen` populates the inode cache before the deleted-file check. `mds-cli --num` now defaults to 3.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/DeepSeek_V4_Pro_(High)-4D6BFE?logoColor=white)