### PR TITLE
[fix][client] Release references held by cancelled periodic tasks

### DIFF
--- a/src/client/vfs/data/reader/file_reader.cc
+++ b/src/client/vfs/data/reader/file_reader.cc
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <boost/intrusive_ptr.hpp>
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/sort.hpp>
 #include <cmath>
@@ -220,12 +221,9 @@ void FileReader::SchedulePeriodicShrink() {
     return;
   }
 
-  AcquireRef();
+  boost::intrusive_ptr<FileReader> self(this);
   vfs_hub_->GetReadCleanupExecutor()->Schedule(
-      [this] {
-        RunPeriodicShrink();
-        ReleaseRef();
-      },
+      [self = std::move(self)] { self->RunPeriodicShrink(); },
       FLAGS_vfs_periodic_flush_interval_ms);
 }
 

--- a/src/client/vfs/data/reader/file_reader.h
+++ b/src/client/vfs/data/reader/file_reader.h
@@ -64,6 +64,12 @@ class FileReader {
 
  private:
   friend class FileReaderTestPeer;
+  friend void intrusive_ptr_add_ref(FileReader* reader) {
+    reader->AcquireRef();
+  }
+  friend void intrusive_ptr_release(FileReader* reader) {
+    reader->ReleaseRef();
+  }
 
   Status GetAttr(ContextSPtr ctx, Attr* attr);
 

--- a/src/client/vfs/data/writer/file_writer.cc
+++ b/src/client/vfs/data/writer/file_writer.cc
@@ -22,6 +22,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <boost/intrusive_ptr.hpp>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -372,13 +373,9 @@ void FileWriter::SchedulePeriodicFlush() {
     }
   }
 
-  AcquireRef();
-
+  boost::intrusive_ptr<FileWriter> self(this);
   vfs_hub_->GetWriteBackgroundExecutor()->Schedule(
-      [this] {
-        RunPeriodicFlush();
-        ReleaseRef();
-      },
+      [self = std::move(self)] { self->RunPeriodicFlush(); },
       FLAGS_vfs_periodic_flush_interval_ms);
 }
 

--- a/src/client/vfs/data/writer/file_writer.h
+++ b/src/client/vfs/data/writer/file_writer.h
@@ -32,6 +32,7 @@ namespace client {
 namespace vfs {
 
 class VFSHub;
+class FileWriterTestPeer;
 
 class FileWriter {
  public:
@@ -66,6 +67,14 @@ class FileWriter {
   void SetStatusIfBroken(const Status& s);
 
  private:
+  friend class FileWriterTestPeer;
+  friend void intrusive_ptr_add_ref(FileWriter* writer) {
+    writer->AcquireRef();
+  }
+  friend void intrusive_ptr_release(FileWriter* writer) {
+    writer->ReleaseRef();
+  }
+
   int32_t GetChunkSize() const;
 
   void AsyncFlush(StatusCallback cb);

--- a/src/utils/executor/bthread/bthread_executor.cc
+++ b/src/utils/executor/bthread/bthread_executor.cc
@@ -31,19 +31,18 @@ bool BthreadExecutor::Start() {
   pool_->Start();
   timer_ = std::make_unique<TimerImpl>(pool_.get());
   CHECK(timer_->Start());
-  running_.store(true);
+  running_.store(true, std::memory_order_release);
   return true;
 }
 
 bool BthreadExecutor::Stop() {
-  if (running_.load()) {
-    CHECK(timer_->Stop());
-    pool_->Stop();
-    running_ = false;
-    return true;
-  } else {
+  if (!running_.exchange(false, std::memory_order_acq_rel)) {
     return false;
   }
+
+  CHECK(timer_->Stop());
+  pool_->Stop();
+  return true;
 }
 
 bool BthreadExecutor::Execute(std::function<void()> func) {
@@ -53,9 +52,10 @@ bool BthreadExecutor::Execute(std::function<void()> func) {
 }
 
 bool BthreadExecutor::Schedule(std::function<void()> func, int delay_ms) {
-  CHECK(running_);
-  timer_->Add(std::move(func), delay_ms);
-  return true;
+  if (!running_.load(std::memory_order_acquire)) {
+    return false;
+  }
+  return timer_->Add(std::move(func), delay_ms);
 }
 
 }  // namespace dingofs

--- a/src/utils/executor/executor.h
+++ b/src/utils/executor/executor.h
@@ -31,6 +31,8 @@ class Executor {
 
   virtual bool Execute(std::function<void()> func) = 0;
 
+  // Returns true only when the delayed task is accepted. The executor does not
+  // retain a rejected task.
   virtual bool Schedule(std::function<void()> func, int delay_ms) = 0;
 
   virtual int ThreadNum() const = 0;

--- a/src/utils/executor/thread/executor_impl.cc
+++ b/src/utils/executor/thread/executor_impl.cc
@@ -31,19 +31,18 @@ bool ExecutorImpl::Start() {
   pool_->Start();
   timer_ = std::make_unique<TimerImpl>(pool_.get());
   CHECK(timer_->Start());
-  running_.store(true);
+  running_.store(true, std::memory_order_release);
   return true;
 }
 
 bool ExecutorImpl::Stop() {
-  if (running_.load()) {
-    CHECK(timer_->Stop());
-    pool_->Stop();
-    running_ = false;
-    return true;
-  } else {
+  if (!running_.exchange(false, std::memory_order_acq_rel)) {
     return false;
   }
+
+  CHECK(timer_->Stop());
+  pool_->Stop();
+  return true;
 }
 
 bool ExecutorImpl::Execute(std::function<void()> func) {
@@ -53,9 +52,10 @@ bool ExecutorImpl::Execute(std::function<void()> func) {
 }
 
 bool ExecutorImpl::Schedule(std::function<void()> func, int delay_ms) {
-  CHECK(running_);
-  timer_->Add(std::move(func), delay_ms);
-  return true;
+  if (!running_.load(std::memory_order_acquire)) {
+    return false;
+  }
+  return timer_->Add(std::move(func), delay_ms);
 }
 
 }  // namespace dingofs

--- a/src/utils/executor/timer/timer.h
+++ b/src/utils/executor/timer/timer.h
@@ -28,8 +28,12 @@ class Timer {
 
   virtual bool Start() = 0;
 
+  // Stops task admission and destroys pending functions without invoking
+  // them. Function destruction completes before Stop returns.
   virtual bool Stop() = 0;
 
+  // Returns true only when the timer accepts ownership of func. The timer does
+  // not retain a rejected function.
   virtual bool Add(std::function<void()> func, int delay_ms) = 0;
 
   virtual bool IsStopped() = 0;

--- a/src/utils/executor/timer/timer_impl.cc
+++ b/src/utils/executor/timer/timer_impl.cc
@@ -29,12 +29,9 @@ namespace dingofs {
 
 using namespace std::chrono;
 
-TimerImpl::TimerImpl(ThreadPool* thread_pool)
-    : thread_pool_(thread_pool) {}
+TimerImpl::TimerImpl(ThreadPool* thread_pool) : thread_pool_(thread_pool) {}
 
-TimerImpl::~TimerImpl() {
-  Stop();
-}
+TimerImpl::~TimerImpl() { Stop(); }
 
 bool TimerImpl::Start() {
   std::lock_guard<std::mutex> lk(mutex_);
@@ -49,6 +46,7 @@ bool TimerImpl::Start() {
 }
 
 bool TimerImpl::Stop() {
+  decltype(heap_) cancelled;
   {
     std::lock_guard<std::mutex> lk(mutex_);
     if (!running_) {
@@ -56,11 +54,7 @@ bool TimerImpl::Stop() {
     }
 
     running_ = false;
-    while (!heap_.empty()) {
-      // TODO: add debug log
-      heap_.pop();
-    }
-
+    heap_.swap(cancelled);
     cv_.notify_all();
   }
 
@@ -68,6 +62,8 @@ bool TimerImpl::Stop() {
     thread_->join();
   }
 
+  // Destroy cancelled functions after releasing mutex_. Their captures may
+  // release the last reference to objects with non-trivial destructors.
   return true;
 }
 

--- a/src/utils/executor/timer/timer_impl.h
+++ b/src/utils/executor/timer/timer_impl.h
@@ -24,8 +24,8 @@
 #include "utils/executor/thread_pool.h"
 #include "utils/executor/timer/timer.h"
 
-
 namespace dingofs {
+class TimerImplTestPeer;
 
 class TimerImpl : public Timer {
  public:
@@ -43,6 +43,8 @@ class TimerImpl : public Timer {
   bool IsStopped() override;
 
  private:
+  friend class TimerImplTestPeer;
+
   void Run();
 
   struct FunctionInfo {

--- a/test/unit/client/vfs/data/test_file_reader.cc
+++ b/test/unit/client/vfs/data/test_file_reader.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gflags/gflags.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -99,6 +100,10 @@ class FileReaderTest : public test::VFSTestBase {
 // progress with sleep_for().
 class FileReaderTestPeer {
  public:
+  static int64_t RefCount(FileReader* reader) {
+    return reader->refs_.load(std::memory_order_acquire);
+  }
+
   static bool WaitForRequest(
       FileReader* reader, int64_t offset, ReadRequestState state,
       int32_t min_readers,
@@ -120,6 +125,20 @@ class FileReaderTestPeer {
     return false;
   }
 };
+
+TEST_F(FileReaderTest, StopReleasesPendingPeriodicTaskRef) {
+  gflags::FlagSaver flag_saver;
+  FLAGS_vfs_periodic_flush_interval_ms = 60 * 60 * 1000;
+
+  auto* reader = MakeOpenReader();
+  ASSERT_EQ(FileReaderTestPeer::RefCount(reader), 2);
+
+  reader->Close();
+  ASSERT_TRUE(read_cleanup_executor_->Stop());
+  EXPECT_EQ(FileReaderTestPeer::RefCount(reader), 1);
+
+  reader->ReleaseRef();
+}
 
 // 1. Read() of a zero-length range returns 0 bytes.
 TEST_F(FileReaderTest, Read_ZeroSize_ReturnsZero) {

--- a/test/unit/client/vfs/data/test_file_writer.cc
+++ b/test/unit/client/vfs/data/test_file_writer.cc
@@ -42,6 +42,13 @@ using ::testing::AnyNumber;
 using ::testing::Invoke;
 using ::testing::Return;
 
+class FileWriterTestPeer {
+ public:
+  static int64_t RefCount(FileWriter* writer) {
+    return writer->refs_.load(std::memory_order_acquire);
+  }
+};
+
 class FileWriterTest : public VFSTestBase {
  protected:
   void SetUp() override {
@@ -70,6 +77,20 @@ class FileWriterTest : public VFSTestBase {
     w->ReleaseRef();
   }
 };
+
+TEST_F(FileWriterTest, StopReleasesPendingPeriodicTaskRef) {
+  gflags::FlagSaver flag_saver;
+  FLAGS_vfs_periodic_flush_interval_ms = 60 * 60 * 1000;
+
+  auto* writer = MakeOpenWriter();
+  ASSERT_EQ(FileWriterTestPeer::RefCount(writer), 2);
+
+  writer->Close();
+  ASSERT_TRUE(write_background_executor_->Stop());
+  EXPECT_EQ(FileWriterTestPeer::RefCount(writer), 1);
+
+  writer->ReleaseRef();
+}
 
 // 1. Write() for a simple in-chunk write succeeds and returns the correct
 //    written size.

--- a/test/unit/utils/executor/test_timer_impl.cc
+++ b/test/unit/utils/executor/test_timer_impl.cc
@@ -14,7 +14,12 @@
 
 #include <unistd.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+#include <thread>
 
 #include "glog/logging.h"
 #include "gtest/gtest.h"
@@ -22,6 +27,25 @@
 #include "utils/executor/timer/timer_impl.h"
 
 namespace dingofs {
+class TimerImplTestPeer {
+ public:
+  static bool CanAcquireMutex(TimerImpl* timer) {
+    std::atomic<bool> acquired{false};
+    std::thread checker([&] {
+      for (int i = 0; i < 100; ++i) {
+        if (timer->mutex_.try_lock()) {
+          acquired.store(true, std::memory_order_release);
+          timer->mutex_.unlock();
+          return;
+        }
+        std::this_thread::yield();
+      }
+    });
+    checker.join();
+    return acquired.load(std::memory_order_acquire);
+  }
+};
+
 namespace utils {
 namespace unit_test {
 
@@ -35,6 +59,23 @@ class TimerImplTest : public ::testing::Test {
   ~TimerImplTest() override = default;
 
   std::unique_ptr<ThreadPoolImpl> pool{nullptr};
+};
+struct TimerCaptureProbe {
+  TimerImpl* timer;
+  std::atomic<bool>* destroyed;
+  std::atomic<bool>* destroyed_outside_mutex;
+
+  TimerCaptureProbe(TimerImpl* timer, std::atomic<bool>* destroyed,
+                    std::atomic<bool>* destroyed_outside_mutex)
+      : timer(timer),
+        destroyed(destroyed),
+        destroyed_outside_mutex(destroyed_outside_mutex) {}
+
+  ~TimerCaptureProbe() {
+    destroyed_outside_mutex->store(TimerImplTestPeer::CanAcquireMutex(timer),
+                                   std::memory_order_release);
+    destroyed->store(true, std::memory_order_release);
+  }
 };
 
 TEST_F(TimerImplTest, BaseTest) {
@@ -78,6 +119,25 @@ TEST_F(TimerImplTest, Add) {
   }
 
   EXPECT_EQ(count.load(), 0);
+}
+
+TEST_F(TimerImplTest, StopDestroysPendingFunctionsOutsideMutex) {
+  auto timer = std::make_unique<TimerImpl>(pool.get());
+  ASSERT_TRUE(timer->Start());
+
+  std::atomic<bool> ran{false};
+  std::atomic<bool> destroyed{false};
+  std::atomic<bool> destroyed_outside_mutex{false};
+  auto probe = std::make_shared<TimerCaptureProbe>(timer.get(), &destroyed,
+                                                   &destroyed_outside_mutex);
+
+  ASSERT_TRUE(timer->Add([probe, &ran] { ran.store(true); }, 60 * 60 * 1000));
+  probe.reset();
+
+  ASSERT_TRUE(timer->Stop());
+  EXPECT_FALSE(ran.load());
+  EXPECT_TRUE(destroyed.load(std::memory_order_acquire));
+  EXPECT_TRUE(destroyed_outside_mutex.load(std::memory_order_acquire));
 }
 
 }  // namespace unit_test

--- a/test/unit/utils/test_executor_impl.cc
+++ b/test/unit/utils/test_executor_impl.cc
@@ -17,8 +17,9 @@
 #include <atomic>
 #include <chrono>              // NOLINT
 #include <condition_variable>  // NOLINT
-#include <mutex>               // NOLINT
-#include <thread>              // NOLINT
+#include <memory>
+#include <mutex>   // NOLINT
+#include <thread>  // NOLINT
 
 #include "utils/executor/bthread/bthread_executor.h"
 #include "utils/executor/thread/executor_impl.h"
@@ -83,6 +84,42 @@ TEST(BthreadExecutorTest, ScheduleRunsTaskAfterDelay) {
   executor.Stop();
 }
 
+TEST(BthreadExecutorTest, StopDestroysPendingScheduledTask) {
+  BthreadExecutor executor(1);
+  ASSERT_TRUE(executor.Start());
+
+  std::atomic<bool> ran{false};
+  auto lifetime = std::make_shared<int>(1);
+  std::weak_ptr<int> weak_lifetime = lifetime;
+  ASSERT_TRUE(executor.Schedule(
+      [lifetime, &ran] { ran.store(true, std::memory_order_release); },
+      60 * 60 * 1000));
+  lifetime.reset();
+
+  ASSERT_FALSE(weak_lifetime.expired());
+  ASSERT_TRUE(executor.Stop());
+  EXPECT_FALSE(ran.load(std::memory_order_acquire));
+  EXPECT_TRUE(weak_lifetime.expired());
+}
+
+TEST(BthreadExecutorTest, ScheduleAfterStopRejectsAndDestroysTask) {
+  BthreadExecutor executor(1);
+  ASSERT_TRUE(executor.Start());
+  ASSERT_TRUE(executor.Stop());
+
+  std::atomic<bool> ran{false};
+  auto lifetime = std::make_shared<int>(1);
+  std::weak_ptr<int> weak_lifetime = lifetime;
+  std::function<void()> task = [lifetime, &ran] {
+    ran.store(true, std::memory_order_release);
+  };
+  lifetime.reset();
+
+  EXPECT_FALSE(executor.Schedule(std::move(task), 1));
+  EXPECT_FALSE(ran.load(std::memory_order_acquire));
+  EXPECT_TRUE(weak_lifetime.expired());
+}
+
 TEST(ExecutorImplTest, StartStopReportsThreadCount) {
   ExecutorImpl executor("unit_test_exec", 3);
 
@@ -123,6 +160,42 @@ TEST(ExecutorImplTest, ScheduleRunsTaskAfterDelay) {
   EXPECT_TRUE(ran.load());
 
   executor.Stop();
+}
+
+TEST(ExecutorImplTest, StopDestroysPendingScheduledTask) {
+  ExecutorImpl executor("unit_test_exec", 1);
+  ASSERT_TRUE(executor.Start());
+
+  std::atomic<bool> ran{false};
+  auto lifetime = std::make_shared<int>(1);
+  std::weak_ptr<int> weak_lifetime = lifetime;
+  ASSERT_TRUE(executor.Schedule(
+      [lifetime, &ran] { ran.store(true, std::memory_order_release); },
+      60 * 60 * 1000));
+  lifetime.reset();
+
+  ASSERT_FALSE(weak_lifetime.expired());
+  ASSERT_TRUE(executor.Stop());
+  EXPECT_FALSE(ran.load(std::memory_order_acquire));
+  EXPECT_TRUE(weak_lifetime.expired());
+}
+
+TEST(ExecutorImplTest, ScheduleAfterStopRejectsAndDestroysTask) {
+  ExecutorImpl executor("unit_test_exec", 1);
+  ASSERT_TRUE(executor.Start());
+  ASSERT_TRUE(executor.Stop());
+
+  std::atomic<bool> ran{false};
+  auto lifetime = std::make_shared<int>(1);
+  std::weak_ptr<int> weak_lifetime = lifetime;
+  std::function<void()> task = [lifetime, &ran] {
+    ran.store(true, std::memory_order_release);
+  };
+  lifetime.reset();
+
+  EXPECT_FALSE(executor.Schedule(std::move(task), 1));
+  EXPECT_FALSE(ran.load(std::memory_order_acquire));
+  EXPECT_TRUE(weak_lifetime.expired());
 }
 
 }  // namespace unit_test


### PR DESCRIPTION
## What problem does this PR solve?

`FileWriter::Open()` and `FileReader::Open()` each start a periodic callback chain through `SchedulePeriodicFlush()` or `SchedulePeriodicShrink()`.

Before this change, each scheduling call manually invoked `AcquireRef()` and captured a raw `this`. The matching `ReleaseRef()` existed only inside the callback body. `ExecutorImpl::Stop()` and `BthreadExecutor::Stop()` stop the timer before stopping their worker pool. A callback still waiting in the timer heap is removed without being invoked, so its callback-body `ReleaseRef()` never runs. The reader or writer, plus everything reachable from it, therefore remains alive after its handle is released.

This exact path produced direct and indirect LeakSanitizer reports in the cross-chunk pressure-flush and normal writable-release scenarios from PR #1066.

## What is changed and how?

### Periodic callback ownership

- Add ADL `intrusive_ptr_add_ref` and `intrusive_ptr_release` hooks for `FileWriter` and `FileReader`, backed by their existing `AcquireRef()` and `ReleaseRef()` methods.
- Replace the manual raw-pointer callback protocol with a moved `boost::intrusive_ptr<FileWriter>` or `boost::intrusive_ptr<FileReader>` capture.
- Keep the existing periodic behavior: an open object schedules the next callback; a closed or closing object returns without rescheduling.

The closure now owns the periodic reference. Running, rejecting, or cancelling the closure all release that reference through the same RAII path; the caller does not need a separate rollback branch when `Schedule()` returns `false`.

### Delayed-task admission contract

- `ExecutorImpl::Schedule()` and `BthreadExecutor::Schedule()` reject immediately when their executor is stopped.
- If the executor precheck passes, both methods return the actual result of `TimerImpl::Add()` instead of always returning `true`.
- `TimerImpl::Add()` performs the authoritative admission check under its mutex. A rejected function is not retained and is destroyed after the mutex guard is released.

This closes the `Schedule()`/`Stop()` race in which the executor precheck can pass immediately before the timer stops.

### Timer cancellation

`TimerImpl::Stop()` now:

1. marks the timer stopped and swaps the pending heap into a local cancellation heap while holding `mutex_`;
2. releases `mutex_` and joins the timer thread;
3. destroys the local cancellation heap during function exit, before `Stop()` returns.

Pending functions are still not invoked. Their captures are now destroyed outside `mutex_`, so releasing the last object reference cannot run a non-trivial destructor while the timer lock is held.

## Lifecycle outcomes

| Delayed callback state | Result |
| --- | --- |
| Executor already stopped | `Schedule()` returns `false`; its by-value function and intrusive capture are destroyed before the call returns. |
| Timer stops after the executor precheck | `TimerImpl::Add()` returns `false`; the rejected function is not retained. |
| Function remains in the timer heap at `Stop()` | It is moved to the cancellation heap and destroyed outside the timer mutex before `Stop()` returns. |
| Function was already handed to a worker pool | Existing pool drain semantics execute the accepted function; its capture releases normally afterward. |
| Periodic callback observes close/closing | It returns without rescheduling; destruction of the current closure releases the periodic reference. |
| Periodic callback completes while still open | It schedules the next intrusive closure, then the current closure releases its reference. |

## Tests added

- `FileWriterTest.StopReleasesPendingPeriodicTaskRef`
- `FileReaderTest.StopReleasesPendingPeriodicTaskRef`
  - use a one-hour interval;
  - verify the owner plus pending callback produce `refs_ == 2`;
  - close the object and stop its executor;
  - verify cancellation changes `refs_` from 2 to 1 before the owner releases the final reference.
- `TimerImplTest.StopDestroysPendingFunctionsOutsideMutex`
  - verifies a cancelled function is not invoked;
  - verifies its capture is destroyed before `Stop()` returns;
  - verifies capture destruction can reacquire the timer mutex.
- `ExecutorImplTest` and `BthreadExecutorTest`
  - verify `Stop()` destroys a pending delayed task;
  - verify `Schedule()` after stop returns `false`, does not run the task, and destroys its capture.

## Verification

Final branch after rebasing onto `upstream/main` at `be94f0e2e`:

- `cmake --build build --target test_utils test_client -j16`
- `test_client`: 471/471 passed
- `test_utils`: 112/112 passed

Leak checks performed before the final rebase with the same source patch:

- targeted ASAN/LSan lifecycle suite: 7/7 passed with no sanitizer report;
- patch applied to PR #1066 head: `VFSImplTest.Write_PressureFlushFails_CrossChunkWriteReturnsShortWrite` passed with no LSan report;
- patch applied to PR #1066 head: `VFSImplTest.Release_WritableHandle_FlushesBeforeMetaClose` passed with no LSan report;
- both PR #1066 reproductions also passed with `quarantine_size_mb=0`.

## Scope and follow-ups

- This change applies to delayed `Schedule()` work. `Execute()` is unchanged and still uses `CHECK(running_)` after executor stop.
- Tasks already transferred from the timer to a worker pool retain the existing drain behavior; this PR changes only cancellation of functions still pending in the timer heap.
- Non-periodic `FileReader` callbacks retain their existing manual exact-once reference protocol and need a separate lifecycle audit.
- No long-running mounted-client leak test was performed; the evidence covers the deterministic reference-count tests and the two original LSan reproductions.