### PR TITLE
WIP: test(mds): reproduce quota-metrics bvar worker starvation

### DIFF
--- a/test/unit/mds/quota/test_quota_metrics_starvation.cc
+++ b/test/unit/mds/quota/test_quota_metrics_starvation.cc
@@ -1,0 +1,265 @@
+// Copyright (c) 2024 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression for brpc#3470: FsQuotaMetric getters may wait on Quota's
+// BthreadRWLock. The callback must run outside bvar's VarMap pthread mutex;
+// otherwise later metric scrapes pin every worker and starve mutations.
+// The deadlocking implementation is exercised in a child process so the
+// parent can enforce a real timeout and kill it safely.
+
+#include <poll.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "bthread/bthread.h"
+#include "common/metrics/mds/quota_metrics.h"
+#include "gtest/gtest.h"
+#include "mds/quota/quota.h"
+
+namespace dingofs {
+namespace mds {
+namespace unit_test {
+namespace {
+
+using quota::Quota;
+
+constexpr int kWorkers = 8;
+constexpr int kScrapesPerWave = 16;
+constexpr int kMutationCount = 12;
+constexpr int kWatchdogMs = 15'000;
+constexpr char kPrefix[] = "fs_quota_starvation_test";
+constexpr char kMetricName[] =
+    "fs_quota_starvation_test_bytes_usage_ratio";
+
+QuotaEntry MakeQuota() {
+  QuotaEntry quota;
+  quota.set_max_bytes(100);
+  quota.set_max_inodes(1000);
+  quota.set_uuid("starvation-test");
+  quota.set_version(1);
+  return quota;
+}
+
+struct MetricSource {
+  static int64_t UsedBytes(void* arg) {
+    return static_cast<MetricSource*>(arg)->quota->GetQuota().used_bytes();
+  }
+  static int64_t UsedInodes(void* arg) {
+    return static_cast<MetricSource*>(arg)->quota->GetQuota().used_inodes();
+  }
+  static int64_t MaxBytes(void* arg) {
+    return static_cast<MetricSource*>(arg)->quota->GetQuota().max_bytes();
+  }
+  static int64_t MaxInodes(void* arg) {
+    return static_cast<MetricSource*>(arg)->quota->GetQuota().max_inodes();
+  }
+
+  Quota* quota;
+};
+
+struct Scenario {
+  Quota quota{1, 10, MakeQuota()};
+  MetricSource source{&quota};
+  metrics::mds::FsQuotaMetric metric{
+      kPrefix, &source, MetricSource::UsedBytes, MetricSource::UsedInodes,
+      MetricSource::MaxBytes, MetricSource::MaxInodes};
+  std::atomic<bool> stop{false};
+  std::atomic<int> scrape_start_error{0};
+
+  Scenario() {
+    for (auto& ran : mutation_ran) {
+      ran.store(false);
+    }
+  }
+  std::array<std::atomic<bool>, kMutationCount> mutation_ran{};
+  std::vector<bthread_t> scrape_tids;
+};
+
+void* Writer(void* arg) {
+  auto* scenario = static_cast<Scenario*>(arg);
+  while (!scenario->stop.load(std::memory_order_relaxed)) {
+    scenario->quota.UpdateUsage(1, 0, "starvation-test");
+  }
+  return nullptr;
+}
+
+void* Scrape(void*) {
+  bvar::Variable::describe_exposed(kMetricName);
+  return nullptr;
+}
+
+void* LaunchScrapes(void* arg) {
+  auto* scenario = static_cast<Scenario*>(arg);
+  while (!scenario->stop.load(std::memory_order_relaxed)) {
+    for (int i = 0; i < kScrapesPerWave; ++i) {
+      bthread_t tid;
+      const int rc = bthread_start_urgent(&tid, nullptr, Scrape, nullptr);
+      if (rc != 0) {
+        scenario->scrape_start_error.store(rc);
+        return nullptr;
+      }
+      scenario->scrape_tids.push_back(tid);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  return nullptr;
+}
+
+void* Mutation(void* arg) {
+  static_cast<std::atomic<bool>*>(arg)->store(true);
+  return nullptr;
+}
+
+std::string RunScenario(bool with_writer, bool with_scrapes,
+                        int mutation_count) {
+  if (bthread_setconcurrency(kWorkers) != 0) {
+    return "bthread_setconcurrency failed";
+  }
+
+  // Heap-allocated and intentionally leaked: on unpatched brpc the
+  // metric destructor would try to take the poisoned VarMap mutex.
+  Scenario* scenario = new Scenario;
+  if (bvar::Variable::describe_exposed(kMetricName).empty()) {
+    return "quota metric is not exposed";
+  }
+
+  bthread_t writer_tid = 0;
+  pthread_t scrape_launcher_tid = 0;
+  std::vector<bthread_t> mutation_tids;
+
+  if (with_writer &&
+      bthread_start_urgent(&writer_tid, nullptr, Writer, scenario) != 0) {
+    return "writer start failed";
+  }
+  if (with_scrapes &&
+      pthread_create(&scrape_launcher_tid, nullptr, LaunchScrapes,
+                     scenario) != 0) {
+    return "scrape launcher start failed";
+  }
+
+  // Let the scrape/writer convoy form before probing the scheduler: on
+  // unpatched brpc the first parked scrape holds the VarMap mutex and
+  // waiters pin the workers within a few waves.
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+
+  for (int i = 0; i < mutation_count; ++i) {
+    bthread_t tid;
+    if (bthread_start_urgent(&tid, nullptr, Mutation,
+                             &scenario->mutation_ran[i]) != 0) {
+      return "mutation start failed";
+    }
+    mutation_tids.push_back(tid);
+
+    for (int waited_ms = 0;
+         waited_ms < 2000 && !scenario->mutation_ran[i].load();
+         waited_ms += 5) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    if (!scenario->mutation_ran[i].load()) {
+      return "mutation " + std::to_string(i) + "/" +
+             std::to_string(mutation_count) + " was never scheduled";
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  }
+
+  scenario->stop.store(true);
+  if (with_scrapes) {
+    pthread_join(scrape_launcher_tid, nullptr);
+  }
+  void* retval = nullptr;
+  if (with_writer) {
+    bthread_join(writer_tid, &retval);
+  }
+  for (bthread_t tid : scenario->scrape_tids) {
+    bthread_join(tid, &retval);
+  }
+  for (bthread_t tid : mutation_tids) {
+    bthread_join(tid, &retval);
+  }
+  if (scenario->scrape_start_error.load() != 0) {
+    return "scrape start failed";
+  }
+  return "OK";
+}
+
+std::string RunInChild(bool with_writer, bool with_scrapes,
+                       int mutation_count) {
+  int fds[2];
+  if (pipe(fds) != 0) {
+    return "pipe failed";
+  }
+
+  const pid_t pid = fork();
+  if (pid < 0) {
+    close(fds[0]);
+    close(fds[1]);
+    return "fork failed";
+  }
+  if (pid == 0) {
+    close(fds[0]);
+    const std::string verdict =
+        RunScenario(with_writer, with_scrapes, mutation_count);
+    (void)write(fds[1], verdict.data(), verdict.size());
+    _exit(verdict == "OK" ? 0 : 1);
+  }
+
+  close(fds[1]);
+  struct pollfd pfd{fds[0], POLLIN, 0};
+  const int poll_rc = poll(&pfd, 1, kWatchdogMs);
+  if (poll_rc <= 0) {
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+    close(fds[0]);
+    return poll_rc == 0 ? "child timed out" : "poll failed";
+  }
+
+  char buf[256];
+  const ssize_t n = read(fds[0], buf, sizeof(buf));
+  close(fds[0]);
+  int status = 0;
+  waitpid(pid, &status, 0);
+  if (n <= 0) {
+    return "child exited without a verdict";
+  }
+  return std::string(buf, n);
+}
+
+}  // namespace
+
+TEST(QuotaMetricStarvationTest, WriterAloneDoesNotStarveMutations) {
+  EXPECT_EQ("OK", RunInChild(true, false, 4));
+}
+
+TEST(QuotaMetricStarvationTest, ScrapesAloneDoNotStarveMutations) {
+  EXPECT_EQ("OK", RunInChild(false, true, 4));
+}
+
+TEST(QuotaMetricStarvationTest, YieldingGetterDoesNotStarveMutations) {
+  EXPECT_EQ("OK", RunInChild(true, true, kMutationCount))
+      << "brpc#3470 must run bvar callbacks outside the VarMap lock";
+}
+
+}  // namespace unit_test
+}  // namespace mds
+}  // namespace dingofs


### PR DESCRIPTION
## WIP: 定向复现 8831 MDS worker 饥饿死锁的单测

> 状态：WIP，先供 review 测试写法；实测两侧结论已出（见下），等 brpc backport 落地节奏再定合入时机。

### 背景

2026-08-30 训练集群 8831 MDS 死锁：Prometheus 抓取 `/brpc_metrics` 时，`bvar::Variable::describe_exposed()` 在持有 VarMap 分片 pthread mutex 的情况下调用 `PassiveStatus` getter；`FsQuotaMetric` 的 getter 经 `Quota::GetQuota()` 拿 `utils::RWLock` 读锁（`concurrent.h:48` 别名 `BthreadRWLock`），写者活跃时 `bthread_rwlock_rdlock -> butex_wait` 让出 bthread——**持 pthread mutex 期间 yield**。后续每个 scrape handler 阻塞在这把无超时的 mutex 上各钉死一个 OS worker，棘轮式耗尽 worker 池，mutation bthread（`LaunchExecuteBatchOperation`）从此无法调度。

上游修复：apache/brpc#3470（commit `71871ee9`），describe/dump/get 移出 VarMap 锁。

### 测试怎么写的（review 重点）

`test/unit/mds/quota/test_quota_metrics_starvation.cc`，只用生产类与公共 API：

| 角色 | 实现 | 对应生产组件 |
|---|---|---|
| 指标 | `FsQuotaMetric`（`fs_quota_starve_test_*`），getter 接 `Quota::GetQuota()` | `QuotaManager::fs_quota_metric_` 同款接线 |
| 写锁流量 | bthread 循环 `Quota::UpdateUsage` | 每次 mutation 的配额记账 |
| 抓取 | **一次性** scrape bthread，16/wave × 400 波，由 launcher pthread 补充 | 每次 Prometheus 抓取 = 一个 handler bthread |
| 受害者 | 20 个单指令 mutation battery bthread | `LaunchExecuteBatchOperation` |
| 隔离 | `fork()` 子进程跑场景 + pipe 回传 verdict，60s 看门狗 | 未打补丁时死锁不污染 gtest 进程 |

关键设计点：
1. **scrape 必须一次性**，不能自旋——bthread 非抢占，自旋循环在有无 bug 时都会饿死 worker（调试中由 `DiagnosticScrapersOnly` 抓出的假阳性，已修正并保留为防回归）。
2. **两个 Diagnostic 测试**隔离 writer-only / scrapers-only 组合，证明只有两者并存才饥饿。
3. 主测试断言**修复后行为**（battery 全调度 + 指标值可解析），未打补丁时以明确失败信息退出（`STARVED: ...`）而非挂死。

### 实测结论（已跑通）

| brpc | 主测试（writer+scrapes） | Diagnostic×2 |
|---|---|---|
| `e63a54dc`（1.17.0，8831 同源） | **STARVED** battery 2/20 永久失调度 | OK / OK |
| `e63a54dc` + `71871ee9` | **OK** 20/20 全调度，指标正常 | OK / OK |

### 后续（合入前）

- [ ] brpc backport 分支落地节奏对齐（`dingodb/brpc` 已推 `dingo` 分支）
- [ ] 真实 MDS 指标集 + 并发 `/brpc_metrics` canary
- [ ] 与上游 brpc 回归测试（1000-bthread yielding PassiveStatus）互补说明