### PR TITLE
feat(mds): add cache observability and quota fixes

### DIFF
--- a/.agents/skills/dev-regression-test/SKILL.md
+++ b/.agents/skills/dev-regression-test/SKILL.md
@@ -219,7 +219,7 @@ mkdir -p ${FIO_LOG_DIR}
 cd ${FIO_TEST_DIR}
 
 # 示例: 运行测试命令
-fio --ioengine=libaio --iodepth=1  --direct=1 --rw=read --bs=128KB --size=8GB --numjobs=32 --group_reporting --name=test --log-file=${FIO_LOG_DIR}/fio.log
+fio --ioengine=libaio --iodepth=1  --direct=1 --rw=read --bs=128KB --size=1GB --numjobs=8 --group_reporting --name=test > ${FIO_LOG_DIR}/fio.log 2>&1
 
 ```
 

--- a/scripts/dev-mds/run_all_test.sh
+++ b/scripts/dev-mds/run_all_test.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+mydir="${BASH_SOURCE%/*}"
+if [[ ! -d "$mydir" ]]; then mydir="$PWD"; fi
+. $mydir/shflags
+
+
+
+DEFINE_string type 'all' 'test type'
+DEFINE_string mds_addr '' 'mds address'
+DEFINE_string mountpoint '' 'mount point'
+
+
+# parse the command-line
+FLAGS "$@" || exit 1
+eval set -- "${FLAGS_ARGV}"
+
+
+if [ -z "${FLAGS_type}" ]; then
+    echo "type is empty"
+    exit -1
+fi
+
+if [ -z "${FLAGS_mountpoint}" ]; then
+    echo "mountpoint is empty"
+    exit -1
+fi
+
+
+
+BASE_DIR=$(dirname $(dirname $(cd $(dirname $0); pwd)))
+MOUNTPOINT=${FLAGS_mountpoint}
+SUFFIX=$(date +%Y%m%d%H%M%S)
+
+function run_e2e_test() {
+  echo "### [e2e] run test......"
+
+
+  E2E_DIR=$BASE_DIR/test/e2e
+  TEST_ROOT_DIR=$MOUNTPOINT/e2e_${SUFFIX}
+  E2E_LOG_DIR=/tmp/dev-regression-test/e2e_test_${SUFFIX}
+
+  # create test directory and log directory
+  mkdir -p $TEST_ROOT_DIR
+  mkdir -p $E2E_LOG_DIR
+
+  cd $E2E_DIR
+  uv sync
+
+  # run test command
+  uv run pytest --mount-point=$TEST_ROOT_DIR > $E2E_LOG_DIR/e2e_test.log 2>&1
+
+  # uv run pytest quota --mount-point=$TEST_ROOT_DIR -m slow  --mds-addr=${FLAGS_mds_addr} --fs-id=10000 --root-ino=1
+
+  echo "### [e2e] test done, log file: $E2E_LOG_DIR/e2e_test.log"
+}
+
+
+function run_pjdtest_test() {
+  echo "### [pjdtest] run test......"
+
+  # env information
+  PJD_DIR=/home/dengzihui/work/dingofs-test/pjdfstest/tests
+  PJD_TEST_DIR=$MOUNTPOINT/pjd_test_${SUFFIX}
+  PJD_LOG_DIR=/tmp/dev-regression-test/pjd_test_${SUFFIX}
+
+  # create test directory and log directory
+  mkdir -p ${PJD_TEST_DIR}
+  mkdir -p ${PJD_LOG_DIR}
+
+  cd ${PJD_TEST_DIR} 
+
+  # run test command
+  sudo prove -rv --exec 'bash -x' ${PJD_DIR} > $PJD_LOG_DIR/pjd_test.log 2>&1
+
+  echo "### [pjdtest] test done, log file: $PJD_LOG_DIR/pjd_test.log"
+}
+
+
+
+function run_fsx_test() {
+  echo "### [fsx] run test......"
+
+  # env information
+  FSX_TEST_FILE=$MOUNTPOINT/fsx_test_${SUFFIX}
+  FSX_LOG_DIR=/tmp/dev-regression-test/fsx_test_${SUFFIX}
+
+  # create test directory and log directory
+  mkdir -p ${FSX_TEST_FILE}
+  mkdir -p ${FSX_LOG_DIR}
+
+  # run test command
+  fsx -l 1073741824 -o 1048576 -S 0 -p 10000 --duration=3600 --record-ops=$FSX_LOG_DIR/fsx.ops -P $FSX_LOG_DIR $FSX_TEST_FILE
+
+  echo "### [fsx] test done, log file: $FSX_LOG_DIR/fsx.ops"
+}
+
+
+function run_mdtest_test() {
+  echo "### [mdtest] run test......"
+
+  # env information
+  MDTEST_TEST_DIR=$MOUNTPOINT/mdtest_test_${SUFFIX}
+  MDTEST_LOG_DIR=/tmp/dev-regression-test/mdtest_test_${SUFFIX}
+
+  # create test directory and log directory
+  mkdir -p ${MDTEST_TEST_DIR}
+  mkdir -p ${MDTEST_LOG_DIR}
+
+  # run test command
+  mpirun -np 4 mdtest -z 2 -b 4 -n 1000 -L -d ${MDTEST_TEST_DIR} > ${MDTEST_LOG_DIR}/mdtest.log 2>&1
+
+  echo "### [mdtest] test done, log file: $MDTEST_LOG_DIR/mdtest.log"
+}
+
+
+function run_fio_test() {
+  echo "### [fio] run test......"
+
+  # env information
+  FIO_TEST_DIR=$MOUNTPOINT/fio_test_${SUFFIX}
+  FIO_LOG_DIR=/tmp/dev-regression-test/fio_test_${SUFFIX}
+
+
+  # create test directory
+  mkdir -p ${FIO_TEST_DIR}
+  mkdir -p ${FIO_LOG_DIR}
+
+  # change to test directory
+  cd ${FIO_TEST_DIR}
+
+  # run test command
+  echo "#### running fio write test..."
+  fio --ioengine=libaio --iodepth=1 --direct=1 --rw=write --bs=128KB --size=512MB --numjobs=8 --group_reporting --name=test > ${FIO_LOG_DIR}/fio.log 2>&1
+  echo "#### running fio read test..."
+  fio --ioengine=libaio --iodepth=1 --direct=1 --rw=read --bs=128KB --size=512MB --numjobs=8 --group_reporting --name=test >> ${FIO_LOG_DIR}/fio.log 2>&1
+  echo "#### running fio randread test..."
+  fio --ioengine=libaio --iodepth=1 --direct=1 --rw=randread --bs=128KB --size=512MB --numjobs=8 --group_reporting --name=test >> ${FIO_LOG_DIR}/fio.log 2>&1
+  echo "#### running fio randwrite test..."
+  fio --ioengine=libaio --iodepth=1 --direct=1 --rw=randwrite --bs=128KB --size=512MB --numjobs=8 --group_reporting --name=test >> ${FIO_LOG_DIR}/fio.log 2>&1
+  echo "#### running fio randrw test..."
+  fio --ioengine=libaio --iodepth=1 --direct=1 --rw=randrw --bs=128KB --size=512MB --numjobs=8 --group_reporting --name=test >> ${FIO_LOG_DIR}/fio.log 2>&1
+
+  echo "### [fio] test done, log file: $FIO_LOG_DIR/fio.log"
+}
+
+function run_fsstress_test() {
+  echo "### [fsstress] run test......"
+
+  # env information
+  FSSTRESS_TEST_DIR=$MOUNTPOINT/fsstress_test_${SUFFIX}
+  FSSTRESS_LOG_DIR=/tmp/dev-regression-test/fsstress_test_${SUFFIX}
+
+  # create test directory and log directory
+  mkdir -p ${FSSTRESS_TEST_DIR}
+  mkdir -p ${FSSTRESS_LOG_DIR}
+
+  # change to test directory
+  cd ${FSSTRESS_TEST_DIR}
+
+  # run test command
+  /opt/ltp/testcases/bin/fsstress -d ${FSSTRESS_TEST_DIR} -n 10000 -p 8 -v > ${FSSTRESS_LOG_DIR}/fsstress.log 2>&1
+
+  echo "### [fsstress] test done, log file: $FSSTRESS_LOG_DIR/fsstress.log"
+}
+
+
+function run_all_tests() {
+  run_e2e_test
+  run_pjdtest_test
+  run_fsx_test
+  run_mdtest_test
+  run_fio_test
+  run_fsstress_test
+}
+
+if [ "$FLAGS_type" = "all" ]; then
+  run_all_tests
+elif [ "$FLAGS_type" = "e2e" ]; then
+  run_e2e_test
+elif [ "$FLAGS_type" = "pjdtest" ]; then
+  run_pjdtest_test
+elif [ "$FLAGS_type" = "fsx" ]; then
+  run_fsx_test
+elif [ "$FLAGS_type" = "mdtest" ]; then
+  run_mdtest_test
+elif [ "$FLAGS_type" = "fio" ]; then
+  run_fio_test
+elif [ "$FLAGS_type" = "fsstress" ]; then
+  run_fsstress_test
+fi

--- a/src/mds/filesystem/chunk_cache.cc
+++ b/src/mds/filesystem/chunk_cache.cc
@@ -14,6 +14,7 @@
 
 #include "mds/filesystem/chunk_cache.h"
 
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -142,6 +143,30 @@ std::vector<ChunkCache::ChunkSPtr> ChunkCache::Get(Ino ino) {
   access_hit_count_ << chunks.size();
 
   return chunks;
+}
+
+std::vector<ChunkEntry> ChunkCache::Find(Ino ino, size_t offset, size_t limit, size_t& total) {
+  total = 0;
+
+  std::vector<ChunkEntry> chunks;
+  shard_map_.withRLock(
+      [ino, offset, limit, &chunks, &total](Map& map) {
+        Key key{.ino = ino, .chunk_index = 0};
+        for (auto it = map.lower_bound(key); it != map.end() && it->first.ino == ino; ++it) {
+          if (total++ >= offset && chunks.size() < limit) chunks.push_back(*it->second);
+        }
+      },
+      ino);
+
+  return chunks;
+}
+
+std::vector<std::pair<Ino, size_t>> ChunkCache::ListInos() {
+  std::map<Ino, size_t> counts;
+  shard_map_.iterate([&counts](const Map& map) {
+    for (const auto& [key, _] : map) ++counts[key.ino];
+  });
+  return {counts.begin(), counts.end()};
 }
 
 bool ChunkCache::IsExist(Ino ino) {

--- a/src/mds/filesystem/chunk_cache.h
+++ b/src/mds/filesystem/chunk_cache.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "absl/container/btree_map.h"
@@ -49,6 +50,9 @@ class ChunkCache {
 
   ChunkSPtr Get(Ino ino, uint64_t chunk_index);
   std::vector<ChunkSPtr> Get(Ino ino);
+  // Returns copies for diagnostics without changing cache metrics or lifetime.
+  std::vector<ChunkEntry> Find(Ino ino, size_t offset, size_t limit, size_t& total);
+  std::vector<std::pair<Ino, size_t>> ListInos();
 
   bool IsExist(Ino ino);
 

--- a/src/mds/filesystem/filesystem.cc
+++ b/src/mds/filesystem/filesystem.cc
@@ -1370,6 +1370,7 @@ Status FileSystem::RmDir(Context& ctx, Ino parent, const std::string& name, Entr
 
   // update parent memo
   parent_memo_.Forget(dentry.ino());
+  if (!enable_trash) DeleteInodeFromCache(dentry.ino());
 
   // notify buddy
   if (IsParentHashPartition()) {

--- a/src/mds/filesystem/inode.cc
+++ b/src/mds/filesystem/inode.cc
@@ -333,16 +333,7 @@ void InodeCache::Clear() {
 }
 
 InodeSPtr InodeCache::Get(Ino ino) {
-  InodeSPtr inode;
-  shard_map_.withRLock(
-      [ino, &inode](Map& map) {
-        auto it = map.find(ino);
-        if (it != map.end()) {
-          inode = it->second;
-        }
-      },
-      ino);
-
+  auto inode = Find(ino);
   if (inode != nullptr) {
     inode->UpdateLastActiveTime();
     access_hit_count_ << 1;
@@ -350,6 +341,18 @@ InodeSPtr InodeCache::Get(Ino ino) {
   } else {
     access_miss_count_ << 1;
   }
+
+  return inode;
+}
+
+InodeSPtr InodeCache::Find(Ino ino) {
+  InodeSPtr inode;
+  shard_map_.withRLock(
+      [ino, &inode](Map& map) {
+        auto it = map.find(ino);
+        if (it != map.end()) inode = it->second;
+      },
+      ino);
 
   return inode;
 }

--- a/src/mds/filesystem/inode.h
+++ b/src/mds/filesystem/inode.h
@@ -207,6 +207,7 @@ class Inode {
 
   void UpdateLastActiveTime() { last_active_time_s_.store(utils::Timestamp(), std::memory_order_relaxed); }
   uint64_t LastActiveTimeS() { return last_active_time_s_.load(std::memory_order_relaxed); }
+  uint64_t LastRefreshTimeS() { return last_refresh_time_s_.load(std::memory_order_relaxed); }
 
   bool IsFresh();
 
@@ -277,6 +278,8 @@ class InodeCache {
   void Clear();
 
   InodeSPtr Get(Ino ino);
+  // Returns an entry for diagnostics without changing cache metrics or lifetime.
+  InodeSPtr Find(Ino ino);
   std::vector<InodeSPtr> Get(std::vector<uint64_t> inoes);
   std::vector<InodeSPtr> GetAll();
 

--- a/src/mds/filesystem/partition.cc
+++ b/src/mds/filesystem/partition.cc
@@ -176,7 +176,17 @@ void DirShard::Dump(Json::Value& value) const {
   value["start"] = ::dingofs::Helper::StringToHex(range_.start);
   value["end"] = ::dingofs::Helper::StringToHex(range_.end);
   value["version"] = version_;
-  value["size"] = Size();
+  value["size"] = children_.size();
+}
+
+void DirShard::Snapshot(size_t offset, size_t limit, std::vector<Dentry>& dentries) const {
+  utils::ReadLockGuard lk(lock_);
+
+  auto it = children_.begin();
+  std::advance(it, std::min(offset, children_.size()));
+  for (; it != children_.end() && dentries.size() < limit; ++it) {
+    dentries.push_back(it->second);
+  }
 }
 
 // --- ShardPartition operations ---
@@ -358,7 +368,17 @@ size_t ShardPartition::Bytes() const {
   return bytes;
 }
 
-void ShardPartition::Dump(Json::Value& value) const {
+static void DentryToJson(const Dentry& dentry, Json::Value& value) {
+  value["name"] = dentry.Name();
+  value["fs_id"] = dentry.FsId();
+  value["ino"] = dentry.INo();
+  value["parent_ino"] = dentry.ParentIno();
+  value["type"] = pb::mds::FileType_Name(dentry.Type());
+  value["flag"] = dentry.Flag();
+}
+
+void ShardPartition::Dump(Json::Value& value, size_t dentry_offset, size_t dentry_limit, size_t delta_offset,
+                          size_t delta_limit) const {
   utils::ReadLockGuard lk(lock_);
 
   value["fs_id"] = fs_id_;
@@ -394,6 +414,7 @@ void ShardPartition::Dump(Json::Value& value) const {
     }
   }
 
+  std::vector<DirShardSPtr> loaded_shards;
   for (const auto& [shard_key, shard] : shard_map_) {
     auto it = shard_map_value.find(shard_key);
     if (it == shard_map_value.end()) continue;
@@ -402,14 +423,52 @@ void ShardPartition::Dump(Json::Value& value) const {
     shard_value["id"] = shard->ID();
     shard_value["size"] = shard->Size();
     shard_value["version"] = shard->Version();
+    loaded_shards.push_back(shard);
   }
 
   Json::Value shards_value(Json::arrayValue);
   for (auto& it : shard_map_value) {
     shards_value.append(it.second);
   }
-
   value["shards"] = shards_value;
+
+  std::sort(loaded_shards.begin(), loaded_shards.end(),
+            [](const DirShardSPtr& lhs, const DirShardSPtr& rhs) { return lhs->Start() < rhs->Start(); });
+  size_t remaining_offset = dentry_offset;
+  size_t total_dentries = 0;
+  std::vector<Dentry> dentries;
+  for (const auto& shard : loaded_shards) {
+    const size_t shard_size = shard->Size();
+    total_dentries += shard_size;
+    if (remaining_offset >= shard_size) {
+      remaining_offset -= shard_size;
+    } else if (dentries.size() < dentry_limit) {
+      shard->Snapshot(remaining_offset, dentry_limit, dentries);
+      remaining_offset = 0;
+    }
+  }
+  value["dentry_total"] = total_dentries;
+  Json::Value dentries_value(Json::arrayValue);
+  for (const auto& dentry : dentries) {
+    Json::Value dentry_value(Json::objectValue);
+    DentryToJson(dentry, dentry_value);
+    dentries_value.append(dentry_value);
+  }
+  value["dentries"] = dentries_value;
+
+  value["delta_dentry_ops_total"] = delta_dentry_ops_.size();
+  Json::Value delta_value(Json::arrayValue);
+  auto it = delta_dentry_ops_.begin();
+  std::advance(it, std::min(delta_offset, delta_dentry_ops_.size()));
+  for (size_t i = 0; it != delta_dentry_ops_.end() && i < delta_limit; ++it, ++i) {
+    Json::Value op_value(Json::objectValue);
+    op_value["op"] = it->op_type == DentryOpType::ADD ? "ADD" : "DELETE";
+    op_value["version"] = it->version;
+    op_value["time_s"] = it->time_s;
+    DentryToJson(it->dentry, op_value["dentry"]);
+    delta_value.append(op_value);
+  }
+  value["delta_dentry_ops"] = delta_value;
 }
 
 // --- ShardPartition private helpers ---
@@ -774,23 +833,25 @@ void PartitionCache::Clear() {
 }
 
 PartitionPtr PartitionCache::Get(Ino ino) {
-  PartitionPtr partition;
-
-  shard_map_.withRLock(
-      [ino, &partition](Map& map) {
-        auto it = map.find(ino);
-        if (it != map.end()) {
-          partition = it->second;
-        }
-      },
-      ino);
-
+  auto partition = Find(ino);
   if (partition != nullptr) {
     access_hit_count_ << 1;
 
   } else {
     access_miss_count_ << 1;
   }
+
+  return partition;
+}
+
+PartitionPtr PartitionCache::Find(Ino ino) {
+  PartitionPtr partition;
+  shard_map_.withRLock(
+      [ino, &partition](Map& map) {
+        auto it = map.find(ino);
+        if (it != map.end()) partition = it->second;
+      },
+      ino);
 
   return partition;
 }

--- a/src/mds/filesystem/partition.h
+++ b/src/mds/filesystem/partition.h
@@ -107,6 +107,7 @@ class DirShard {
   size_t Bytes() const;
 
   void Dump(Json::Value& value) const;
+  void Snapshot(size_t offset, size_t limit, std::vector<Dentry>& dentries) const;
 
  private:
   const uint64_t id_;
@@ -168,7 +169,8 @@ class ShardPartition {
   size_t ShardSize() const;
   size_t Bytes() const;
 
-  void Dump(Json::Value& value) const;
+  void Dump(Json::Value& value, size_t dentry_offset = 0, size_t dentry_limit = 0, size_t delta_offset = 0,
+            size_t delta_limit = 0) const;
 
  private:
   friend class PartitionCache;
@@ -256,6 +258,8 @@ class PartitionCache {
   void Clear();
 
   PartitionPtr Get(Ino ino);
+  // Returns an entry for diagnostics without changing cache metrics.
+  PartitionPtr Find(Ino ino);
   std::vector<PartitionPtr> GetAll();
 
   size_t Size();

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -4408,6 +4408,10 @@ void OperationProcessor::ProcessOperation(Dispatcher& dispatcher) {
     if (operation) {
       stage_operations.push_back(operation);
       operation = nullptr;
+
+      if (before_batch_drain_hook_for_test_) {
+        std::call_once(before_batch_drain_hook_once_for_test_, [this] { before_batch_drain_hook_for_test_(); });
+      }
     }
 
     if (is_stop_.load(std::memory_order_relaxed) && stage_operations.empty()) {

--- a/src/mds/filesystem/store_operation.cc
+++ b/src/mds/filesystem/store_operation.cc
@@ -4443,6 +4443,8 @@ void OperationProcessor::ProcessOperation(Dispatcher& dispatcher) {
   while (operations.Dequeue(operation)) {
     LOG_DEBUG << fmt::format("[operation] pending operation type({}) ino({}).", operation->OpName(),
                              operation->GetIno());
+    operation->SetStatus(Status(pb::error::ESERVICE_STOPPED, "operation stopped"));
+    operation->NotifyEvent();
   }
 }
 

--- a/src/mds/filesystem/store_operation.h
+++ b/src/mds/filesystem/store_operation.h
@@ -2940,6 +2940,13 @@ class OperationProcessor : public std::enable_shared_from_this<OperationProcesso
   Status RunAlone(Operation* operation);
   bool AsyncRun(OperationSPtr operation, OperationTask::PostHandler post_handler);
 
+  // Must be set before Init(). Invoked once after a dispatcher dequeues the
+  // first operation of a batch and before it drains further operations.
+  void SetBeforeBatchDrainHookForTest(std::function<void()> hook) {
+    CHECK(dispatchers_.empty()) << "test hook must be set before Init.";
+    before_batch_drain_hook_for_test_ = std::move(hook);
+  }
+
   Status CheckTable(const Range& range);
   Status CreateTable(const std::string& table_name, const Range& range, int64_t& table_id);
 
@@ -2987,6 +2994,9 @@ class OperationProcessor : public std::enable_shared_from_this<OperationProcesso
   std::vector<std::unique_ptr<Dispatcher>> dispatchers_;
 
   std::atomic<bool> is_stop_{false};
+
+  std::function<void()> before_batch_drain_hook_for_test_;
+  std::once_flag before_batch_drain_hook_once_for_test_;
 
   ConflictController conflict_controller_;
 

--- a/src/mds/quota/quota.cc
+++ b/src/mds/quota/quota.cc
@@ -14,6 +14,7 @@
 
 #include "mds/quota/quota.h"
 
+#include <atomic>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -38,6 +39,11 @@ Quota::Quota(uint32_t fs_id, Ino ino, const QuotaEntry& quota) : fs_id_(fs_id), 
   LOG_DEBUG << fmt::format("[quota.{}.{}] create quota, detail({}).", fs_id_, ino_, quota.ShortDebugString());
 }
 
+std::string Quota::UUID() {
+  utils::ReadLockGuard lk(rwlock_);
+  return quota_.uuid;
+}
+
 Quota::InnerUsage Quota::GetDeltaAccumulatedUsage(uint64_t& timepoint) {
   if (!delta_usages_.empty()) timepoint = delta_usages_.back().time_ns;
 
@@ -49,9 +55,9 @@ Quota::InnerUsage Quota::GetDeltaAccumulatedUsage(uint64_t& timepoint) {
 }
 
 Quota::InnerUsage Quota::GetTotalAccumulatedUsage(uint64_t& timepoint) {
-  auto usage = GetDeltaAccumulatedUsage(timepoint);
-  usage.bytes = usage.bytes + quota_.used_bytes;
-  usage.inodes = usage.inodes + quota_.used_inodes;
+  InnerUsage usage = GetDeltaAccumulatedUsage(timepoint);
+  usage.bytes += quota_.used_bytes.load(std::memory_order_acquire);
+  usage.inodes += quota_.used_inodes.load(std::memory_order_acquire);
 
   return usage;
 }
@@ -61,8 +67,9 @@ Quota::InnerUsage Quota::CompactDeltaUsage(uint64_t timepoint) {
   while (!delta_usages_.empty()) {
     const auto& delta_usage = delta_usages_.front();
     if (delta_usage.time_ns > timepoint) break;
-    usage.bytes = usage.bytes + delta_usage.bytes;
-    usage.inodes = usage.inodes + delta_usage.inodes;
+    usage.bytes += delta_usage.bytes;
+    usage.inodes += delta_usage.inodes;
+
     delta_bytes_ -= delta_usage.bytes;
     delta_inodes_ -= delta_usage.inodes;
     delta_usages_.pop_front();

--- a/src/mds/quota/quota.h
+++ b/src/mds/quota/quota.h
@@ -83,7 +83,7 @@ class Quota {
   }
 
   Ino INo() const { return ino_; }
-  std::string UUID() const { return quota_.uuid; }
+  std::string UUID();
 
   void UpdateUsage(int64_t byte_delta, int64_t inode_delta, const std::string& reason);
 

--- a/src/mds/service/fsstat_service.cc
+++ b/src/mds/service/fsstat_service.cc
@@ -17,9 +17,11 @@
 #include <json/value.h>
 #include <sys/types.h>
 
+#include <charconv>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -471,6 +473,8 @@ void FsStatServiceImpl::RenderAutoIncrementIdGenerator(FileSystemSetSPtr file_sy
   os << R"(</div>)";
 }
 
+static std::string HtmlEscape(const std::string& input);
+
 static void RenderMdsCacheSummary(Json::Value& json_value, butil::IOBufBuilder& os) {
   os << R"(<div style="margin:12px;margin-top:64px;font-size:smaller">)";
   os << R"(<h3>MDS Cache Summary</h3>)";
@@ -510,7 +514,14 @@ static void RenderMdsCacheSummary(Json::Value& json_value, butil::IOBufBuilder& 
       os << "<tr>";
 
       os << "<td>" << fs_id << "</td>";
-      os << "<td>" << name << "</td>";
+      os << "<td>";
+      if (name == "partitioncache" || name == "inodecache" || name == "chunkcache") {
+        os << fmt::format(R"(<a href="/FsStatService/cache/{}/{}" target="_blank" rel="noopener">{}</a>)", name, fs_id,
+                          name);
+      } else {
+        os << HtmlEscape(name);
+      }
+      os << "</td>";
       os << "<td>" << item["count"].asUInt64() << "</td>";
       os << "<td>" << (item["total_count"].isNull() ? "N/A" : std::to_string(item["total_count"].asUInt64()))
          << "</td>";
@@ -572,6 +583,257 @@ static std::string HtmlEscape(const std::string& input) {
   }
 
   return output;
+}
+
+static constexpr size_t kCachePageSize = 100;
+
+static bool ParseUint64(const std::string& input, uint64_t& value) {
+  if (input.empty()) return false;
+  const auto [ptr, ec] = std::from_chars(input.data(), input.data() + input.size(), value);
+  return ec == std::errc() && ptr == input.data() + input.size();
+}
+
+static size_t ParsePage(const std::string* input) {
+  uint64_t page = 0;
+  if (input == nullptr || !ParseUint64(*input, page) || page == 0 ||
+      page > std::numeric_limits<size_t>::max() / kCachePageSize) {
+    return 1;
+  }
+  return static_cast<size_t>(page);
+}
+
+static std::string CacheUrl(const std::string& cache_name, uint32_t fs_id, Ino ino, size_t dentry_page,
+                            size_t delta_page, size_t chunk_page) {
+  return fmt::format("/FsStatService/cache/{}/{}?ino={}&dentry_page={}&delta_page={}&chunk_page={}", cache_name, fs_id,
+                     ino, dentry_page, delta_page, chunk_page);
+}
+
+static void RenderCachePageStart(const std::string& cache_name, uint32_t fs_id, butil::IOBufBuilder& os) {
+  os << "<!DOCTYPE html><html>" << RenderHead("dingofs local cache") << "<body>";
+  os << fmt::format(R"(<h1 style="text-align:center;">Local {} (fs {})</h1>)", cache_name, fs_id);
+  os << R"(<div style="margin:12px;font-size:smaller">)";
+}
+
+static void RenderCachePageEnd(butil::IOBufBuilder& os) { os << "</div></body></html>"; }
+
+static void RenderPageNavigation(const std::string& cache_name, uint32_t fs_id, Ino ino, size_t dentry_page,
+                                 size_t delta_page, size_t chunk_page, const char* page_name, size_t page, size_t total,
+                                 butil::IOBufBuilder& os) {
+  const size_t page_count = (total + kCachePageSize - 1) / kCachePageSize;
+  if (page_count <= 1) return;
+
+  os << fmt::format("<p>Page {}/{} ", page, page_count);
+  if (page > 1) {
+    size_t previous_dentry_page = dentry_page;
+    size_t previous_delta_page = delta_page;
+    size_t previous_chunk_page = chunk_page;
+    if (std::string(page_name) == "dentry_page") previous_dentry_page = page - 1;
+    if (std::string(page_name) == "delta_page") previous_delta_page = page - 1;
+    if (std::string(page_name) == "chunk_page") previous_chunk_page = page - 1;
+    os << fmt::format(R"(<a href="{}">Previous</a> )",
+                      CacheUrl(cache_name, fs_id, ino, previous_dentry_page, previous_delta_page, previous_chunk_page));
+  }
+  if (page < page_count) {
+    size_t next_dentry_page = dentry_page;
+    size_t next_delta_page = delta_page;
+    size_t next_chunk_page = chunk_page;
+    if (std::string(page_name) == "dentry_page") next_dentry_page = page + 1;
+    if (std::string(page_name) == "delta_page") next_delta_page = page + 1;
+    if (std::string(page_name) == "chunk_page") next_chunk_page = page + 1;
+    os << fmt::format(R"(<a href="{}">Next</a>)",
+                      CacheUrl(cache_name, fs_id, ino, next_dentry_page, next_delta_page, next_chunk_page));
+  }
+  os << "</p>";
+}
+
+static std::string CacheListUrl(const std::string& cache_name, uint32_t fs_id, size_t page) {
+  return fmt::format("/FsStatService/cache/{}/{}?page={}", cache_name, fs_id, page);
+}
+
+static void RenderListNavigation(const std::string& cache_name, uint32_t fs_id, size_t page, size_t total,
+                                 butil::IOBufBuilder& os) {
+  const size_t page_count = std::max<size_t>(1, (total + kCachePageSize - 1) / kCachePageSize);
+  if (page_count <= 1) return;
+
+  os << fmt::format("<p>Page {}/{} ", page, page_count);
+  if (page > 1) os << fmt::format(R"(<a href="{}">Previous</a> )", CacheListUrl(cache_name, fs_id, page - 1));
+  if (page < page_count) os << fmt::format(R"(<a href="{}">Next</a>)", CacheListUrl(cache_name, fs_id, page + 1));
+  os << "</p>";
+}
+
+static void RenderPartitionCacheListPage(uint32_t fs_id, size_t page, std::vector<PartitionPtr> partitions,
+                                         butil::IOBufBuilder& os) {
+  std::sort(partitions.begin(), partitions.end(),
+            [](const PartitionPtr& lhs, const PartitionPtr& rhs) { return lhs->INo() < rhs->INo(); });
+  const size_t total = partitions.size();
+  const size_t page_count = std::max<size_t>(1, (total + kCachePageSize - 1) / kCachePageSize);
+  page = std::min(page, page_count);
+  const size_t begin = (page - 1) * kCachePageSize;
+  const size_t end = std::min(begin + kCachePageSize, total);
+
+  RenderCachePageStart("Partition Cache", fs_id, os);
+  os << fmt::format(R"(<h3>Cached partitions [{}]</h3><table class="gridtable sortable" border=1>)"
+                    R"(<tr><th>Ino</th><th>Base version</th><th>Delta version</th><th>Loaded shards</th>)"
+                    R"(<th>Loaded dentries</th></tr>)",
+                    total);
+  for (size_t i = begin; i < end; ++i) {
+    const auto& partition = partitions[i];
+    os << fmt::format(
+        R"(<tr><td><a href="/FsStatService/cache/partitioncache/{}?ino={}" target="_blank" rel="noopener">{}</a></td>)"
+        R"(<td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>)",
+        fs_id, partition->INo(), partition->INo(), partition->BaseVersion(), partition->DeltaVersion(),
+        partition->ShardSize(), partition->Size());
+  }
+  os << "</table>";
+  RenderListNavigation("partitioncache", fs_id, page, total, os);
+  RenderCachePageEnd(os);
+}
+
+static void RenderInodeCacheListPage(uint32_t fs_id, size_t page, std::vector<InodeSPtr> inodes,
+                                     butil::IOBufBuilder& os) {
+  std::sort(inodes.begin(), inodes.end(),
+            [](const InodeSPtr& lhs, const InodeSPtr& rhs) { return lhs->Ino() < rhs->Ino(); });
+  const size_t total = inodes.size();
+  const size_t page_count = std::max<size_t>(1, (total + kCachePageSize - 1) / kCachePageSize);
+  page = std::min(page, page_count);
+  const size_t begin = (page - 1) * kCachePageSize;
+  const size_t end = std::min(begin + kCachePageSize, total);
+
+  RenderCachePageStart("Inode Cache", fs_id, os);
+  os << fmt::format(R"(<h3>Cached inodes [{}]</h3><table class="gridtable sortable" border=1>)"
+                    R"(<tr><th>Ino</th><th>Type</th><th>Version</th><th>Fresh</th></tr>)",
+                    total);
+  for (size_t i = begin; i < end; ++i) {
+    const auto& inode = inodes[i];
+    os << fmt::format(
+        R"(<tr><td><a href="/FsStatService/cache/inodecache/{}?ino={}" target="_blank" rel="noopener">{}</a></td>)"
+        R"(<td>{}</td><td>{}</td><td>{}</td></tr>)",
+        fs_id, inode->Ino(), inode->Ino(), pb::mds::FileType_Name(inode->Type()), inode->Version(),
+        inode->IsFresh() ? "yes" : "no");
+  }
+  os << "</table>";
+  RenderListNavigation("inodecache", fs_id, page, total, os);
+  RenderCachePageEnd(os);
+}
+
+static void RenderChunkCacheListPage(uint32_t fs_id, size_t page, std::vector<std::pair<Ino, size_t>> entries,
+                                     butil::IOBufBuilder& os) {
+  const size_t total = entries.size();
+  const size_t page_count = std::max<size_t>(1, (total + kCachePageSize - 1) / kCachePageSize);
+  page = std::min(page, page_count);
+  const size_t begin = (page - 1) * kCachePageSize;
+  const size_t end = std::min(begin + kCachePageSize, total);
+
+  RenderCachePageStart("Chunk Cache", fs_id, os);
+  os << fmt::format(R"(<h3>Cached files [{}]</h3><table class="gridtable sortable" border=1>)"
+                    R"(<tr><th>Ino</th><th>Cached chunks</th></tr>)",
+                    total);
+  for (size_t i = begin; i < end; ++i) {
+    const auto& [ino, chunk_count] = entries[i];
+    os << fmt::format(
+        R"(<tr><td><a href="/FsStatService/cache/chunkcache/{}?ino={}" target="_blank" rel="noopener">{}</a></td><td>{}</td></tr>)",
+        fs_id, ino, ino, chunk_count);
+  }
+  os << "</table>";
+  RenderListNavigation("chunkcache", fs_id, page, total, os);
+  RenderCachePageEnd(os);
+}
+
+static void RenderPartitionCachePage(uint32_t fs_id, Ino ino, size_t dentry_page, size_t delta_page,
+                                     const Json::Value& value, butil::IOBufBuilder& os) {
+  RenderCachePageStart("Partition Cache", fs_id, os);
+  os << fmt::format("<h3>Partition ino {}: base version {}, delta version {}</h3>", ino,
+                    value["base_version"].asUInt64(), value["delta_version"].asUInt64());
+
+  os << fmt::format(R"(<h3>Shards [{}]</h3><table class="gridtable sortable" border=1><tr><th>Range</th><th>ID</th>)"
+                    R"(<th>Size</th><th>Version</th></tr>)",
+                    value["shards"].size());
+  for (const auto& shard : value["shards"]) {
+    os << "<tr>";
+    os << fmt::format("<td>[{}, {})</td>", HtmlEscape(shard["start"].asString()), HtmlEscape(shard["end"].asString()));
+    os << "<td>" << (shard["id"].isNull() ? "not loaded" : std::to_string(shard["id"].asUInt64())) << "</td>";
+    os << "<td>" << (shard["size"].isNull() ? "unknown" : std::to_string(shard["size"].asUInt64())) << "</td>";
+    os << "<td>" << (shard["version"].isNull() ? "unknown" : std::to_string(shard["version"].asUInt64()))
+       << "</td></tr>";
+  }
+  os << "</table>";
+
+  const size_t dentry_total = value["dentry_total"].asUInt64();
+  os << fmt::format(R"(<h3>Loaded dentries [{}]</h3><table class="gridtable sortable" border=1>)"
+                    R"(<tr><th>No.</th><th>Name</th><th>Ino</th><th>Parent</th><th>Type</th><th>Flag</th></tr>)",
+                    dentry_total);
+  size_t number = (dentry_page - 1) * kCachePageSize;
+  for (const auto& dentry : value["dentries"]) {
+    os << fmt::format("<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>", ++number,
+                      HtmlEscape(dentry["name"].asString()), dentry["ino"].asUInt64(), dentry["parent_ino"].asUInt64(),
+                      HtmlEscape(dentry["type"].asString()), dentry["flag"].asUInt());
+  }
+  os << "</table>";
+  RenderPageNavigation("partitioncache", fs_id, ino, dentry_page, delta_page, 1, "dentry_page", dentry_page,
+                       dentry_total, os);
+
+  const size_t delta_total = value["delta_dentry_ops_total"].asUInt64();
+  os << fmt::format(R"(<h3>Pending delta operations [{}]</h3><table class="gridtable sortable" border=1>)"
+                    R"(<tr><th>No.</th><th>Operation</th><th>Version</th><th>Time</th><th>Name</th><th>Ino</th></tr>)",
+                    delta_total);
+  number = (delta_page - 1) * kCachePageSize;
+  for (const auto& op : value["delta_dentry_ops"]) {
+    const auto& dentry = op["dentry"];
+    os << fmt::format("<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>", ++number,
+                      op["op"].asString(), op["version"].asUInt64(),
+                      utils::FormatMsTime(op["time_s"].asUInt64() * 1000), HtmlEscape(dentry["name"].asString()),
+                      dentry["ino"].asUInt64());
+  }
+  os << "</table>";
+  RenderPageNavigation("partitioncache", fs_id, ino, dentry_page, delta_page, 1, "delta_page", delta_page, delta_total,
+                       os);
+  RenderCachePageEnd(os);
+}
+
+static void RenderInodeCachePage(uint32_t fs_id, Ino ino, const InodeSPtr& inode, butil::IOBufBuilder& os) {
+  RenderCachePageStart("Inode Cache", fs_id, os);
+
+  AttrEntry attr = inode->ToAttr();
+  std::string attr_json;
+  ::dingofs::Helper::ProtoToJson(attr, attr_json);
+  os << fmt::format("<h3>Inode {}: base version {}, current version {}, fresh {}</h3>", ino, inode->BaseVersion(),
+                    inode->Version(), inode->IsFresh() ? "yes" : "no");
+  os << fmt::format("<p>Last active: {}<br>Last refresh: {}</p>", utils::FormatMsTime(inode->LastActiveTimeS() * 1000),
+                    utils::FormatMsTime(inode->LastRefreshTimeS() * 1000));
+  os << "<h3>Attributes</h3><pre>" << HtmlEscape(attr_json) << "</pre>";
+
+  RenderCachePageEnd(os);
+}
+
+static void RenderChunkCachePage(uint32_t fs_id, Ino ino, size_t chunk_page, size_t total,
+                                 const std::vector<ChunkEntry>& chunks, butil::IOBufBuilder& os) {
+  RenderCachePageStart("Chunk Cache", fs_id, os);
+
+  os << fmt::format(
+      R"(<h3>Cached chunks [{}]</h3><table class="gridtable sortable" border=1>)"
+      R"(<tr><th>Index</th><th>Version</th><th>Expires</th><th>Slices</th><th>Compacted slices</th></tr>)",
+      total);
+  for (const auto& chunk : chunks) {
+    os << fmt::format("<tr><td>{}</td><td>{}</td><td>{}</td><td><ul>", chunk.index(), chunk.version(),
+                      utils::FormatMsTime(chunk.expire_time_s() * 1000));
+    for (const auto& slice : chunk.slices()) {
+      os << fmt::format("<li>id={} pos={} size={} off={} len={}</li>", slice.id(), slice.pos(), slice.size(),
+                        slice.off(), slice.len());
+    }
+    os << "</ul></td><td><ul>";
+    for (const auto& compacted : chunk.compacted_slices()) {
+      os << fmt::format("<li>time={} ids=", utils::FormatMsTime(compacted.time_ms()));
+      for (int i = 0; i < compacted.slice_ids_size(); ++i) {
+        if (i > 0) os << ",";
+        os << compacted.slice_ids(i);
+      }
+      os << "</li>";
+    }
+    os << "</ul></td></tr>";
+  }
+  os << "</table>";
+  RenderPageNavigation("chunkcache", fs_id, ino, 1, 1, chunk_page, "chunk_page", chunk_page, total, os);
+  RenderCachePageEnd(os);
 }
 
 // Tools module: parse a raw storage key (hex string) and show its decoded
@@ -1899,6 +2161,77 @@ void FsStatServiceImpl::default_method(::google::protobuf::RpcController* contro
   } else if (params.size() == 1 && params[0] == "server") {
     // /FsStatService/server
     RenderServerPage(os);
+
+  } else if (params.size() == 3 && params[0] == "cache") {
+    // /FsStatService/cache/{partitioncache|inodecache|chunkcache}/{fs_id}?ino={ino}
+    const std::string& cache_name = params[1];
+    uint64_t parsed_fs_id = 0;
+    if ((cache_name != "partitioncache" && cache_name != "inodecache" && cache_name != "chunkcache") ||
+        !ParseUint64(params[2], parsed_fs_id) || parsed_fs_id > std::numeric_limits<uint32_t>::max()) {
+      cntl->SetFailed("invalid cache path: " + path);
+    } else {
+      const uint32_t fs_id = static_cast<uint32_t>(parsed_fs_id);
+      auto file_system = Server::GetInstance().GetFileSystemSet()->GetFileSystem(fs_id);
+      if (file_system == nullptr) {
+        RenderCachePageStart(cache_name, fs_id, os);
+        os << fmt::format(R"(<p class="red-text">File system {} was not found on this MDS.</p>)", fs_id);
+        RenderCachePageEnd(os);
+      } else {
+        const std::string* ino_query = cntl->http_request().uri().GetQuery("ino");
+        if (ino_query == nullptr) {
+          const size_t page = ParsePage(cntl->http_request().uri().GetQuery("page"));
+          if (cache_name == "partitioncache") {
+            RenderPartitionCacheListPage(fs_id, page, file_system->GetPartitionCache().GetAll(), os);
+          } else if (cache_name == "inodecache") {
+            RenderInodeCacheListPage(fs_id, page, file_system->GetInodeCache().GetAll(), os);
+          } else {
+            RenderChunkCacheListPage(fs_id, page, file_system->GetChunkCache().ListInos(), os);
+          }
+        } else {
+          uint64_t ino = 0;
+          if (!ParseUint64(*ino_query, ino) || ino == 0) {
+            RenderCachePageStart(cache_name, fs_id, os);
+            os << R"(<p class="red-text">Please enter a valid non-zero ino.</p>)";
+            RenderCachePageEnd(os);
+          } else if (cache_name == "partitioncache") {
+            const size_t dentry_page = ParsePage(cntl->http_request().uri().GetQuery("dentry_page"));
+            const size_t delta_page = ParsePage(cntl->http_request().uri().GetQuery("delta_page"));
+            auto partition = file_system->GetPartitionCache().Find(ino);
+            if (partition == nullptr) {
+              RenderCachePageStart(cache_name, fs_id, os);
+              os << R"(<p class="red-text">This ino is not in the local partition cache.</p>)";
+              RenderCachePageEnd(os);
+            } else {
+              Json::Value value;
+              partition->Dump(value, (dentry_page - 1) * kCachePageSize, kCachePageSize,
+                              (delta_page - 1) * kCachePageSize, kCachePageSize);
+              RenderPartitionCachePage(fs_id, ino, dentry_page, delta_page, value, os);
+            }
+          } else if (cache_name == "inodecache") {
+            auto inode = file_system->GetInodeCache().Find(ino);
+            if (inode == nullptr) {
+              RenderCachePageStart(cache_name, fs_id, os);
+              os << R"(<p class="red-text">This ino is not in the local inode cache.</p>)";
+              RenderCachePageEnd(os);
+            } else {
+              RenderInodeCachePage(fs_id, ino, inode, os);
+            }
+          } else {
+            const size_t chunk_page = ParsePage(cntl->http_request().uri().GetQuery("chunk_page"));
+            size_t total = 0;
+            auto chunks =
+                file_system->GetChunkCache().Find(ino, (chunk_page - 1) * kCachePageSize, kCachePageSize, total);
+            if (total == 0) {
+              RenderCachePageStart(cache_name, fs_id, os);
+              os << R"(<p class="red-text">This ino is not in the local chunk cache.</p>)";
+              RenderCachePageEnd(os);
+            } else {
+              RenderChunkCachePage(fs_id, ino, chunk_page, total, chunks, os);
+            }
+          }
+        }
+      }
+    }
 
   } else if (params.size() == 1) {
     // /FsStatService/{fs_id}

--- a/test/unit/mds/common/test_distribution_lock.cc
+++ b/test/unit/mds/common/test_distribution_lock.cc
@@ -36,7 +36,9 @@ class CoorDistributionLockTest : public testing::Test {
 };
 
 TEST_F(CoorDistributionLockTest, Lock) {
-  GTEST_SKIP() << "Skip test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip slow test case.";
+  }
 
   auto coordinator_client = DingoCoordinatorClient::New();
   ASSERT_TRUE(coordinator_client->Init("172.20.3.17:22001"));

--- a/test/unit/mds/filesystem/test_chunk_cache.cc
+++ b/test/unit/mds/filesystem/test_chunk_cache.cc
@@ -114,6 +114,27 @@ TEST_F(ChunkCacheTest, Get) {
   ASSERT_EQ(chunk_cache.Size(), 0);
 }
 
+TEST_F(ChunkCacheTest, FindPaginatesWithoutMixingInodes) {
+  mds::ChunkCache chunk_cache(kFsId);
+  const Ino ino = 100000;
+  ASSERT_TRUE(chunk_cache.PutIf(ino, GenChunkEntry(0, 1)));
+  ASSERT_TRUE(chunk_cache.PutIf(ino, GenChunkEntry(1, 2)));
+  ASSERT_TRUE(chunk_cache.PutIf(ino + 1, GenChunkEntry(0, 3)));
+
+  size_t total = 0;
+  auto chunks = chunk_cache.Find(ino, 1, 1, total);
+
+  ASSERT_EQ(2, total);
+  ASSERT_EQ(1, chunks.size());
+  EXPECT_EQ(1, chunks[0].index());
+  EXPECT_EQ(2, chunks[0].version());
+
+  const auto entries = chunk_cache.ListInos();
+  ASSERT_EQ(2, entries.size());
+  EXPECT_EQ(ino, entries[0].first);
+  EXPECT_EQ(2, entries[0].second);
+}
+
 TEST_F(ChunkCacheTest, Delete) {
   mds::ChunkCache chunk_cache(kFsId);
   Ino ino = 100000;

--- a/test/unit/mds/filesystem/test_dentry.cc
+++ b/test/unit/mds/filesystem/test_dentry.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <glog/logging.h>
-#include "common/helper.h"
 
 #include <chrono>
 #include <cstdint>
@@ -25,6 +24,7 @@
 #include <thread>
 #include <vector>
 
+#include "common/helper.h"
 #include "dingofs/mds.pb.h"
 #include "fmt/format.h"
 #include "gtest/gtest.h"
@@ -83,7 +83,9 @@ class FileStore {
 using FileStoreSPtr = std::shared_ptr<FileStore>;
 
 TEST_F(DentryTest, ReadDir) {
-  GTEST_SKIP() << "Skip DentryTest.ReadDir test case.";
+  if (getenv("SLOW_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip slow test case.";
+  }
 
   FileStoreSPtr file_store = std::make_shared<FileStore>();
 
@@ -153,8 +155,9 @@ TEST_F(DentryTest, ReadDir) {
   for (int i = 0; i < createfile_thread_num; ++i) {
     std::thread t([sandbox, thread_no = i, file_store]() {
       for (size_t j = 0; j < 10000; ++j) {
-        const std::string file_path = fmt::format(
-            "{}/file_{}_{}", sandbox, ::dingofs::Helper::GenerateRandomString(32), j);
+        const std::string file_path =
+            fmt::format("{}/file_{}_{}", sandbox,
+                        ::dingofs::Helper::GenerateRandomString(32), j);
 
         std::ofstream ofs(file_path);
         // ofs << "this is a test file." << '\n';

--- a/test/unit/mds/filesystem/test_filesystem.cc
+++ b/test/unit/mds/filesystem/test_filesystem.cc
@@ -13,10 +13,17 @@
 // limitations under the License.
 
 #include <absl/container/flat_hash_map.h>
+#include <fcntl.h>
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
+#include <mutex>
+#include <numeric>
+#include <random>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -228,16 +235,16 @@ FileSystemSPtr FileSystemTest::fs = nullptr;
 OperationProcessorSPtr FileSystemTest::operation_processor = nullptr;
 
 TEST_F(FileSystemSetTest, CreateFs) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs_set = FsSet();
 
   FileSystemSet::CreateFsParam param;
+  param.fs_id = 0;
   param.fs_name = "test_fs_for_create";
   param.block_size = 1024 * 1024;
+  param.chunk_size = 64 * 1024 * 1024;
   param.fs_type = pb::mds::FsType::S3;
+  param.partition_type = pb::mds::PartitionType::MONOLITHIC_PARTITION;
+  param.candidate_mds_ids = {kMdsId};
   *param.fs_extra.mutable_s3_info() = CreateS3Info();
   param.enable_dir_stats = false;
   param.owner = "dengzh";
@@ -255,16 +262,16 @@ TEST_F(FileSystemSetTest, CreateFs) {
 }
 
 TEST_F(FileSystemSetTest, GetFsInfo) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs_set = FsSet();
 
   FileSystemSet::CreateFsParam param;
+  param.fs_id = 0;
   param.fs_name = "test_fs_for_get";
   param.block_size = 1024 * 1024;
+  param.chunk_size = 64 * 1024 * 1024;
   param.fs_type = pb::mds::FsType::S3;
+  param.partition_type = pb::mds::PartitionType::MONOLITHIC_PARTITION;
+  param.candidate_mds_ids = {kMdsId};
   *param.fs_extra.mutable_s3_info() = CreateS3Info();
   param.enable_dir_stats = false;
   param.owner = "dengzh";
@@ -290,15 +297,16 @@ TEST_F(FileSystemSetTest, GetFsInfo) {
 }
 
 TEST_F(FileSystemSetTest, DeleteFs) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
   auto fs_set = FsSet();
 
   FileSystemSet::CreateFsParam param;
+  param.fs_id = 0;
   param.fs_name = "test_fs_for_delete";
   param.block_size = 1024 * 1024;
+  param.chunk_size = 64 * 1024 * 1024;
   param.fs_type = pb::mds::FsType::S3;
+  param.partition_type = pb::mds::PartitionType::MONOLITHIC_PARTITION;
+  param.candidate_mds_ids = {kMdsId};
   *param.fs_extra.mutable_s3_info() = CreateS3Info();
   param.enable_dir_stats = false;
   param.owner = "dengzh";
@@ -324,16 +332,16 @@ TEST_F(FileSystemSetTest, DeleteFs) {
 }
 
 TEST_F(FileSystemSetTest, MountFs) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs_set = FsSet();
 
   FileSystemSet::CreateFsParam param;
+  param.fs_id = 0;
   param.fs_name = "test_fs_for_mount";
   param.block_size = 1024 * 1024;
+  param.chunk_size = 64 * 1024 * 1024;
   param.fs_type = pb::mds::FsType::S3;
+  param.partition_type = pb::mds::PartitionType::MONOLITHIC_PARTITION;
+  param.candidate_mds_ids = {kMdsId};
   *param.fs_extra.mutable_s3_info() = CreateS3Info();
   param.enable_dir_stats = false;
   param.owner = "dengzh";
@@ -349,6 +357,7 @@ TEST_F(FileSystemSetTest, MountFs) {
 
   Context ctx;
   pb::mds::MountPoint mount_point;
+  mount_point.set_client_id("00000000-0000-0000-0000-000000000002");
   mount_point.set_hostname("localhost");
   mount_point.set_port(8080);
   mount_point.set_path("/mnt/dingofs");
@@ -369,16 +378,16 @@ TEST_F(FileSystemSetTest, MountFs) {
 }
 
 TEST_F(FileSystemSetTest, UnMountFs) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs_set = FsSet();
 
   FileSystemSet::CreateFsParam param;
+  param.fs_id = 0;
   param.fs_name = "test_fs_for_unmount";
   param.block_size = 1024 * 1024;
+  param.chunk_size = 64 * 1024 * 1024;
   param.fs_type = pb::mds::FsType::S3;
+  param.partition_type = pb::mds::PartitionType::MONOLITHIC_PARTITION;
+  param.candidate_mds_ids = {kMdsId};
   *param.fs_extra.mutable_s3_info() = CreateS3Info();
   param.enable_dir_stats = false;
   param.owner = "dengzh";
@@ -394,7 +403,7 @@ TEST_F(FileSystemSetTest, UnMountFs) {
 
   Context ctx;
   pb::mds::MountPoint mount_point;
-  mount_point.set_client_id("xxxxxxxxxxxxxxxxxxxxxxxx");
+  mount_point.set_client_id("00000000-0000-0000-0000-000000000001");
   mount_point.set_hostname("localhost");
   mount_point.set_port(8080);
   mount_point.set_path("/mnt/dingofs");
@@ -427,10 +436,6 @@ TEST_F(FileSystemSetTest, UnMountFs) {
 }
 
 TEST_F(FileSystemTest, CreateRoot) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
 
   auto& partition_cache = fs->GetPartitionCache();
@@ -446,10 +451,6 @@ TEST_F(FileSystemTest, CreateRoot) {
 }
 
 TEST_F(FileSystemTest, MkNod) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -488,10 +489,24 @@ TEST_F(FileSystemTest, MkNod) {
   ASSERT_EQ(param.rdev, inode->Rdev()) << "inode rdev not equal.";
 }
 
+TEST_F(FileSystemTest, MkNodDuplicate) {
+  auto fs = Fs();
+  Context ctx;
+
+  FileSystem::MkNodParam param;
+  param.parent = kRootIno;
+  param.name = "duplicate_file";
+
+  EntryWithPaOut entry_out;
+  ASSERT_TRUE(fs->MkNod(ctx, param, entry_out).ok());
+  const auto first_ino = entry_out.attr.ino();
+
+  auto status = fs->MkNod(ctx, param, entry_out);
+  ASSERT_EQ(pb::error::EEXISTED, status.error_code());
+  ASSERT_EQ(first_ino, entry_out.attr.ino());
+}
+
 TEST_F(FileSystemTest, MkDir) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -523,13 +538,30 @@ TEST_F(FileSystemTest, MkDir) {
   InodeSPtr inode = inode_cache.Get(entry_out.attr.ino());
   ASSERT_TRUE(status.ok()) << "get inode fail, error: " << status.error_str();
   ASSERT_TRUE(inode != nullptr) << "get inode fail.";
-  ASSERT_EQ(param.mode, inode->Mode()) << "inode mode not equal.";
+  ASSERT_EQ(S_IFDIR | param.mode, inode->Mode()) << "inode mode not equal.";
   ASSERT_EQ(param.uid, inode->Uid()) << "inode uid not equal.";
   ASSERT_EQ(param.gid, inode->Gid()) << "inode gid not equal.";
   ASSERT_EQ(pb::mds::FileType::DIRECTORY, inode->Type())
       << "inode type not equal.";
   ASSERT_EQ(4096, inode->Length()) << "inode length not equal.";
   ASSERT_EQ(param.rdev, inode->Rdev()) << "inode rdev not equal.";
+}
+
+TEST_F(FileSystemTest, MkDirDuplicate) {
+  auto fs = Fs();
+  Context ctx;
+
+  FileSystem::MkDirParam param;
+  param.parent = kRootIno;
+  param.name = "duplicate_dir";
+
+  EntryWithPaOut entry_out;
+  ASSERT_TRUE(fs->MkDir(ctx, param, entry_out).ok());
+  const auto first_ino = entry_out.attr.ino();
+
+  auto status = fs->MkDir(ctx, param, entry_out);
+  ASSERT_EQ(pb::error::EEXISTED, status.error_code());
+  ASSERT_EQ(first_ino, entry_out.attr.ino());
 }
 
 TEST_F(FileSystemTest, CreateInheritsSetgidParent) {
@@ -581,10 +613,6 @@ TEST_F(FileSystemTest, CreateInheritsSetgidParent) {
 }
 
 TEST_F(FileSystemTest, RmDir) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -634,9 +662,6 @@ TEST_F(FileSystemTest, RmDir) {
 }
 
 TEST_F(FileSystemTest, Link) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -645,7 +670,7 @@ TEST_F(FileSystemTest, Link) {
 
   FileSystem::MkNodParam param;
   param.parent = kRootIno;
-  param.name = "link_file";
+  param.name = "link_file_source";
   param.mode = 0777;
   param.uid = 1;
   param.gid = 3;
@@ -661,18 +686,24 @@ TEST_F(FileSystemTest, Link) {
 
   {
     EntryWithPaOut entry_out;
-    auto status = fs->Link(ctx, inode->Ino(), kRootIno, "link_file", entry_out);
+    auto status =
+        fs->Link(ctx, inode->Ino(), kRootIno, "link_file_hardlink", entry_out);
     ASSERT_TRUE(status.ok()) << "link fail, error: " << status.error_str();
     ASSERT_EQ(inode->Ino(), entry_out.attr.ino()) << "ino is invalid.";
     ASSERT_EQ(2, inode->Nlink()) << "nlink not equal.";
   }
 }
 
-TEST_F(FileSystemTest, UnLink) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
+TEST_F(FileSystemTest, RmDirNotFound) {
+  auto fs = Fs();
+  Context ctx;
+  EntryWithPaOut entry_out;
 
+  auto status = fs->RmDir(ctx, kRootIno, "missing_dir", entry_out);
+  ASSERT_EQ(pb::error::ENOT_FOUND, status.error_code());
+}
+
+TEST_F(FileSystemTest, UnLink) {
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -681,7 +712,7 @@ TEST_F(FileSystemTest, UnLink) {
 
   FileSystem::MkNodParam param;
   param.parent = kRootIno;
-  param.name = "unlink_file";
+  param.name = "unlink_file_source";
   param.mode = 0777;
   param.uid = 1;
   param.gid = 3;
@@ -697,22 +728,68 @@ TEST_F(FileSystemTest, UnLink) {
 
   {
     EntryWithPaOut entry_out;
-    auto status = fs->Link(ctx, inode->Ino(), kRootIno, "link_file", entry_out);
+    auto status = fs->Link(ctx, inode->Ino(), kRootIno, "unlink_file_hardlink",
+                           entry_out);
     ASSERT_TRUE(status.ok()) << "link fail, error: " << status.error_str();
     ASSERT_EQ(inode->Ino(), entry_out.attr.ino()) << "ino is invalid.";
     ASSERT_EQ(2, inode->Nlink()) << "nlink not equal.";
 
-    status = fs->UnLink(ctx, kRootIno, "link_file", entry_out);
+    status = fs->UnLink(ctx, kRootIno, "unlink_file_hardlink", entry_out);
     ASSERT_TRUE(status.ok()) << "link fail, error: " << status.error_str();
     ASSERT_EQ(1, inode->Nlink()) << "nlink not equal.";
   }
 }
 
-TEST_F(FileSystemTest, SymlinkWithFile) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
+TEST_F(FileSystemTest, UnLinkNotFound) {
+  auto fs = Fs();
+  Context ctx;
+  EntryWithPaOut entry_out;
 
+  auto status = fs->UnLink(ctx, kRootIno, "missing_file", entry_out);
+  ASSERT_EQ(pb::error::ENOT_FOUND, status.error_code());
+}
+
+TEST_F(FileSystemTest, LinkDuplicate) {
+  auto fs = Fs();
+  Context ctx;
+
+  FileSystem::MkNodParam param;
+  param.parent = kRootIno;
+  param.name = "duplicate_hardlink_source";
+
+  EntryWithPaOut source_out;
+  ASSERT_TRUE(fs->MkNod(ctx, param, source_out).ok());
+
+  const std::string link_name = "duplicate_hardlink";
+  EntryWithPaOut entry_out;
+  ASSERT_TRUE(
+      fs->Link(ctx, source_out.attr.ino(), kRootIno, link_name, entry_out)
+          .ok());
+  const auto first_ino = entry_out.attr.ino();
+
+  auto status =
+      fs->Link(ctx, source_out.attr.ino(), kRootIno, link_name, entry_out);
+  ASSERT_EQ(pb::error::EEXISTED, status.error_code());
+  ASSERT_EQ(first_ino, entry_out.attr.ino());
+}
+
+TEST_F(FileSystemTest, SymlinkDuplicate) {
+  auto fs = Fs();
+  Context ctx;
+  const std::string link_name = "duplicate_symlink";
+
+  EntryWithPaOut entry_out;
+  ASSERT_TRUE(
+      fs->Symlink(ctx, "/target", kRootIno, link_name, 1, 1, entry_out).ok());
+  const auto first_ino = entry_out.attr.ino();
+
+  auto status =
+      fs->Symlink(ctx, "/target", kRootIno, link_name, 1, 1, entry_out);
+  ASSERT_EQ(pb::error::EEXISTED, status.error_code());
+  ASSERT_EQ(first_ino, entry_out.attr.ino());
+}
+
+TEST_F(FileSystemTest, SymlinkWithFile) {
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -737,7 +814,7 @@ TEST_F(FileSystemTest, SymlinkWithFile) {
 
   {
     std::string symlink = fmt::format("/{}", param.name);
-    std::string name = "symlinkwithfile";
+    std::string name = "symlink_file_link";
     EntryWithPaOut entry_out;
     auto status = fs->Symlink(ctx, symlink, kRootIno, name, 1, 3, entry_out);
     ASSERT_TRUE(status.ok())
@@ -753,10 +830,6 @@ TEST_F(FileSystemTest, SymlinkWithFile) {
 }
 
 TEST_F(FileSystemTest, SymlinkWithDir) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -797,10 +870,6 @@ TEST_F(FileSystemTest, SymlinkWithDir) {
 }
 
 TEST_F(FileSystemTest, ReadLink) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -841,10 +910,6 @@ TEST_F(FileSystemTest, ReadLink) {
 }
 
 TEST_F(FileSystemTest, SetXAttr) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -876,10 +941,6 @@ TEST_F(FileSystemTest, SetXAttr) {
 }
 
 TEST_F(FileSystemTest, GetXAttr) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -915,9 +976,9 @@ TEST_F(FileSystemTest, GetXAttr) {
   ASSERT_EQ(xattr.size(), actual_xattr.size()) << "xattr not equal.";
 
   std::string value;
-  status = fs->GetXAttr(ctx, inode->Ino(), "key1", value);
+  status = fs->GetXAttr(ctx, inode->Ino(), "key3", value);
   ASSERT_TRUE(status.ok()) << "get xattr fail, error: " << status.error_str();
-  ASSERT_EQ("value1", value) << "xattr value not equal.";
+  ASSERT_EQ("value3", value) << "xattr value not equal.";
 }
 
 // /
@@ -929,10 +990,6 @@ TEST_F(FileSystemTest, GetXAttr) {
 // |  |--file2
 // rename dir1/file1 to dir1/file2
 TEST_F(FileSystemTest, RenameWithSameDir) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -989,7 +1046,10 @@ TEST_F(FileSystemTest, RenameWithSameDir) {
   auto status = fs->Rename(ctx, param, rename_result);
   ASSERT_TRUE(status.ok()) << "rename fail, error: " << status.error_str();
 
+  std::vector<EntryWithNameOut> entries;
+  ASSERT_TRUE(fs->ReadDir(ctx, old_parent_ino, "", 0, false, entries).ok());
   auto partition = partition_cache.Get(old_parent_ino);
+  ASSERT_TRUE(partition != nullptr);
   Dentry dentry;
   status = partition->Get(old_name, dentry);
   ASSERT_FALSE(status.ok())
@@ -1012,10 +1072,6 @@ TEST_F(FileSystemTest, RenameWithSameDir) {
 // |  |--file1
 // rename dir1/file1 to dir2/file1
 TEST_F(FileSystemTest, RenameWithDiffDir) {
-  if (getenv("MANUAL_TEST") == nullptr) {
-    GTEST_SKIP() << "Skip manual test case.";
-  }
-
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -1084,7 +1140,7 @@ TEST_F(FileSystemTest, RenameWithDiffDir) {
   FileSystem::RenameParam param;
   param.old_parent = old_parent_ino;
   param.old_name = old_name;
-  param.new_parent = old_parent_ino;
+  param.new_parent = new_parent_ino;
   param.new_name = new_name;
 
   FileSystem::RenameResult rename_result;
@@ -1092,7 +1148,10 @@ TEST_F(FileSystemTest, RenameWithDiffDir) {
   ASSERT_TRUE(status.ok()) << "rename fail, error: " << status.error_str();
 
   {
+    std::vector<EntryWithNameOut> entries;
+    ASSERT_TRUE(fs->ReadDir(ctx, old_parent_ino, "", 0, false, entries).ok());
     auto partition = partition_cache.Get(old_parent_ino);
+    ASSERT_TRUE(partition != nullptr);
     Dentry dentry;
     auto status = partition->Get(old_name, dentry);
     ASSERT_FALSE(status.ok())
@@ -1100,7 +1159,10 @@ TEST_F(FileSystemTest, RenameWithDiffDir) {
   }
 
   {
+    std::vector<EntryWithNameOut> entries;
+    ASSERT_TRUE(fs->ReadDir(ctx, new_parent_ino, "", 0, false, entries).ok());
     auto partition = partition_cache.Get(new_parent_ino);
+    ASSERT_TRUE(partition != nullptr);
     Dentry dentry;
     auto status = partition->Get(new_name, dentry);
     ASSERT_TRUE(status.ok())
@@ -1794,6 +1856,607 @@ TEST_F(FileSystemTest, CalcDirStatNoPageBoundaryDoubleCount) {
   ASSERT_TRUE(fs->CalcDirStat(bypass_ctx, d, st).ok());
   EXPECT_EQ(st.inodes(),
             kCount);  // exactly kCount, not kCount + (boundary dups)
+}
+
+// Every worker owns a private directory.  The operation order is random, but
+// each operation has a pre-created, independent fixture so failures are real
+// filesystem failures rather than expected dependency races.
+TEST_F(FileSystemTest, ChaosOperations) {
+  if (getenv("SLOW_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip slow test case.";
+  }
+
+  auto fs = Fs();
+  constexpr int kWorkerCount = 8;
+  constexpr int kRoundCount = 1000;
+
+  struct Fixture {
+    std::string prefix;
+    std::string file_name;
+    std::string src_name;
+    std::string dst_name;
+    std::string unlink_name;
+    std::string batch_unlink_a;
+    std::string batch_unlink_b;
+    std::string rmdir_name;
+    std::string rename_src;
+    std::string rename_dst;
+    std::string readlink_name;
+    Ino dir{0};
+    Ino file{0};
+    Ino src{0};
+    Ino dst{0};
+    Ino unlink_ino{0};
+    Ino rmdir_ino{0};
+    Ino rename_ino{0};
+    Ino readlink_ino{0};
+    uint64_t first_slice_id{0};
+    uint64_t second_slice_id{0};
+    std::string release_session;
+  };
+
+  std::vector<Fixture> fixtures(kWorkerCount * kRoundCount);
+  auto make_dir = [&](Ino parent, const std::string& name) -> Ino {
+    FileSystem::MkDirParam param;
+    param.parent = parent;
+    param.name = name;
+    param.mode = 0755;
+    param.uid = 1;
+    param.gid = 1;
+    EntryWithPaOut out;
+    Context ctx("chaos-setup-" + name, "ChaosSetup");
+    auto status = fs->MkDir(ctx, param, out);
+    if (!status.ok()) {
+      ADD_FAILURE() << "mkdir " << name << ": " << status.error_str();
+      return 0;
+    }
+    return out.attr.ino();
+  };
+  auto make_file = [&](Ino parent, const std::string& name) -> Ino {
+    FileSystem::MkNodParam param;
+    param.parent = parent;
+    param.name = name;
+    param.mode = 0644;
+    param.uid = 1;
+    param.gid = 1;
+    EntryWithPaOut out;
+    Context ctx("chaos-setup-" + name, "ChaosSetup");
+    auto status = fs->MkNod(ctx, param, out);
+    if (!status.ok()) {
+      ADD_FAILURE() << "mknod " << name << ": " << status.error_str();
+      return 0;
+    }
+    return out.attr.ino();
+  };
+
+  for (int round = 0; round < kRoundCount; ++round) {
+    for (int worker = 0; worker < kWorkerCount; ++worker) {
+      auto& f = fixtures[round * kWorkerCount + worker];
+      f.prefix = fmt::format("chaos_ops_{}_{}", round, worker);
+      f.file_name = f.prefix + "_file";
+      f.src_name = f.prefix + "_src";
+      f.dst_name = f.prefix + "_dst";
+      f.unlink_name = f.prefix + "_unlink";
+      f.batch_unlink_a = f.prefix + "_batch_unlink_a";
+      f.batch_unlink_b = f.prefix + "_batch_unlink_b";
+      f.rmdir_name = f.prefix + "_rmdir";
+      f.rename_src = f.prefix + "_rename_src";
+      f.rename_dst = f.prefix + "_rename_dst";
+      f.readlink_name = f.prefix + "_readlink";
+      f.release_session = f.prefix + "_release_session";
+
+      f.dir = make_dir(kRootIno, f.prefix);
+      ASSERT_GT(f.dir, 0u);
+      f.file = make_file(f.dir, f.file_name);
+      f.src = make_file(f.dir, f.src_name);
+      f.dst = make_file(f.dir, f.dst_name);
+      f.unlink_ino = make_file(f.dir, f.unlink_name);
+      ASSERT_GT(f.file, 0u);
+      ASSERT_GT(f.src, 0u);
+      ASSERT_GT(f.dst, 0u);
+      ASSERT_GT(f.unlink_ino, 0u);
+      ASSERT_GT(make_file(f.dir, f.batch_unlink_a), 0u);
+      ASSERT_GT(make_file(f.dir, f.batch_unlink_b), 0u);
+      f.rmdir_ino = make_dir(f.dir, f.rmdir_name);
+      ASSERT_GT(f.rmdir_ino, 0u);
+      f.rename_ino = make_file(f.dir, f.rename_src);
+      ASSERT_GT(f.rename_ino, 0u);
+
+      {
+        EntryWithPaOut out;
+        Context ctx("chaos-setup-" + f.readlink_name, "ChaosSetup");
+        auto status = fs->Symlink(ctx, "/chaos-target", f.dir, f.readlink_name,
+                                  1, 1, out);
+        ASSERT_TRUE(status.ok()) << status.error_str();
+        f.readlink_ino = out.attr.ino();
+      }
+
+      // Give the slice operations a stable chunk with two slices.  The IDs are
+      // deliberately outside the test generator's normal range and unique per
+      // worker.
+      f.first_slice_id = (1ULL << 50) + (round * kWorkerCount + worker) * 100;
+      f.second_slice_id = f.first_slice_id + 1;
+      auto seed_slices = [&](Ino ino, uint64_t first_id, int count) {
+        DeltaSliceEntry delta;
+        delta.set_chunk_index(0);
+        delta.set_curr_version(0);
+        for (int i = 0; i < count; ++i) {
+          auto* slice = delta.add_slices();
+          slice->set_id(first_id + i);
+          slice->set_off(0);
+          slice->set_size(4096);
+          slice->set_pos(i * 4096);
+          slice->set_len(4096);
+        }
+        EntryWithChunkOut out;
+        Context ctx(fmt::format("chaos-setup-slice-{}", ino), "ChaosSetup");
+        auto status = fs->WriteSlice(ctx, ino, {delta}, out);
+        ASSERT_TRUE(status.ok()) << status.error_str();
+        ASSERT_EQ(out.attr.ino(), ino);
+      };
+      seed_slices(f.file, f.first_slice_id, 2);
+      seed_slices(f.src, f.first_slice_id + 10, 1);
+
+      {
+        Inode::XAttrMap xattrs;
+        xattrs["chaos.seed"] = "value";
+        xattrs["chaos.remove"] = "value";
+        EntryOut out;
+        Context ctx("chaos-setup-xattr-" + std::to_string(worker),
+                    "ChaosSetup");
+        auto status = fs->SetXAttr(ctx, f.file, xattrs, out);
+        ASSERT_TRUE(status.ok()) << status.error_str();
+      }
+
+      {
+        FileSystem::OpenParam param;
+        param.flags = O_RDWR;
+        param.session_id = f.release_session;
+        EntryOutForOpen out;
+        Context ctx("chaos-setup-open-" + std::to_string(worker), "ChaosSetup");
+        auto status = fs->Open(ctx, f.file, param, out);
+        ASSERT_TRUE(status.ok()) << status.error_str();
+        ASSERT_EQ(out.attr.ino(), f.file);
+      }
+    }
+  }
+
+  std::mutex failures_mutex;
+  std::vector<std::string> failures;
+  auto fail = [&](const std::string& message) {
+    std::lock_guard<std::mutex> lock(failures_mutex);
+    failures.push_back(message);
+  };
+  auto check_status = [&](int worker, const char* operation,
+                          const Status& status) {
+    if (!status.ok()) {
+      fail(fmt::format("worker {} {}: {}", worker, operation,
+                       status.error_str()));
+      return false;
+    }
+    return true;
+  };
+
+  struct OperationContext {
+    OperationContext(int worker, const char* name)
+        : context(fmt::format("chaos-{}-{}", worker, name), "ChaosOperations") {
+    }
+    operator Context&() { return context; }
+    Context context;
+  };
+
+  std::atomic<int> ready_workers{0};
+  std::atomic<bool> start_workers{false};
+  std::vector<std::thread> workers;
+  workers.reserve(kWorkerCount);
+  for (int worker = 0; worker < kWorkerCount; ++worker) {
+    workers.emplace_back([&, worker] {
+      ready_workers.fetch_add(1);
+      while (!start_workers.load()) std::this_thread::yield();
+
+      for (int round = 0; round < kRoundCount; ++round) {
+        const auto& f = fixtures[round * kWorkerCount + worker];
+        std::vector<int> operations(27);
+        std::iota(operations.begin(), operations.end(), 0);
+        std::mt19937 random(
+            static_cast<uint32_t>(0xd1a0f5 + round * kWorkerCount + worker));
+        std::shuffle(operations.begin(), operations.end(), random);
+
+        for (int operation : operations) {
+          auto context = [&](const char* name) {
+            return OperationContext(worker, name);
+          };
+          switch (operation) {
+            case 0: {  // Lookup
+              EntryOut out;
+              auto status =
+                  fs->Lookup(context("lookup"), f.dir, f.file_name, out);
+              if (check_status(worker, "Lookup", status) &&
+                  out.attr.ino() != f.file) {
+                fail(fmt::format("worker {} Lookup returned ino {} (want {})",
+                                 worker, out.attr.ino(), f.file));
+              }
+              break;
+            }
+            case 1: {  // BatchCreate
+              std::vector<FileSystem::MkNodParam> params(2);
+              for (int i = 0; i < 2; ++i) {
+                params[i].parent = f.dir;
+                params[i].name = fmt::format("{}_batch_create_{}", f.prefix, i);
+                params[i].mode = 0644;
+              }
+              EntriesWithPaOut out;
+              auto status =
+                  fs->BatchCreate(context("batch-create"), f.dir, params, out);
+              if (check_status(worker, "BatchCreate", status)) {
+                if (out.attrs.size() != 2) {
+                  fail(fmt::format("worker {} BatchCreate returned {} attrs",
+                                   worker, out.attrs.size()));
+                }
+                for (const auto& attr : out.attrs) {
+                  if (attr.type() != pb::mds::FileType::FILE || attr.ino() == 0)
+                    fail(fmt::format("worker {} BatchCreate returned bad attr",
+                                     worker));
+                }
+              }
+              break;
+            }
+            case 2: {  // MkNod
+              FileSystem::MkNodParam param;
+              param.parent = f.dir;
+              param.name = f.prefix + "_mknod";
+              param.mode = 0644;
+              EntryWithPaOut out;
+              auto status = fs->MkNod(context("mknod"), param, out);
+              if (check_status(worker, "MkNod", status) &&
+                  (out.attr.ino() == 0 ||
+                   out.attr.type() != pb::mds::FileType::FILE)) {
+                fail(fmt::format("worker {} MkNod returned bad attr", worker));
+              }
+              break;
+            }
+            case 3: {  // BatchMkNod
+              std::vector<FileSystem::MkNodParam> params(2);
+              for (int i = 0; i < 2; ++i) {
+                params[i].parent = f.dir;
+                params[i].name = fmt::format("{}_batch-mknod_{}", f.prefix, i);
+                params[i].mode = 0644;
+              }
+              EntriesWithPaOut out;
+              auto status = fs->BatchMkNod(context("batch-mknod"), params, out);
+              if (check_status(worker, "BatchMkNod", status) &&
+                  out.attrs.size() != 2) {
+                fail(fmt::format("worker {} BatchMkNod returned {} attrs",
+                                 worker, out.attrs.size()));
+              }
+              break;
+            }
+            case 4: {  // Open
+              FileSystem::OpenParam param;
+              param.flags = O_RDWR;
+              param.session_id = f.prefix + "_open_session";
+              EntryOutForOpen out;
+              auto status = fs->Open(context("open"), f.file, param, out);
+              if (check_status(worker, "Open", status) &&
+                  out.attr.ino() != f.file) {
+                fail(fmt::format("worker {} Open returned wrong ino", worker));
+              }
+              break;
+            }
+            case 5: {  // Release
+              auto status =
+                  fs->Release(context("release"), f.file, f.release_session);
+              check_status(worker, "Release", status);
+              break;
+            }
+            case 6: {  // FlushFile
+              FileSystem::FlushFileParam param;
+              param.length = 12345 + worker;
+              EntryWithFileChangeOut out;
+              auto status = fs->FlushFile(context("flush"), f.file, param, out);
+              if (check_status(worker, "FlushFile", status) &&
+                  out.attr.length() != param.length) {
+                fail(fmt::format("worker {} FlushFile length {} (want {})",
+                                 worker, out.attr.length(), param.length));
+              }
+              break;
+            }
+            case 7: {  // MkDir
+              FileSystem::MkDirParam param;
+              param.parent = f.dir;
+              param.name = f.prefix + "_mkdir";
+              param.mode = 0755;
+              EntryWithPaOut out;
+              auto status = fs->MkDir(context("mkdir"), param, out);
+              if (check_status(worker, "MkDir", status) &&
+                  out.attr.type() != pb::mds::FileType::DIRECTORY) {
+                fail(fmt::format("worker {} MkDir returned non-directory",
+                                 worker));
+              }
+              break;
+            }
+            case 8: {  // BatchMkDir
+              std::vector<FileSystem::MkDirParam> params(2);
+              for (int i = 0; i < 2; ++i) {
+                params[i].parent = f.dir;
+                params[i].name = fmt::format("{}_batch-mkdir_{}", f.prefix, i);
+                params[i].mode = 0755;
+              }
+              EntriesWithPaOut out;
+              auto status = fs->BatchMkDir(context("batch-mkdir"), params, out);
+              if (check_status(worker, "BatchMkDir", status) &&
+                  out.attrs.size() != 2) {
+                fail(fmt::format("worker {} BatchMkDir returned {} attrs",
+                                 worker, out.attrs.size()));
+              }
+              break;
+            }
+            case 9: {  // RmDir
+              EntryWithPaOut out;
+              auto status =
+                  fs->RmDir(context("rmdir"), f.dir, f.rmdir_name, out);
+              if (check_status(worker, "RmDir", status) &&
+                  out.attr.ino() != f.rmdir_ino) {
+                fail(fmt::format("worker {} RmDir returned wrong ino", worker));
+              }
+              break;
+            }
+            case 10: {  // ReadDir
+              std::vector<EntryWithNameOut> entries;
+              auto status =
+                  fs->ReadDir(context("readdir"), f.dir, "", 0, false, entries);
+              if (check_status(worker, "ReadDir", status)) {
+                const bool found = std::any_of(
+                    entries.begin(), entries.end(), [&](const auto& entry) {
+                      return entry.name == f.file_name &&
+                             entry.attr.ino() == f.file;
+                    });
+                if (!found)
+                  fail(fmt::format("worker {} ReadDir missed file", worker));
+              }
+              break;
+            }
+            case 11: {  // Link
+              EntryWithPaOut out;
+              auto status = fs->Link(context("link"), f.file, f.dir,
+                                     f.prefix + "_link", out);
+              if (check_status(worker, "Link", status) &&
+                  out.attr.ino() != f.file) {
+                fail(fmt::format("worker {} Link returned wrong ino", worker));
+              }
+              break;
+            }
+            case 12: {  // UnLink
+              EntryWithPaOut out;
+              auto status =
+                  fs->UnLink(context("unlink"), f.dir, f.unlink_name, out);
+              if (check_status(worker, "UnLink", status) &&
+                  out.attr.ino() != f.unlink_ino) {
+                fail(
+                    fmt::format("worker {} UnLink returned wrong ino", worker));
+              }
+              break;
+            }
+            case 13: {  // BatchUnLink
+              EntriesWithPaOut out;
+              auto status =
+                  fs->BatchUnLink(context("batch-unlink"), f.dir,
+                                  {f.batch_unlink_a, f.batch_unlink_b}, out);
+              if (check_status(worker, "BatchUnLink", status) &&
+                  out.attrs.size() != 2) {
+                fail(fmt::format("worker {} BatchUnLink returned {} attrs",
+                                 worker, out.attrs.size()));
+              }
+              break;
+            }
+            case 14: {  // Symlink
+              EntryWithPaOut out;
+              auto status =
+                  fs->Symlink(context("symlink"), "/chaos-created-target",
+                              f.dir, f.prefix + "_symlink", 1, 1, out);
+              if (check_status(worker, "Symlink", status) &&
+                  (out.attr.type() != pb::mds::FileType::SYM_LINK ||
+                   out.attr.symlink() != "/chaos-created-target")) {
+                fail(
+                    fmt::format("worker {} Symlink returned bad attr", worker));
+              }
+              break;
+            }
+            case 15: {  // ReadLink
+              std::string link;
+              auto status =
+                  fs->ReadLink(context("readlink"), f.readlink_ino, link);
+              if (check_status(worker, "ReadLink", status) &&
+                  link != "/chaos-target") {
+                fail(fmt::format("worker {} ReadLink returned {}", worker,
+                                 link));
+              }
+              break;
+            }
+            case 16: {  // SetAttr
+              FileSystem::SetAttrParam param;
+              param.to_set = kSetAttrMode;
+              param.attr.set_fs_id(fs->FsId());
+              param.attr.set_ino(f.file);
+              param.attr.set_mode(0600);
+              EntryWithChunkOut out;
+              auto status = fs->SetAttr(context("setattr"), f.file, param, out);
+              if (check_status(worker, "SetAttr", status) &&
+                  out.attr.mode() != 0600) {
+                fail(fmt::format("worker {} SetAttr mode {}", worker,
+                                 out.attr.mode()));
+              }
+              break;
+            }
+            case 17: {  // GetAttr
+              EntryOut out;
+              auto status = fs->GetAttr(context("getattr"), f.file, out);
+              if (check_status(worker, "GetAttr", status) &&
+                  out.attr.ino() != f.file) {
+                fail(fmt::format("worker {} GetAttr returned wrong ino",
+                                 worker));
+              }
+              break;
+            }
+            case 18: {  // GetXAttr
+              Inode::XAttrMap xattrs;
+              auto status = fs->GetXAttr(context("getxattr"), f.file, xattrs);
+              if (check_status(worker, "GetXAttr", status) &&
+                  xattrs["chaos.seed"] != "value") {
+                fail(fmt::format("worker {} GetXAttr lost seed", worker));
+              }
+              break;
+            }
+            case 19: {  // SetXAttr
+              Inode::XAttrMap xattrs;
+              xattrs["chaos.set"] = "value";
+              EntryOut out;
+              auto status =
+                  fs->SetXAttr(context("setxattr"), f.file, xattrs, out);
+              if (check_status(worker, "SetXAttr", status) &&
+                  out.attr.xattrs().find("chaos.set") ==
+                      out.attr.xattrs().end()) {
+                fail(fmt::format("worker {} SetXAttr returned no value",
+                                 worker));
+              }
+              break;
+            }
+            case 20: {  // RemoveXAttr
+              EntryOut out;
+              auto status = fs->RemoveXAttr(context("removexattr"), f.file,
+                                            "chaos.remove", out);
+              if (check_status(worker, "RemoveXAttr", status) &&
+                  out.attr.xattrs().find("chaos.remove") !=
+                      out.attr.xattrs().end()) {
+                fail(fmt::format("worker {} RemoveXAttr kept value", worker));
+              }
+              break;
+            }
+            case 21: {  // Rename
+              FileSystem::RenameParam param;
+              param.old_parent = f.dir;
+              param.old_name = f.rename_src;
+              param.new_parent = f.dir;
+              param.new_name = f.rename_dst;
+              FileSystem::RenameResult out;
+              auto status = fs->Rename(context("rename"), param, out);
+              if (check_status(worker, "Rename", status)) {
+                EntryOut renamed;
+                auto lookup = fs->Lookup(context("rename-verify"), f.dir,
+                                         f.rename_dst, renamed);
+                if (check_status(worker, "Rename verify", lookup) &&
+                    renamed.attr.ino() != f.rename_ino) {
+                  fail(fmt::format("worker {} Rename returned ino {} (want {})",
+                                   worker, renamed.attr.ino(), f.rename_ino));
+                }
+              }
+              break;
+            }
+            case 22: {  // WriteSlice
+              DeltaSliceEntry delta;
+              delta.set_chunk_index(0);
+              delta.set_curr_version(1);
+              auto* slice = delta.add_slices();
+              slice->set_id(f.first_slice_id + 2);
+              slice->set_off(0);
+              slice->set_size(1024);
+              slice->set_pos(8192);
+              slice->set_len(1024);
+              EntryWithChunkOut out;
+              auto status =
+                  fs->WriteSlice(context("writeslice"), f.file, {delta}, out);
+              if (check_status(worker, "WriteSlice", status) &&
+                  (out.attr.ino() != f.file || out.chunks.empty())) {
+                fail(fmt::format("worker {} WriteSlice returned bad result",
+                                 worker));
+              }
+              break;
+            }
+            case 23: {  // ReadSlice
+              ChunkDescriptor descriptor;
+              descriptor.set_index(0);
+              descriptor.set_version(1);
+              std::vector<ChunkEntry> chunks;
+              auto status = fs->ReadSlice(context("readslice"), f.file,
+                                          {descriptor}, chunks);
+              const bool found = std::any_of(
+                  chunks.begin(), chunks.end(),
+                  [](const auto& chunk) { return chunk.index() == 0; });
+              if (check_status(worker, "ReadSlice", status) && !found) {
+                fail(fmt::format("worker {} ReadSlice missed chunk", worker));
+              }
+              break;
+            }
+            case 24: {  // CopyFileRange
+              FileSystem::CopyFileRangeParam param{.src_ino = f.src,
+                                                   .dst_ino = f.dst,
+                                                   .src_off = 0,
+                                                   .dst_off = 0,
+                                                   .len = 4096};
+              EntryWithChunkOut out;
+              auto status = fs->CopyFileRange(context("copy"), param, out);
+              if (check_status(worker, "CopyFileRange", status) &&
+                  (out.delta_bytes != 4096 || out.chunks.empty())) {
+                fail(fmt::format("worker {} CopyFileRange copied {} bytes",
+                                 worker, out.delta_bytes));
+              }
+              break;
+            }
+            case 25: {  // Fallocate
+              EntryOut before;
+              auto get_status =
+                  fs->GetAttr(context("fallocate-before"), f.dst, before);
+              if (!check_status(worker, "Fallocate GetAttr", get_status)) break;
+              EntryWithChunkOut out;
+              auto status = fs->Fallocate(context("fallocate"), f.dst, 0, 8192,
+                                          4096, out);
+              const uint64_t want =
+                  std::max<uint64_t>(before.attr.length(), 12288);
+              if (check_status(worker, "Fallocate", status) &&
+                  out.attr.length() != want) {
+                fail(fmt::format("worker {} Fallocate length {} (want {})",
+                                 worker, out.attr.length(), want));
+              }
+              break;
+            }
+            case 26: {  // CompactChunk
+              FileSystem::CompactChunkParam param;
+              param.start_pos = 0;
+              param.start_slice_id = f.first_slice_id;
+              param.end_pos = 1;
+              param.end_slice_id = f.second_slice_id;
+              SliceEntry replacement;
+              replacement.set_id(f.first_slice_id + 3);
+              replacement.set_size(8192);
+              replacement.set_pos(0);
+              replacement.set_len(8192);
+              param.new_slices.push_back(replacement);
+              ChunkEntry out;
+              auto status =
+                  fs->CompactChunk(context("compact"), f.file, 0, param, out);
+              if (check_status(worker, "CompactChunk", status) &&
+                  (out.index() != 0 || out.slices_size() == 0)) {
+                fail(fmt::format("worker {} CompactChunk returned bad chunk",
+                                 worker));
+              }
+              break;
+            }
+            default:
+              fail(fmt::format("worker {} unknown operation {}", worker,
+                               operation));
+          }
+          std::this_thread::yield();
+        }
+      }
+    });
+  }
+  while (ready_workers.load() != kWorkerCount) std::this_thread::yield();
+  start_workers.store(true);
+  for (auto& worker : workers) worker.join();
+
+  std::string failure_message;
+  for (const auto& failure : failures) failure_message += "\n" + failure;
+  ASSERT_TRUE(failures.empty()) << failure_message;
 }
 
 // --- Performance test ---

--- a/test/unit/mds/filesystem/test_filesystem.cc
+++ b/test/unit/mds/filesystem/test_filesystem.cc
@@ -228,7 +228,9 @@ FileSystemSPtr FileSystemTest::fs = nullptr;
 OperationProcessorSPtr FileSystemTest::operation_processor = nullptr;
 
 TEST_F(FileSystemSetTest, CreateFs) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs_set = FsSet();
 
@@ -253,7 +255,9 @@ TEST_F(FileSystemSetTest, CreateFs) {
 }
 
 TEST_F(FileSystemSetTest, GetFsInfo) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs_set = FsSet();
 
@@ -286,8 +290,9 @@ TEST_F(FileSystemSetTest, GetFsInfo) {
 }
 
 TEST_F(FileSystemSetTest, DeleteFs) {
-  GTEST_SKIP() << "skip test.";
-
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
   auto fs_set = FsSet();
 
   FileSystemSet::CreateFsParam param;
@@ -319,7 +324,9 @@ TEST_F(FileSystemSetTest, DeleteFs) {
 }
 
 TEST_F(FileSystemSetTest, MountFs) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs_set = FsSet();
 
@@ -362,7 +369,9 @@ TEST_F(FileSystemSetTest, MountFs) {
 }
 
 TEST_F(FileSystemSetTest, UnMountFs) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs_set = FsSet();
 
@@ -418,7 +427,9 @@ TEST_F(FileSystemSetTest, UnMountFs) {
 }
 
 TEST_F(FileSystemTest, CreateRoot) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
 
@@ -435,7 +446,9 @@ TEST_F(FileSystemTest, CreateRoot) {
 }
 
 TEST_F(FileSystemTest, MkNod) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -476,8 +489,9 @@ TEST_F(FileSystemTest, MkNod) {
 }
 
 TEST_F(FileSystemTest, MkDir) {
-  GTEST_SKIP() << "skip test.";
-
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -567,7 +581,9 @@ TEST_F(FileSystemTest, CreateInheritsSetgidParent) {
 }
 
 TEST_F(FileSystemTest, RmDir) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -618,8 +634,9 @@ TEST_F(FileSystemTest, RmDir) {
 }
 
 TEST_F(FileSystemTest, Link) {
-  GTEST_SKIP() << "skip test.";
-
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
   auto& inode_cache = fs->GetInodeCache();
@@ -652,7 +669,9 @@ TEST_F(FileSystemTest, Link) {
 }
 
 TEST_F(FileSystemTest, UnLink) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -690,7 +709,9 @@ TEST_F(FileSystemTest, UnLink) {
 }
 
 TEST_F(FileSystemTest, SymlinkWithFile) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -732,7 +753,9 @@ TEST_F(FileSystemTest, SymlinkWithFile) {
 }
 
 TEST_F(FileSystemTest, SymlinkWithDir) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -774,7 +797,9 @@ TEST_F(FileSystemTest, SymlinkWithDir) {
 }
 
 TEST_F(FileSystemTest, ReadLink) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -816,7 +841,9 @@ TEST_F(FileSystemTest, ReadLink) {
 }
 
 TEST_F(FileSystemTest, SetXAttr) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -849,7 +876,9 @@ TEST_F(FileSystemTest, SetXAttr) {
 }
 
 TEST_F(FileSystemTest, GetXAttr) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -900,7 +929,9 @@ TEST_F(FileSystemTest, GetXAttr) {
 // |  |--file2
 // rename dir1/file1 to dir1/file2
 TEST_F(FileSystemTest, RenameWithSameDir) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -981,7 +1012,9 @@ TEST_F(FileSystemTest, RenameWithSameDir) {
 // |  |--file1
 // rename dir1/file1 to dir2/file1
 TEST_F(FileSystemTest, RenameWithDiffDir) {
-  GTEST_SKIP() << "skip test.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto fs = Fs();
   auto& partition_cache = fs->GetPartitionCache();
@@ -1769,8 +1802,8 @@ TEST_F(FileSystemTest, CalcDirStatNoPageBoundaryDoubleCount) {
 // Note: DummyStorage keeps everything in memory, ~1KB+/dir; 1e8 dirs needs
 // 100GB+ RAM, use PERF_MKDIR_COUNT to scale down on small machines.
 TEST_F(FileSystemTest, MkDirPerf) {
-  if (getenv("FILESYSTEM_PERF") == nullptr) {
-    GTEST_SKIP() << "set FILESYSTEM_PERF=1 to run (long running perf test)";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
   }
 
   uint64_t total = 100000000ULL;  // 1亿
@@ -1834,8 +1867,8 @@ TEST_F(FileSystemTest, MkDirPerf) {
 }
 
 TEST_F(FileSystemTest, MapPerf) {
-  if (getenv("FILESYSTEM_PERF") == nullptr) {
-    GTEST_SKIP() << "set FILESYSTEM_PERF=1 to run (long running perf test)";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
   }
 
   absl::flat_hash_map<Ino, InodeSPtr> map;

--- a/test/unit/mds/filesystem/test_inode.cc
+++ b/test/unit/mds/filesystem/test_inode.cc
@@ -326,8 +326,8 @@ TEST_F(InodeCacheTest, Get) {
 }
 
 TEST_F(InodeCacheTest, Benchmark) {
-  if (getenv("INODECACHE_PERF") == nullptr) {
-    GTEST_SKIP() << "Skip InodeCacheTest.Benchmark test case.";
+  if (getenv("SLOW_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip slow test case.";
   }
 
   InodeCache inode_cache(kFsId);
@@ -375,8 +375,8 @@ TEST_F(InodeCacheTest, Benchmark) {
 }
 
 TEST_F(InodeCacheTest, BenchmarkBthread) {
-  if (getenv("INODECACHE_PERF") == nullptr) {
-    GTEST_SKIP() << "Skip InodeCacheTest.Benchmark test case.";
+  if (getenv("SLOW_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip slow test case.";
   }
 
   InodeCache inode_cache(kFsId);

--- a/test/unit/mds/filesystem/test_operation_processor.cc
+++ b/test/unit/mds/filesystem/test_operation_processor.cc
@@ -1,0 +1,650 @@
+// Copyright (c) 2026 dingodb.com, Inc. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bthread/countdown_event.h>
+#include <gflags/gflags.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <ctime>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "mds/common/codec.h"
+#include "mds/common/tracing.h"
+#include "mds/common/type.h"
+#include "mds/filesystem/store_operation.h"
+#include "mds/storage/dummy_storage.h"
+
+namespace dingofs {
+namespace mds {
+
+DECLARE_uint32(mds_store_operation_batch_size);
+DECLARE_uint32(mds_store_operation_dispatcher_num);
+DECLARE_uint32(mds_store_operation_max_inflight_per_key);
+DECLARE_uint32(mds_txn_max_retry_times);
+
+namespace unit_test {
+namespace {
+
+constexpr uint32_t kFsId = 100;
+constexpr Ino kDirIno = 1;
+
+Status RetryStatus() { return Status(pb::error::ESTORE_MAYBE_RETRY, "retry"); }
+
+AttrEntry MakeDirAttr(Ino ino) {
+  AttrEntry attr;
+  attr.set_fs_id(kFsId);
+  attr.set_ino(ino);
+  attr.set_mode(S_IFDIR | 0755);
+  attr.set_type(pb::mds::FileType::DIRECTORY);
+  attr.set_nlink(2);
+  attr.set_version(1);
+  return attr;
+}
+
+bool WaitFor(bthread::CountdownEvent& event) {
+  timespec deadline;
+  clock_gettime(CLOCK_REALTIME, &deadline);
+  deadline.tv_sec += 3;
+  return event.timed_wait(deadline) == 0;
+}
+
+class Gate {
+ public:
+  void Wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    entered_ = true;
+    cond_.notify_all();
+    cond_.wait(lock, [this] { return open_; });
+  }
+
+  bool WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cond_.wait_for(lock, std::chrono::seconds(3),
+                          [this] { return entered_; });
+  }
+
+  void Open() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    open_ = true;
+    cond_.notify_all();
+  }
+
+  ~Gate() { Open(); }
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cond_;
+  bool entered_{false};
+  bool open_{false};
+};
+
+class ScriptedStorage;
+
+class ScriptedTxn : public Txn {
+ public:
+  ScriptedTxn(TxnUPtr txn, ScriptedStorage* storage)
+      : txn_(std::move(txn)), storage_(storage) {}
+
+  int64_t ID() const override { return txn_->ID(); }
+  Status Put(const std::string& key, const std::string& value) override {
+    return txn_->Put(key, value);
+  }
+  Status PutIfAbsent(const std::string& key,
+                     const std::string& value) override {
+    return txn_->PutIfAbsent(key, value);
+  }
+  Status Delete(const std::string& key) override { return txn_->Delete(key); }
+  Status Get(const std::string& key, std::string& value) override {
+    return txn_->Get(key, value);
+  }
+  Status BatchGet(const std::vector<std::string>& keys,
+                  std::vector<KeyValue>& kvs) override;
+  Status Scan(const Range& range, uint64_t limit,
+              std::vector<KeyValue>& kvs) override {
+    return txn_->Scan(range, limit, kvs);
+  }
+  Status Scan(const Range& range, ScanHandlerType handler) override {
+    return txn_->Scan(range, handler);
+  }
+  Status Scan(const Range& range,
+              std::function<bool(KeyValue&)> handler) override {
+    return txn_->Scan(range, handler);
+  }
+  Status Commit() override;
+  Trace::Txn GetTrace() override { return txn_->GetTrace(); }
+
+ private:
+  TxnUPtr txn_;
+  ScriptedStorage* storage_;
+};
+
+class ScriptedStorage : public DummyStorage {
+ public:
+  TxnUPtr NewTxn(
+      Txn::IsolationLevel isolation_level = Txn::kSnapshotIsolation) override {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (new_txn_failures_ > 0) {
+        --new_txn_failures_;
+        return nullptr;
+      }
+    }
+    return std::make_unique<ScriptedTxn>(DummyStorage::NewTxn(isolation_level),
+                                         this);
+  }
+
+  Status IsExistTable(const std::string& start_key,
+                      const std::string& end_key) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    checked_start_ = start_key;
+    checked_end_ = end_key;
+    return check_table_status_;
+  }
+
+  Status CreateTable(const std::string& name, const TableOption& option,
+                     int64_t& table_id) override {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      created_name_ = name;
+      created_option_ = option;
+      if (!create_table_status_.ok()) return create_table_status_;
+    }
+    return DummyStorage::CreateTable(name, option, table_id);
+  }
+
+  void SetNewTxnFailures(uint32_t failures) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    new_txn_failures_ = failures;
+  }
+
+  void SetBatchGetStatuses(std::vector<Status> statuses) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    batch_get_statuses_ = {statuses.begin(), statuses.end()};
+  }
+
+  void SetCommitStatuses(std::vector<Status> statuses) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    commit_statuses_ = {statuses.begin(), statuses.end()};
+  }
+
+  void SetCheckTableStatus(const Status& status) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    check_table_status_ = status;
+  }
+
+  void SetCreateTableStatus(const Status& status) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    create_table_status_ = status;
+  }
+
+  Status TakeBatchGetStatus() { return TakeStatus(batch_get_statuses_); }
+  Status TakeCommitStatus() { return TakeStatus(commit_statuses_); }
+
+  std::string CheckedStart() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return checked_start_;
+  }
+  std::string CheckedEnd() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return checked_end_;
+  }
+  std::string CreatedName() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return created_name_;
+  }
+  TableOption CreatedOption() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return created_option_;
+  }
+
+ private:
+  Status TakeStatus(std::deque<Status>& statuses) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (statuses.empty()) return Status::OK();
+    Status status = statuses.front();
+    statuses.pop_front();
+    return status;
+  }
+
+  mutable std::mutex mutex_;
+  uint32_t new_txn_failures_{0};
+  std::deque<Status> batch_get_statuses_;
+  std::deque<Status> commit_statuses_;
+  Status check_table_status_;
+  Status create_table_status_;
+  std::string checked_start_;
+  std::string checked_end_;
+  std::string created_name_;
+  TableOption created_option_;
+};
+
+Status ScriptedTxn::BatchGet(const std::vector<std::string>& keys,
+                             std::vector<KeyValue>& kvs) {
+  Status status = storage_->TakeBatchGetStatus();
+  return status.ok() ? txn_->BatchGet(keys, kvs) : status;
+}
+
+Status ScriptedTxn::Commit() {
+  Status status = storage_->TakeCommitStatus();
+  return status.ok() ? txn_->Commit() : status;
+}
+
+class TestOperation : public Operation {
+ public:
+  TestOperation(Trace& trace, OpType type, uint32_t fs_id, Ino ino)
+      : Operation(trace), type_(type), fs_id_(fs_id), ino_(ino) {}
+
+  OpType GetOpType() const override { return type_; }
+  uint32_t GetFsId() const override { return fs_id_; }
+  Ino GetIno() const override { return ino_; }
+
+  Status Run(TxnUPtr& txn) override {
+    ++run_calls_;
+    return run_handler_ ? run_handler_(txn) : Next(run_statuses_, run_index_);
+  }
+
+  Status RunInBatch(TxnUPtr&, BatchSharedParam&) override {
+    ++batch_calls_;
+    return Next(batch_statuses_, batch_index_);
+  }
+
+  void SetResultAttr(BatchSharedParam&) override {}
+
+  void SetRunStatuses(std::vector<Status> statuses) {
+    run_statuses_ = std::move(statuses);
+  }
+  void SetBatchStatuses(std::vector<Status> statuses) {
+    batch_statuses_ = std::move(statuses);
+  }
+  void SetRunHandler(std::function<Status(TxnUPtr&)> handler) {
+    run_handler_ = std::move(handler);
+  }
+
+  uint32_t RunCalls() const { return run_calls_.load(); }
+  uint32_t BatchCalls() const { return batch_calls_.load(); }
+
+ private:
+  static Status Next(const std::vector<Status>& statuses, size_t& index) {
+    return index < statuses.size() ? statuses[index++] : Status::OK();
+  }
+
+  OpType type_;
+  uint32_t fs_id_;
+  Ino ino_;
+  std::vector<Status> run_statuses_;
+  std::vector<Status> batch_statuses_;
+  size_t run_index_{0};
+  size_t batch_index_{0};
+  std::function<Status(TxnUPtr&)> run_handler_;
+  std::atomic<uint32_t> run_calls_{0};
+  std::atomic<uint32_t> batch_calls_{0};
+};
+
+class OperationProcessorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    old_batch_size_ = FLAGS_mds_store_operation_batch_size;
+    old_dispatcher_num_ = FLAGS_mds_store_operation_dispatcher_num;
+    old_max_inflight_ = FLAGS_mds_store_operation_max_inflight_per_key;
+    old_max_retries_ = FLAGS_mds_txn_max_retry_times;
+
+    FLAGS_mds_store_operation_batch_size = 8;
+    FLAGS_mds_store_operation_dispatcher_num = 1;
+    FLAGS_mds_store_operation_max_inflight_per_key = 1;
+    FLAGS_mds_txn_max_retry_times = 1;
+
+    storage_ = std::make_shared<ScriptedStorage>();
+    ASSERT_TRUE(storage_->Init(""));
+  }
+
+  void TearDown() override {
+    if (processor_ != nullptr) processor_->Stop();
+
+    FLAGS_mds_store_operation_batch_size = old_batch_size_;
+    FLAGS_mds_store_operation_dispatcher_num = old_dispatcher_num_;
+    FLAGS_mds_store_operation_max_inflight_per_key = old_max_inflight_;
+    FLAGS_mds_txn_max_retry_times = old_max_retries_;
+  }
+
+  void Start() {
+    processor_ = OperationProcessor::New(storage_);
+    ASSERT_TRUE(processor_->Init());
+  }
+
+  void SeedDir(Ino ino = kDirIno) {
+    ASSERT_TRUE(storage_
+                    ->Put(KVStorage::WriteOption(),
+                          MetaCodec::EncodeInodeKey(kFsId, ino),
+                          MetaCodec::EncodeInodeValue(MakeDirAttr(ino)))
+                    .ok());
+  }
+
+  void SetBatchGate(Gate& gate) {
+    processor_ = OperationProcessor::New(storage_);
+    processor_->SetBeforeBatchDrainHookForTest([&gate] { gate.Wait(); });
+    ASSERT_TRUE(processor_->Init());
+  }
+
+  std::shared_ptr<ScriptedStorage> storage_;
+  OperationProcessorSPtr processor_;
+
+ private:
+  uint32_t old_batch_size_{0};
+  uint32_t old_dispatcher_num_{0};
+  uint32_t old_max_inflight_{0};
+  uint32_t old_max_retries_{0};
+};
+
+TEST_F(OperationProcessorTest, LifecycleAccessorsAndRejectAfterStop) {
+  Start();
+  EXPECT_EQ(processor_->GetKVStorage(), storage_);
+  EXPECT_EQ(processor_->GetSelfPtr(), processor_);
+
+  ASSERT_TRUE(processor_->Stop());
+
+  Trace batch_trace;
+  TestOperation batch_op(batch_trace, Operation::OpType::kUpdateAttr, kFsId,
+                         kDirIno);
+  EXPECT_FALSE(processor_->RunBatched(&batch_op));
+
+  Trace async_trace;
+  auto async_op = std::make_shared<TestOperation>(
+      async_trace, Operation::OpType::kGetFs, kFsId, kDirIno);
+  EXPECT_FALSE(processor_->AsyncRun(async_op, nullptr));
+  EXPECT_EQ(async_op->RunCalls(), 0u);
+}
+
+TEST_F(OperationProcessorTest, RunAloneRetriesAndPropagatesFailures) {
+  Start();
+
+  Trace success_trace;
+  TestOperation success(success_trace, Operation::OpType::kGetFs, kFsId,
+                        kDirIno);
+  storage_->SetCommitStatuses({RetryStatus(), Status::OK()});
+  ASSERT_TRUE(processor_->RunAlone(&success).ok());
+  EXPECT_EQ(success.RunCalls(), 2u);
+  EXPECT_EQ(success_trace.GetTxns().size(), 2u);
+
+  Trace failure_trace;
+  TestOperation failure(failure_trace, Operation::OpType::kGetFs, kFsId,
+                        kDirIno);
+  storage_->SetCommitStatuses({RetryStatus(), RetryStatus()});
+  Status status = processor_->RunAlone(&failure);
+  EXPECT_EQ(status.error_code(), pb::error::ESTORE_MAYBE_RETRY);
+  EXPECT_EQ(failure.GetStatus().error_code(), pb::error::ESTORE_MAYBE_RETRY);
+
+  Trace new_txn_trace;
+  TestOperation new_txn_failure(new_txn_trace, Operation::OpType::kGetFs, kFsId,
+                                kDirIno);
+  storage_->SetNewTxnFailures(2);
+  status = processor_->RunAlone(&new_txn_failure);
+  EXPECT_EQ(status.error_code(), pb::error::EBACKEND_STORE);
+  EXPECT_EQ(new_txn_failure.GetStatus().error_code(),
+            pb::error::EBACKEND_STORE);
+}
+
+TEST_F(OperationProcessorTest, AsyncRunCallsHandlerOnlyAfterSuccess) {
+  Start();
+
+  bthread::CountdownEvent callback_done(1);
+  std::atomic<uint32_t> callback_count{0};
+  Trace success_trace;
+  auto success = std::make_shared<TestOperation>(
+      success_trace, Operation::OpType::kGetFs, kFsId, kDirIno);
+  ASSERT_TRUE(processor_->AsyncRun(success, [&](OperationSPtr) {
+    ++callback_count;
+    callback_done.signal();
+  }));
+  ASSERT_TRUE(WaitFor(callback_done));
+  EXPECT_EQ(callback_count.load(), 1u);
+  EXPECT_EQ(success->RunCalls(), 1u);
+
+  Gate failure_gate;
+  std::atomic<uint32_t> failure_callback_count{0};
+  Trace failure_trace;
+  auto failure = std::make_shared<TestOperation>(
+      failure_trace, Operation::OpType::kGetFs, kFsId, kDirIno);
+  failure->SetRunHandler([&](TxnUPtr&) {
+    failure_gate.Wait();
+    return Status(pb::error::EINTERNAL, "operation failed");
+  });
+  ASSERT_TRUE(processor_->AsyncRun(
+      failure, [&](OperationSPtr) { ++failure_callback_count; }));
+  ASSERT_TRUE(failure_gate.WaitUntilEntered());
+  EXPECT_EQ(failure_callback_count.load(), 0u);
+  failure_gate.Open();
+
+  bthread::CountdownEvent sentinel_done(1);
+  Trace sentinel_trace;
+  auto sentinel = std::make_shared<TestOperation>(
+      sentinel_trace, Operation::OpType::kGetFs, kFsId, kDirIno);
+  ASSERT_TRUE(processor_->AsyncRun(
+      sentinel, [&](OperationSPtr) { sentinel_done.signal(); }));
+  ASSERT_TRUE(WaitFor(sentinel_done));
+  EXPECT_EQ(failure_callback_count.load(), 0u);
+  EXPECT_EQ(failure->GetStatus().error_code(), pb::error::EINTERNAL);
+}
+
+TEST_F(OperationProcessorTest,
+       BatchedOperationsShareTransactionWhenGateCollectsThem) {
+  SeedDir();
+  Gate gate;
+  SetBatchGate(gate);
+
+  Trace first_trace;
+  Trace second_trace;
+  TestOperation first(first_trace, Operation::OpType::kUpdateAttr, kFsId,
+                      kDirIno);
+  TestOperation second(second_trace, Operation::OpType::kUpdateAttr, kFsId,
+                       kDirIno);
+  bthread::CountdownEvent done(2);
+  first.SetEvent(&done);
+  second.SetEvent(&done);
+
+  ASSERT_TRUE(processor_->RunBatched(&first));
+  ASSERT_TRUE(gate.WaitUntilEntered());
+  ASSERT_TRUE(processor_->RunBatched(&second));
+  gate.Open();
+  ASSERT_TRUE(WaitFor(done));
+
+  ASSERT_TRUE(first.GetStatus().ok());
+  ASSERT_TRUE(second.GetStatus().ok());
+  ASSERT_EQ(first_trace.GetTxns().size(), 1u);
+  ASSERT_EQ(second_trace.GetTxns().size(), 1u);
+  EXPECT_EQ(first_trace.GetTxns()[0].txn_id, second_trace.GetTxns()[0].txn_id);
+}
+
+TEST_F(OperationProcessorTest, BatchedOperationsWithDifferentKeysComplete) {
+  SeedDir(kDirIno);
+  SeedDir(3);
+  Start();
+
+  Trace first_trace;
+  Trace second_trace;
+  TestOperation first(first_trace, Operation::OpType::kUpdateAttr, kFsId,
+                      kDirIno);
+  TestOperation second(second_trace, Operation::OpType::kUpdateAttr, kFsId, 3);
+  bthread::CountdownEvent done(2);
+  first.SetEvent(&done);
+  second.SetEvent(&done);
+
+  ASSERT_TRUE(processor_->RunBatched(&first));
+  ASSERT_TRUE(processor_->RunBatched(&second));
+  ASSERT_TRUE(WaitFor(done));
+  EXPECT_TRUE(first.GetStatus().ok());
+  EXPECT_TRUE(second.GetStatus().ok());
+  EXPECT_EQ(first_trace.GetTxns().size(), 1u);
+  EXPECT_EQ(second_trace.GetTxns().size(), 1u);
+}
+
+TEST_F(OperationProcessorTest, BatchedOperationFailureDoesNotAbortPeers) {
+  SeedDir();
+  Gate gate;
+  SetBatchGate(gate);
+
+  Trace failed_trace;
+  Trace success_trace;
+  TestOperation failed(failed_trace, Operation::OpType::kUpdateAttr, kFsId,
+                       kDirIno);
+  failed.SetBatchStatuses({Status(pb::error::EINTERNAL, "operation failed")});
+  TestOperation success(success_trace, Operation::OpType::kUpdateAttr, kFsId,
+                        kDirIno);
+  bthread::CountdownEvent done(2);
+  failed.SetEvent(&done);
+  success.SetEvent(&done);
+
+  ASSERT_TRUE(processor_->RunBatched(&failed));
+  ASSERT_TRUE(gate.WaitUntilEntered());
+  ASSERT_TRUE(processor_->RunBatched(&success));
+  gate.Open();
+  ASSERT_TRUE(WaitFor(done));
+
+  EXPECT_EQ(failed.GetStatus().error_code(), pb::error::EINTERNAL);
+  EXPECT_TRUE(success.GetStatus().ok());
+  EXPECT_EQ(failed.BatchCalls(), 1u);
+  EXPECT_EQ(success.BatchCalls(), 1u);
+}
+
+TEST_F(OperationProcessorTest, BatchedRetryResetsOperationStatus) {
+  SeedDir();
+  storage_->SetCommitStatuses({RetryStatus(), Status::OK()});
+  Start();
+
+  Trace trace;
+  TestOperation operation(trace, Operation::OpType::kUpdateAttr, kFsId,
+                          kDirIno);
+  operation.SetBatchStatuses(
+      {Status(pb::error::ENOT_FOUND, "stale prefetch"), Status::OK()});
+  bthread::CountdownEvent done(1);
+  operation.SetEvent(&done);
+
+  ASSERT_TRUE(processor_->RunBatched(&operation));
+  ASSERT_TRUE(WaitFor(done));
+  EXPECT_TRUE(operation.GetStatus().ok());
+  EXPECT_EQ(operation.BatchCalls(), 2u);
+}
+
+TEST_F(OperationProcessorTest,
+       BatchedTransactionFailureNotifiesEveryOperation) {
+  SeedDir();
+  storage_->SetBatchGetStatuses({RetryStatus(), RetryStatus()});
+  Gate gate;
+  SetBatchGate(gate);
+
+  Trace first_trace;
+  Trace second_trace;
+  TestOperation first(first_trace, Operation::OpType::kUpdateAttr, kFsId,
+                      kDirIno);
+  TestOperation second(second_trace, Operation::OpType::kUpdateAttr, kFsId,
+                       kDirIno);
+  bthread::CountdownEvent done(2);
+  first.SetEvent(&done);
+  second.SetEvent(&done);
+
+  ASSERT_TRUE(processor_->RunBatched(&first));
+  ASSERT_TRUE(gate.WaitUntilEntered());
+  ASSERT_TRUE(processor_->RunBatched(&second));
+  gate.Open();
+  ASSERT_TRUE(WaitFor(done));
+
+  EXPECT_EQ(first.GetStatus().error_code(), pb::error::ESTORE_MAYBE_RETRY);
+  EXPECT_EQ(second.GetStatus().error_code(), pb::error::ESTORE_MAYBE_RETRY);
+}
+
+TEST_F(OperationProcessorTest,
+       RmDirAllowsConcurrentDirMutationToUseMutationKey) {
+  SeedDir();
+  Start();
+
+  Gate rmdir_gate;
+  Trace rmdir_trace;
+  TestOperation rmdir(rmdir_trace, Operation::OpType::kRmDir, kFsId, kDirIno);
+  rmdir.SetRunHandler([&](TxnUPtr&) {
+    rmdir_gate.Wait();
+    return Status::OK();
+  });
+  Status rmdir_status;
+  std::thread rmdir_thread(
+      [&] { rmdir_status = processor_->RunAlone(&rmdir); });
+  ASSERT_TRUE(rmdir_gate.WaitUntilEntered());
+
+  Trace batch_trace;
+  TestOperation batch(batch_trace, Operation::OpType::kMkNod, kFsId, kDirIno);
+  bthread::CountdownEvent done(1);
+  batch.SetEvent(&done);
+  const bool submitted = processor_->RunBatched(&batch);
+  EXPECT_TRUE(submitted);
+  const bool completed = submitted && WaitFor(done);
+  EXPECT_TRUE(completed);
+
+  if (completed) {
+    std::string value;
+    ASSERT_TRUE(
+        storage_->Get(MetaCodec::EncodeInodeKey(kFsId, kDirIno), value).ok());
+    EXPECT_EQ(MetaCodec::DecodeInodeValue(value).version(), 1u);
+    EXPECT_TRUE(
+        storage_
+            ->Get(MetaCodec::EncodeDirInodeMutationKey(kFsId, kDirIno, 1),
+                  value)
+            .ok());
+    EXPECT_TRUE(batch.GetStatus().ok());
+  }
+
+  rmdir_gate.Open();
+  rmdir_thread.join();
+  EXPECT_TRUE(rmdir_status.ok());
+}
+
+TEST_F(OperationProcessorTest, TableHelpersForwardArgumentsAndStatuses) {
+  Start();
+  const Range range{"a", "z"};
+
+  EXPECT_TRUE(processor_->CheckTable(range).ok());
+  EXPECT_EQ(storage_->CheckedStart(), range.start);
+  EXPECT_EQ(storage_->CheckedEnd(), range.end);
+
+  storage_->SetCheckTableStatus(Status(pb::error::ENOT_FOUND, "missing"));
+  Status status = processor_->CheckTable(range);
+  EXPECT_EQ(status.error_code(), pb::error::ENOT_FOUND);
+  EXPECT_EQ(storage_->CheckedStart(), range.start);
+  EXPECT_EQ(storage_->CheckedEnd(), range.end);
+
+  int64_t table_id = 0;
+  ASSERT_TRUE(processor_->CreateTable("table", range, table_id).ok());
+  EXPECT_GT(table_id, 0);
+  EXPECT_EQ(storage_->CreatedName(), "table");
+  EXPECT_EQ(storage_->CreatedOption().start_key, range.start);
+  EXPECT_EQ(storage_->CreatedOption().end_key, range.end);
+
+  storage_->SetCreateTableStatus(
+      Status(pb::error::EBACKEND_STORE, "backend failed"));
+  status = processor_->CreateTable("failed", range, table_id);
+  EXPECT_EQ(status.error_code(), pb::error::EINTERNAL);
+}
+
+}  // namespace
+}  // namespace unit_test
+}  // namespace mds
+}  // namespace dingofs

--- a/test/unit/mds/filesystem/test_partition.cc
+++ b/test/unit/mds/filesystem/test_partition.cc
@@ -171,6 +171,22 @@ TEST_F(DirShardTest, MultipleDentries) {
   }
 }
 
+TEST_F(DirShardTest, SnapshotPaginates) {
+  std::vector<Dentry> initial_dentries;
+  initial_dentries.emplace_back(
+      GenDentry(kFsId, kParentIno, 200, "first", pb::mds::FileType::FILE));
+  initial_dentries.emplace_back(GenDentry(kFsId, kParentIno, 201, "second",
+                                          pb::mds::FileType::DIRECTORY));
+  DirShardSPtr shard = DirShard::New(1, Range{"", ""}, 1, initial_dentries);
+
+  std::vector<Dentry> snapshot;
+  shard->Snapshot(1, 1, snapshot);
+
+  ASSERT_EQ(1, snapshot.size());
+  EXPECT_EQ("second", snapshot[0].Name());
+  EXPECT_EQ(pb::mds::FileType::DIRECTORY, snapshot[0].Type());
+}
+
 TEST_F(DirShardTest, Scan) {
   Range range{"", ""};
   std::vector<Dentry> initial_dentries;
@@ -652,6 +668,26 @@ TEST_F(ShardPartitionBasicTest, PutWithVersion) {
   // Note: Size() only counts dentries in shards, not delta ops
   // So size will be 0 because no shard has been fetched yet
   ASSERT_EQ(partition_->Size(), 0);
+}
+
+TEST_F(ShardPartitionBasicTest, DumpPaginatesPendingDentryOperations) {
+  partition_->Put(Dentry(GenDentry(kFsId, kParentIno, 200, "first",
+                                   pb::mds::FileType::FILE)),
+                  2);
+  partition_->Put(Dentry(GenDentry(kFsId, kParentIno, 201, "second",
+                                   pb::mds::FileType::DIRECTORY)),
+                  3);
+
+  Json::Value value;
+  partition_->Dump(value, 0, 100, 1, 1);
+
+  ASSERT_EQ(2, value["delta_dentry_ops_total"].asUInt64());
+  ASSERT_EQ(1, value["delta_dentry_ops"].size());
+  EXPECT_EQ("ADD", value["delta_dentry_ops"][0]["op"].asString());
+  EXPECT_EQ("second",
+            value["delta_dentry_ops"][0]["dentry"]["name"].asString());
+  EXPECT_EQ("DIRECTORY",
+            value["delta_dentry_ops"][0]["dentry"]["type"].asString());
 }
 
 TEST_F(ShardPartitionBasicTest, DeleteSingle) {

--- a/test/unit/mds/filesystem/test_partition.cc
+++ b/test/unit/mds/filesystem/test_partition.cc
@@ -826,8 +826,8 @@ TEST_F(ShardPartitionWithBoundariesTest, PutMultipleShards) {
 // Run: PARTITION_PERF=1 ./test_mds --gtest_filter=ShardPartitionPerfTest.*
 // Optionally override count: PERF_PUT_COUNT=1000000
 TEST(ShardPartitionPerfTest, Put400Million) {
-  if (getenv("PARTITION_PERF") == nullptr) {
-    GTEST_SKIP() << "set PARTITION_PERF=1 to run (long running perf test)";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
   }
 
   uint64_t total = 400000000ULL;  // 4亿

--- a/test/unit/mds/storage/test_tikv_go_storage.cc
+++ b/test/unit/mds/storage/test_tikv_go_storage.cc
@@ -50,7 +50,9 @@ class TikvGoStorageTest : public testing::Test {
 KVStorageSPtr TikvGoStorageTest::storage_ = nullptr;
 
 TEST_F(TikvGoStorageTest, Put) {
-  GTEST_SKIP() << "Skip Put test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
 
@@ -66,7 +68,9 @@ TEST_F(TikvGoStorageTest, Put) {
 }
 
 TEST_F(TikvGoStorageTest, PutGet) {
-  GTEST_SKIP() << "Skip PutGet test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
 
@@ -92,7 +96,9 @@ TEST_F(TikvGoStorageTest, PutGet) {
 }
 
 TEST_F(TikvGoStorageTest, PutDelete) {
-  GTEST_SKIP() << "Skip PutDelete test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string key =
       "unit_tikv_go_putdelete_" + ::dingofs::Helper::GenerateRandomString(32);
@@ -125,7 +131,9 @@ TEST_F(TikvGoStorageTest, PutDelete) {
 }
 
 TEST_F(TikvGoStorageTest, PutBatchGet) {
-  GTEST_SKIP() << "Skip PutBatchGet test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::vector<std::string> keys;
   {
@@ -166,7 +174,9 @@ TEST_F(TikvGoStorageTest, PutBatchGet) {
 }
 
 TEST_F(TikvGoStorageTest, Scan) {
-  GTEST_SKIP() << "Skip Scan test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string prefix =
       "unit_tikv_go_scan_" + ::dingofs::Helper::GenerateRandomString(16) + "_";
@@ -200,7 +210,9 @@ TEST_F(TikvGoStorageTest, Scan) {
 }
 
 TEST_F(TikvGoStorageTest, ScanWithLimit) {
-  GTEST_SKIP() << "Skip ScanWithLimit test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string prefix = "unit_tikv_go_scanlimit_" +
                        ::dingofs::Helper::GenerateRandomString(16) + "_";
@@ -232,7 +244,9 @@ TEST_F(TikvGoStorageTest, ScanWithLimit) {
 }
 
 TEST_F(TikvGoStorageTest, ScanWithHandler) {
-  GTEST_SKIP() << "Skip ScanWithHandler test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string prefix = "unit_tikv_go_scanhandler_" +
                        ::dingofs::Helper::GenerateRandomString(16) + "_";
@@ -269,7 +283,9 @@ TEST_F(TikvGoStorageTest, ScanWithHandler) {
 }
 
 TEST_F(TikvGoStorageTest, StoragePutGet) {
-  GTEST_SKIP() << "Skip StoragePutGet test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string key = "unit_tikv_go_storage_putget_" +
                     ::dingofs::Helper::GenerateRandomString(32);
@@ -287,7 +303,9 @@ TEST_F(TikvGoStorageTest, StoragePutGet) {
 }
 
 TEST_F(TikvGoStorageTest, StorageDelete) {
-  GTEST_SKIP() << "Skip StorageDelete test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string key = "unit_tikv_go_storage_delete_" +
                     ::dingofs::Helper::GenerateRandomString(32);
@@ -308,7 +326,9 @@ TEST_F(TikvGoStorageTest, StorageDelete) {
 }
 
 TEST_F(TikvGoStorageTest, StorageBatchPut) {
-  GTEST_SKIP() << "Skip StorageBatchPut test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::vector<KeyValue> kvs;
   for (int i = 0; i < 10; ++i) {
@@ -338,7 +358,9 @@ TEST_F(TikvGoStorageTest, StorageBatchPut) {
 }
 
 TEST_F(TikvGoStorageTest, GetNotFound) {
-  GTEST_SKIP() << "Skip GetNotFound test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
   std::string value;
@@ -351,7 +373,9 @@ TEST_F(TikvGoStorageTest, GetNotFound) {
 }
 
 TEST_F(TikvGoStorageTest, BatchGetEmpty) {
-  GTEST_SKIP() << "Skip BatchGetEmpty test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
   std::vector<std::string> keys;
@@ -363,7 +387,9 @@ TEST_F(TikvGoStorageTest, BatchGetEmpty) {
 }
 
 TEST_F(TikvGoStorageTest, BatchGetPartialMiss) {
-  GTEST_SKIP() << "Skip BatchGetPartialMiss test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string existing_key =
       "unit_tikv_go_partialmiss_" + ::dingofs::Helper::GenerateRandomString(32);
@@ -390,7 +416,9 @@ TEST_F(TikvGoStorageTest, BatchGetPartialMiss) {
 }
 
 TEST_F(TikvGoStorageTest, ScanWithKVHandler) {
-  GTEST_SKIP() << "Skip ScanWithKVHandler test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string prefix = "unit_tikv_go_scankvhandler_" +
                        ::dingofs::Helper::GenerateRandomString(16) + "_";
@@ -425,7 +453,9 @@ TEST_F(TikvGoStorageTest, ScanWithKVHandler) {
 }
 
 TEST_F(TikvGoStorageTest, ScanHandlerEarlyStop) {
-  GTEST_SKIP() << "Skip ScanHandlerEarlyStop test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string prefix = "unit_tikv_go_earlystop_" +
                        ::dingofs::Helper::GenerateRandomString(16) + "_";
@@ -462,7 +492,9 @@ TEST_F(TikvGoStorageTest, ScanHandlerEarlyStop) {
 }
 
 TEST_F(TikvGoStorageTest, ScanEmptyRange) {
-  GTEST_SKIP() << "Skip ScanEmptyRange test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
   Range range;
@@ -478,7 +510,9 @@ TEST_F(TikvGoStorageTest, ScanEmptyRange) {
 }
 
 TEST_F(TikvGoStorageTest, PutIfAbsent) {
-  GTEST_SKIP() << "Skip PutIfAbsent test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
   auto status = txn->PutIfAbsent("any_key", "any_value");
@@ -488,7 +522,9 @@ TEST_F(TikvGoStorageTest, PutIfAbsent) {
 }
 
 TEST_F(TikvGoStorageTest, TxnID) {
-  GTEST_SKIP() << "Skip TxnID test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
   ASSERT_NE(txn->ID(), 0) << "txn id should not be zero.";
@@ -496,7 +532,9 @@ TEST_F(TikvGoStorageTest, TxnID) {
 }
 
 TEST_F(TikvGoStorageTest, GetTrace) {
-  GTEST_SKIP() << "Skip GetTrace test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn();
 
@@ -518,7 +556,9 @@ TEST_F(TikvGoStorageTest, GetTrace) {
 }
 
 TEST_F(TikvGoStorageTest, StoragePutKV) {
-  GTEST_SKIP() << "Skip StoragePutKV test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   KeyValue kv;
   kv.key = "unit_tikv_go_storage_putkv_" +
@@ -536,7 +576,9 @@ TEST_F(TikvGoStorageTest, StoragePutKV) {
 }
 
 TEST_F(TikvGoStorageTest, StorageBatchDelete) {
-  GTEST_SKIP() << "Skip StorageBatchDelete test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::vector<std::string> keys;
   KVStorage::WriteOption opt;
@@ -559,7 +601,9 @@ TEST_F(TikvGoStorageTest, StorageBatchDelete) {
 }
 
 TEST_F(TikvGoStorageTest, StorageScan) {
-  GTEST_SKIP() << "Skip StorageScan test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string prefix = "unit_tikv_go_storage_scan_" +
                        ::dingofs::Helper::GenerateRandomString(16) + "_";
@@ -582,7 +626,9 @@ TEST_F(TikvGoStorageTest, StorageScan) {
 }
 
 TEST_F(TikvGoStorageTest, NewTxnReadCommitted) {
-  GTEST_SKIP() << "Skip NewTxnReadCommitted test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   auto txn = storage_->NewTxn(Txn::kReadCommitted);
   ASSERT_NE(txn, nullptr);
@@ -603,7 +649,9 @@ TEST_F(TikvGoStorageTest, NewTxnReadCommitted) {
 }
 
 TEST_F(TikvGoStorageTest, PutOverwrite) {
-  GTEST_SKIP() << "Skip PutOverwrite test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   std::string key =
       "unit_tikv_go_overwrite_" + ::dingofs::Helper::GenerateRandomString(32);
@@ -635,7 +683,9 @@ TEST_F(TikvGoStorageTest, PutOverwrite) {
 }
 
 TEST_F(TikvGoStorageTest, MultiBthreadConcurrent) {
-  GTEST_SKIP() << "Skip MultiBthreadConcurrent test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   struct Param {
     KVStorageSPtr storage;
@@ -685,6 +735,10 @@ TEST_F(TikvGoStorageTest, MultiBthreadConcurrent) {
 }
 
 TEST_F(TikvGoStorageTest, PutBatchGetInBthread) {
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
+
   struct Param {
     KVStorageSPtr storage;
   };
@@ -733,7 +787,9 @@ TEST_F(TikvGoStorageTest, PutBatchGetInBthread) {
 }
 
 TEST_F(TikvGoStorageTest, LostUpdate) {
-  GTEST_SKIP() << "Skip LostUpdate test case.";
+  if (getenv("MANUAL_TEST") == nullptr) {
+    GTEST_SKIP() << "Skip manual test case.";
+  }
 
   struct Param {
     KVStorageSPtr storage;


### PR DESCRIPTION
## Summary

MDS now exposes detailed local cache state through browsable fsstat pages and improves quota accounting and filesystem operation cleanup. The branch also adds focused operation-processor coverage and a script for running the MDS regression suite.

## Changes

- Add paginated dashboard pages for partition, inode, and chunk caches, including cache entries, loaded dentries, pending delta operations, inode attributes, and chunk metadata.
- Fix quota usage reads for concurrent updates and remove deleted inodes from the cache when trash is disabled.
- Mark queued operations as service-stopped and notify waiters during processor shutdown.
- Add operation-processor and cache coverage, gate slow or manual tests behind environment flags, and add `scripts/dev-mds/run_all_test.sh` for common regression workloads.

## Test plan

- Added unit coverage for cache inspection, partition behavior, filesystem cleanup, operation-processor shutdown, and related test gating.
- Full test execution was not run in this environment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/gpt--5.6--luna_(High)-000000)