### PR TITLE
feat(client): optimize warmup performance

### DIFF
--- a/src/client/vfs/metasystem/mds/block_cache_cleanup.cc
+++ b/src/client/vfs/metasystem/mds/block_cache_cleanup.cc
@@ -100,7 +100,7 @@ void BlockCacheCleaner::Execute(Ino ino, uint64_t length) {
 
   auto task =
       std::make_shared<BlockCacheCleanupTask>(fs_id_, ino, length, *this);
-  if (!executor_.ExecuteByHash(ino, task, true)) {
+  if (!executor_.ExecuteByHash(ino, task, false)) {
     LOG(ERROR) << fmt::format(
         "[meta.cleanup.{}] submit block cache cleanup task fail, "
         "length({}).",

--- a/src/client/vfs/metasystem/mds/executor.cc
+++ b/src/client/vfs/metasystem/mds/executor.cc
@@ -33,6 +33,10 @@ bool Executor::Init() {
 
 void Executor::Stop() { worker_set_->Stop(); }
 
+bool Executor::ExecuteLeastQueue(TaskRunnablePtr task) {
+  return worker_set_->ExecuteLeastQueue(task);
+}
+
 bool Executor::ExecuteByHash(uint64_t hash_id, TaskRunnablePtr task,
                              bool retry) {
   do {

--- a/src/client/vfs/metasystem/mds/executor.h
+++ b/src/client/vfs/metasystem/mds/executor.h
@@ -39,7 +39,8 @@ class Executor {
   bool Init();
   void Stop();
 
-  bool ExecuteByHash(uint64_t hash_id, TaskRunnablePtr task, bool retry = true);
+  bool ExecuteLeastQueue(TaskRunnablePtr task);
+  bool ExecuteByHash(uint64_t hash_id, TaskRunnablePtr task, bool retry);
 
  private:
   const std::string name_;

--- a/src/client/vfs/metasystem/mds/metasystem.cc
+++ b/src/client/vfs/metasystem/mds/metasystem.cc
@@ -69,7 +69,7 @@ DEFINE_uint32(vfs_meta_executor_max_pending_num, 1048576,
 const std::string kBgExecutorWorkerSetName = "meta_bg_executor";
 
 DEFINE_uint32(vfs_meta_bg_executor_worker_num, 16, "number of compact workers");
-DEFINE_uint32(vfs_meta_bg_executor_max_pending_num, 4096,
+DEFINE_uint32(vfs_meta_bg_executor_max_pending_num, 8192,
               "compact worker max pending num");
 DEFINE_bool(vfs_meta_bg_executor_use_pthread, true,
             "compact worker use pthread");
@@ -653,7 +653,7 @@ Status MDSMetaSystem::MkNod(ContextSPtr ctx, Ino parent,
 
 Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
                              const std::string& session_id,
-                             FileSessionSPtr file_session) {
+                             FileSessionSPtr file_session, bool is_async) {
   CHECK(file_session != nullptr) << "file_session is null.";
 
   // check whether prefetch chunk
@@ -673,10 +673,10 @@ Status MDSMetaSystem::DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
                                  chunk_descriptors, attr_entry, chunks);
 
   LOG_DEBUG << fmt::format(
-      "[meta.fs.{}.{}] open file flags({:o}:{}) session_id({}) "
-      "chunks({}) status({}).",
+      "[meta.fs.{}.{}] open file flags({:o}:{}) session_id({}) is_async({})"
+      " chunks({}) status({}).",
       ino, fh, flags, dingofs::Helper::DescOpenFlags(flags), session_id,
-      chunks.size(), status.ToString());
+      is_async, chunks.size(), status.ToString());
 
   if (!status.ok()) return status;
 
@@ -749,7 +749,7 @@ void MDSMetaSystem::AsyncOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
       }
 
       auto status = metasystem_.DoOpen(ctx_, ino_, flags_, fh_, session_id_,
-                                       file_session_);
+                                       file_session_, true);
       if (!status.ok()) {
         LOG(ERROR) << fmt::format(
             "[meta.fs.{}.{}] async open file fail, error({}).", ino_, fh_,
@@ -816,7 +816,7 @@ Status MDSMetaSystem::Open(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
     }
   }
 
-  auto status = DoOpen(ctx, ino, flags, fh, session_id, file_session);
+  auto status = DoOpen(ctx, ino, flags, fh, session_id, file_session, false);
   if (!status.ok()) {
     LOG(ERROR) << fmt::format("[meta.fs.{}.{}] open file fail, error({}).", ino,
                               fh, status.ToString());

--- a/src/client/vfs/metasystem/mds/metasystem.h
+++ b/src/client/vfs/metasystem/mds/metasystem.h
@@ -261,7 +261,8 @@ class MDSMetaSystem : public vfs::MetaSystem {
   void InvalidateFileSessionReadCache(Ino ino);
 
   Status DoOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
-                const std::string& session_id, FileSessionSPtr file_session);
+                const std::string& session_id, FileSessionSPtr file_session,
+                bool is_async);
   void AsyncOpen(ContextSPtr ctx, Ino ino, int flags, uint64_t fh,
                  const std::string& session_id, FileSessionSPtr file_session);
 

--- a/src/client/vfs/metasystem/mds/warmup.cc
+++ b/src/client/vfs/metasystem/mds/warmup.cc
@@ -52,20 +52,43 @@ class WarmupDirAccessStatsWatcher : public AccessStatsWatcher {
     if (!warmup_processor_.IsEnableBlockCache()) return;
     if (count < FLAGS_vfs_meta_open_threshold_count) return;
 
+    warmup_processor_.AsyncWarmupSmallFile(ino);
+  }
+
+ private:
+  WarmupProcessor& warmup_processor_;
+};
+
+class WarmupTask final : public mds::TaskRunnable {
+ public:
+  WarmupTask(Ino ino, WarmupProcessor& warmup_processor)
+      : ino_(ino), warmup_processor_(warmup_processor) {}
+
+  std::string Type() override { return "WARMUP"; }
+  std::string Key() override { return std::to_string(ino_); }
+
+  void Run() override {
     // check dentry cache
     auto& dentry_cache = warmup_processor_.GetDentryCache();
     auto& warmup_memo = warmup_processor_.GetWarmupMemo();
 
     // maybe some files already fetch by readdir, so directly warmup data and
     // chunk
-    std::vector<Ino> child_inoes = dentry_cache.ListFile(ino);
-    warmup_processor_.WarmupSmallFileDataAndChunk(ino, child_inoes);
+    std::vector<Ino> child_inoes = dentry_cache.ListFile(ino_);
+    warmup_processor_.AsyncWarmupSmallFileDataAndChunk(ino_, child_inoes);
 
     // fetch other files in the same directory
-    warmup_processor_.ExecuteReadDir(ino);
+    Status status = warmup_processor_.DoWarmupReadDir(ino_);
+    if (!status.ok()) {
+      LOG(ERROR) << fmt::format(
+          "[meta.warmup.{}] warmup readdir fail, error({}).", ino_,
+          status.ToString());
+    }
   }
 
  private:
+  const Ino ino_;
+
   WarmupProcessor& warmup_processor_;
 };
 
@@ -82,7 +105,7 @@ class WarmupChunkTask final : public mds::TaskRunnable {
   std::string Key() override { return std::to_string(inoes_.front()); }
 
   void Run() override {
-    Status status = DoWarmup();
+    Status status = warmup_processor_.DoWarmupSmallFileChunk(parent_, inoes_);
     if (!status.ok()) {
       LOG(ERROR) << fmt::format(
           "[meta.warmup.{}] warmup chunk fail, error({}).", parent_,
@@ -91,117 +114,9 @@ class WarmupChunkTask final : public mds::TaskRunnable {
   }
 
  private:
-  Status DoWarmup() {
-    auto& chunk_memo = warmup_processor_.GetChunkMemo();
-    auto& mds_client = warmup_processor_.GetMDSClient();
-    auto& read_chunk_cache = warmup_processor_.GetReadChunkCache();
-
-    LOG_DEBUG << fmt::format(
-        "[meta.warmup] do warmup chunk, parent({}) child_count({}).", parent_,
-        inoes_.size());
-
-    std::vector<MDSClient::ReadSliceInEntry> in_entries;
-    in_entries.reserve(inoes_.size());
-    for (const auto& ino : inoes_) {
-      MDSClient::ReadSliceInEntry in_entry;
-      in_entry.ino = ino;
-      in_entry.index = 0;
-      in_entry.version = chunk_memo.GetVersion(ino, in_entry.index);
-      in_entries.push_back(in_entry);
-    }
-
-    auto ctx = std::make_shared<Context>("");
-    std::vector<MDSClient::ReadSliceOutEntry> out_entries;
-    Status status = mds_client.ReadSlice(ctx, in_entries, out_entries);
-    if (!status.ok() && !status.IsNotFound()) return status;
-
-    for (const auto& entry : out_entries) {
-      read_chunk_cache.Put(entry.ino, entry.chunk);
-    }
-
-    return Status::OK();
-  }
-
   const uint32_t fs_id_;
   const Ino parent_;
   const std::vector<Ino> inoes_;
-
-  WarmupProcessor& warmup_processor_;
-};
-
-class ReadDirTask : public mds::TaskRunnable {
- public:
-  ReadDirTask(uint32_t fs_id, Ino ino, WarmupProcessor& warmup_processor)
-      : fs_id_(fs_id), ino_(ino), warmup_processor_(warmup_processor) {}
-
-  std::string Type() override { return "READ_DIR"; }
-  std::string Key() override { return std::to_string(ino_); }
-
-  void Run() override {
-    auto& warmup_memo = warmup_processor_.GetWarmupMemo();
-
-    if (warmup_memo.IsRemembered(ino_)) {
-      LOG_DEBUG << fmt::format(
-          "[meta.warmup.{}] warmup readdir skipped cause by remembered.", ino_);
-      return;
-    }
-
-    warmup_memo.Remember(ino_);
-
-    Status status = DoReadDir();
-    if (!status.ok()) {
-      LOG(ERROR) << fmt::format("[meta.warmup.{}] read dir fail, error({}).",
-                                ino_, status.ToString());
-    }
-  }
-
- private:
-  Status DoReadDir() {
-    auto& mds_client = warmup_processor_.GetMDSClient();
-    auto& inode_cache = warmup_processor_.GetInodeCache();
-    auto& dentry_cache = warmup_processor_.GetDentryCache();
-
-    LOG_DEBUG << fmt::format("[meta.warmup.{}] readdir by warmup.", ino_);
-
-    auto ctx = std::make_shared<Context>("");
-    ctx->reason = "warmup";
-
-    std::string last_name;
-    do {
-      std::vector<MDSClient::ReadDirEntry> dentries;
-      Status status = mds_client.ReadDir(ctx, ino_, 0, last_name,
-                                         FLAGS_vfs_meta_read_dir_batch_size,
-                                         true, dentries);
-
-      if (!status.ok()) return status;
-
-      std::vector<Ino> child_inoes;
-      child_inoes.reserve(dentries.size());
-
-      // cache inode and dentry
-      for (auto& dentry : dentries) {
-        if (!IsFile(dentry.ino)) continue;
-        if (!dingofs::Helper::IsSmallFile(dentry.attr_entry.length())) continue;
-
-        inode_cache.Put(dentry.ino, dentry.attr_entry);
-        dentry_cache.Put(ino_, dentry.name, dentry.ino);
-        child_inoes.push_back(dentry.ino);
-      }
-
-      // warmup small file data and chunk
-      warmup_processor_.WarmupSmallFileDataAndChunk(ino_, child_inoes);
-
-      if (dentries.size() < FLAGS_vfs_meta_read_dir_batch_size) break;
-
-      last_name = dentries.back().name;
-
-    } while (true);
-
-    return Status::OK();
-  }
-
-  const uint32_t fs_id_;
-  const Ino ino_;
 
   WarmupProcessor& warmup_processor_;
 };
@@ -223,6 +138,7 @@ void WarmupMemo::Forget(Ino ino) {
 
 bool WarmupMemo::IsRemembered(Ino ino) {
   uint64_t now = utils::Timestamp();
+
   bool remembered = false;
   shard_map_.withRLock(
       [&](const Map& map) {
@@ -231,6 +147,25 @@ bool WarmupMemo::IsRemembered(Ino ino) {
             now <= (it->second.last_time_s +
                     FLAGS_vfs_meta_warmup_readdir_interval_s)) {
           remembered = true;
+        }
+      },
+      ino);
+
+  return remembered;
+}
+
+bool WarmupMemo::CheckAndRemember(Ino ino, uint64_t now_s) {
+  bool remembered = false;
+  shard_map_.withWLock(
+      [&](Map& map) {
+        auto [it, inserted] = map.try_emplace(ino, Value{utils::Timestamp()});
+        if (!inserted) {
+          if (now_s <= (it->second.last_time_s +
+                        FLAGS_vfs_meta_warmup_readdir_interval_s)) {
+            remembered = true;
+          } else {
+            it->second.last_time_s = now_s;
+          }
         }
       },
       ino);
@@ -268,65 +203,131 @@ bool WarmupProcessor::Init() {
   return true;
 }
 
-void WarmupProcessor::ExecuteReadDir(Ino ino) {
-  if (warmup_memo_.IsRemembered(ino)) return;
+void WarmupProcessor::AsyncWarmupSmallFile(Ino parent) {
+  if (warmup_manager_ == nullptr) return;
 
-  auto task = std::make_shared<ReadDirTask>(fs_id_, ino, *this);
-
-  if (!executor_.ExecuteByHash(ino, task)) {
-    LOG(ERROR) << fmt::format(
-        "[meta.warmup] submit warmup readdir task fail, ino({}).", ino);
+  auto task = std::make_shared<WarmupTask>(parent, *this);
+  if (!executor_.ExecuteByHash(parent, task, false)) {
+    LOG(ERROR) << fmt::format("[meta.warmup.{}] submit warmup task fail.",
+                              parent);
   }
 }
 
-void WarmupProcessor::WarmupSmallFileData(Ino parent,
-                                          const std::vector<Ino>& inos) {
+void WarmupProcessor::DoWarmupSmallFileData(Ino parent,
+                                            const std::vector<Ino>& inos) {
   if (inos.empty()) return;
   if (warmup_manager_ == nullptr) return;
 
-  LOG_DEBUG << fmt::format(
-      "[meta.warmup] submit warmup data task, parent({}) child_count({}).",
-      parent, inos.size());
+  LOG_DEBUG << fmt::format("[meta.warmup.{}] do warmup data, child_count({}).",
+                           parent, inos.size());
 
   // warmup small file data
   Status status = warmup_manager_->SubmitTask(WarmupTaskContext(inos));
   if (!status.ok()) {
     LOG(ERROR) << fmt::format(
-        "[meta.warmup] submit warmup task fail, inos({}) error({}).", inos,
-        status.ToString());
+        "[meta.warmup.{}] submit warmup data task fail, inos({}) error({}).",
+        parent, inos, status.ToString());
   }
 }
 
-void WarmupProcessor::WarmupSmallFileChunk(Ino parent,
-                                           const std::vector<Ino>& inos) {
-  if (inos.empty()) return;
+Status WarmupProcessor::DoWarmupSmallFileChunk(Ino parent,
+                                               const std::vector<Ino>& inos) {
+  if (inos.empty()) return Status::OK();
 
-  LOG_DEBUG << fmt::format(
-      "[meta.warmup] submit warmup chunk task, parent({}) child_count({}).",
-      parent, inos.size());
+  LOG_DEBUG << fmt::format("[meta.warmup.{}] do warmup chunk, child_count({}).",
+                           parent, inos.size());
+
+  std::vector<MDSClient::ReadSliceInEntry> in_entries;
+  in_entries.reserve(inos.size());
+  for (const auto& ino : inos) {
+    MDSClient::ReadSliceInEntry in_entry;
+    in_entry.ino = ino;
+    in_entry.index = 0;
+    in_entry.version = chunk_memo_.GetVersion(ino, in_entry.index);
+    in_entries.push_back(in_entry);
+  }
+
+  auto ctx = std::make_shared<Context>("");
+  std::vector<MDSClient::ReadSliceOutEntry> out_entries;
+  Status status = mds_client_.ReadSlice(ctx, in_entries, out_entries);
+  if (!status.ok() && !status.IsNotFound()) return status;
+
+  for (const auto& entry : out_entries) {
+    read_chunk_cache_.Put(entry.ino, entry.chunk);
+  }
+
+  return Status::OK();
+}
+
+void WarmupProcessor::AsyncWarmupSmallFileChunk(Ino parent,
+                                                const std::vector<Ino>& inos) {
+  if (inos.empty()) return;
 
   auto task = std::make_shared<WarmupChunkTask>(fs_id_, parent, inos, *this);
 
-  if (!executor_.ExecuteByHash(inos.front(), task)) {
+  if (!executor_.ExecuteLeastQueue(task)) {
     LOG(ERROR) << fmt::format(
-        "[meta.warmup] submit warmup chunk task fail, inos({}).", inos);
+        "[meta.warmup.{}] submit warmup chunk task fail, inos({}).", parent,
+        inos);
   }
 }
 
-void WarmupProcessor::WarmupSmallFileDataAndChunk(
+void WarmupProcessor::AsyncWarmupSmallFileDataAndChunk(
     Ino parent, const std::vector<Ino>& inos) {
   std::vector<Ino> warmup_inoes;
   warmup_inoes.reserve(inos.size());
-  for (auto ino : inos) {
-    if (!warmup_memo_.IsRemembered(ino)) warmup_inoes.push_back(ino);
+  uint64_t now_s = utils::Timestamp();
+  for (const auto& ino : inos) {
+    if (!warmup_memo_.CheckAndRemember(ino, now_s)) warmup_inoes.push_back(ino);
   }
 
   if (warmup_inoes.empty()) return;
 
-  for (const auto& ino : warmup_inoes) warmup_memo_.Remember(ino);
+  DoWarmupSmallFileData(parent, warmup_inoes);
+  AsyncWarmupSmallFileChunk(parent, warmup_inoes);
+}
 
-  WarmupSmallFileData(parent, warmup_inoes);
-  WarmupSmallFileChunk(parent, warmup_inoes);
+Status WarmupProcessor::DoWarmupReadDir(Ino parent) {
+  if (warmup_memo_.IsRemembered(parent)) return Status::OK();
+  warmup_memo_.Remember(parent);
+
+  LOG_DEBUG << fmt::format("[meta.warmup.{}] do warmup readdir.", parent);
+
+  auto ctx = std::make_shared<Context>("");
+  ctx->reason = "warmup";
+
+  std::string last_name;
+  do {
+    std::vector<MDSClient::ReadDirEntry> dentries;
+    Status status =
+        mds_client_.ReadDir(ctx, parent, 0, last_name,
+                            FLAGS_vfs_meta_read_dir_batch_size, true, dentries);
+
+    if (!status.ok()) return status;
+
+    std::vector<Ino> child_inoes;
+    child_inoes.reserve(dentries.size());
+
+    // cache inode and dentry
+    for (auto& dentry : dentries) {
+      if (!IsFile(dentry.ino)) continue;
+      if (!dingofs::Helper::IsSmallFile(dentry.attr_entry.length())) continue;
+
+      inode_cache_.Put(dentry.ino, dentry.attr_entry);
+      dentry_cache_.Put(parent, dentry.name, dentry.ino);
+      child_inoes.push_back(dentry.ino);
+    }
+
+    // warmup small file data and chunk
+    AsyncWarmupSmallFileDataAndChunk(parent, child_inoes);
+
+    if (dentries.size() < FLAGS_vfs_meta_read_dir_batch_size) break;
+
+    last_name = dentries.back().name;
+
+  } while (true);
+
+  return Status::OK();
 }
 
 }  // namespace meta

--- a/src/client/vfs/metasystem/mds/warmup.h
+++ b/src/client/vfs/metasystem/mds/warmup.h
@@ -41,6 +41,7 @@ class WarmupMemo {
   void Forget(Ino ino);
 
   bool IsRemembered(Ino ino);
+  bool CheckAndRemember(Ino ino, uint64_t now_s);
 
   void CleanExpired(uint64_t expire_s);
 
@@ -54,7 +55,7 @@ class WarmupMemo {
   // ino -> last warmup timestamp
   using Map = absl::flat_hash_map<Ino, Value>;
 
-  constexpr static size_t kShardNum = 64;
+  constexpr static size_t kShardNum = 128;
   utils::Shards<Map, kShardNum> shard_map_;
 };
 
@@ -88,6 +89,7 @@ class WarmupProcessor {
   void CleanExpired(uint64_t expire_s) { warmup_memo_.CleanExpired(expire_s); }
 
  private:
+  friend class WarmupTask;
   friend class WarmupChunkTask;
   friend class ReadDirTask;
   friend class WarmupDirAccessStatsWatcher;
@@ -99,11 +101,17 @@ class WarmupProcessor {
   ReadChunkCache& GetReadChunkCache() { return read_chunk_cache_; }
   WarmupMemo& GetWarmupMemo() { return warmup_memo_; }
 
-  void ExecuteReadDir(Ino ino);
+  void AsyncWarmupSmallFile(Ino parent);
 
-  void WarmupSmallFileData(Ino parent, const std::vector<Ino>& inos);
-  void WarmupSmallFileChunk(Ino parent, const std::vector<Ino>& inos);
-  void WarmupSmallFileDataAndChunk(Ino parent, const std::vector<Ino>& inos);
+  void DoWarmupSmallFileData(Ino parent, const std::vector<Ino>& inos);
+
+  Status DoWarmupSmallFileChunk(Ino parent, const std::vector<Ino>& inos);
+  void AsyncWarmupSmallFileChunk(Ino parent, const std::vector<Ino>& inos);
+
+  void AsyncWarmupSmallFileDataAndChunk(Ino parent,
+                                        const std::vector<Ino>& inos);
+
+  Status DoWarmupReadDir(Ino parent);
 
   const uint32_t fs_id_{0};
 


### PR DESCRIPTION
## Summary

Improve client metadata warmup performance by scheduling small-file warmup asynchronously and reducing unnecessary executor retries.

## Changes

- Queue small-file data and chunk warmup through the metadata executor.
- Keep directory warmup deduplication atomic while allowing repeated directory scans after the configured interval.
- Increase metadata background executor capacity and avoid retrying cleanup and warmup submissions.
- Include async state in open-file diagnostics.

## Validation

Not run locally; this is a client performance and scheduling change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)